### PR TITLE
New deploy

### DIFF
--- a/deploy-typesense.py
+++ b/deploy-typesense.py
@@ -8,36 +8,57 @@ import binascii
 def get_field_defaults_for_schema_file(schema_file):
     return [(prop, [] if details['type'] == 'array' else '') for prop, details in json.load(open(schema_file, encoding = 'utf-8'))['properties'].items()]
 
+def process_record(path, fields):
+    record = json.load(path.open(encoding = 'utf-8'))
+    record = {prop: (str(value) if type(value) is bool else value) for prop, value in record.items()}
+    record['id'] = record['slug']
+        
+    # Typesense *expects* an int (or float) as a sortable field. We don't have that, so we use this rather ugly hack for now.
+    record['sort-index'] = int(binascii.hexlify(str.encode(record['id']))[:7], 16)
 
-# TODO: Once implemented, use the bulk import feature instead of inserting records one-by-one: https://github.com/typesense/typesense/issues/35
+    # Typesense also expects all fields declared in the schema to have a value.
+    for field, default in fields:
+        if field not in record: record[field] = default
+    
+    return record
+
+def document_update(index, record):
+    # TODO: Let's hope Typesense implements record updates in the future.
+    try:
+        client.collections[index].documents[record['id']].delete()
+    except typesense.exceptions.ObjectNotFound:
+        pass
+    client.collections[index].documents.create(record)
+
 def deploy_index(index, directory, fields):
+    entrylist = [json.loads(entry) for entry in client.collections[index].documents.export() if len(entry) > 0]
+    entries = {entry['id']: entry for entry in entrylist}
+    
     pathlist = Path(directory).glob('**/*.json')
     for path in pathlist:
-        record = json.load(open(path, encoding = 'utf-8'))
-        record = {prop: (str(value) if type(value) is bool else value) for prop, value in record.items()}
-
-        print('Updating ' + record['slug'])
-        # TODO: Let's hope Typesense implements record updates in the future.
+        record = process_record(path, fields)
+        
+        if not record['id'] in entries:
+            print('Creating ' + record['id'])
+            client.collections[index].documents.create(record)
+        else:
+            if record != entries[record['id']]:
+                print('Updating ' + record['id'])
+                document_update(index, record)
+            del entries[record['id']]
+    
+    for id in entries.keys():
+        print('Deleting ' + id)
         try:
-            client.collections[index].documents[record['slug']].delete()
+            client.collections[index].documents[id].delete()
         except typesense.exceptions.ObjectNotFound:
             pass
 
-        record['id'] = record['slug']
-        # Typesense *expects* an int (or float) as a sortable field. We don't have that, so we use this rather ugly hack for now.
-        record['sort-index'] = int(binascii.hexlify(str.encode(record['slug']))[:7], 16)
-        # Typesense also expects all fields declared in the schema to have a value.
-        for field, default in fields:
-            if field not in record: record[field] = default
-
-        client.collections[index].documents.create(record)
-
-
 client = typesense.Client({
     'master_node': {
-        'host': 'search.datenanfragen.de',
-        'port': '443',
-        'protocol': 'https',
+        'host': 'localhost',
+        'port': '8108',
+        'protocol': 'http',
         'api_key': os.environ['TYPESENSE_API_KEY']
     },
     'timeout_seconds': 2

--- a/deploy-typesense.py
+++ b/deploy-typesense.py
@@ -56,9 +56,9 @@ def deploy_index(index, directory, fields):
 
 client = typesense.Client({
     'master_node': {
-        'host': 'localhost',
-        'port': '8108',
-        'protocol': 'http',
+        'host': 'search.datenanfragen.de',
+        'port': '443',
+        'protocol': 'https',
         'api_key': os.environ['TYPESENSE_API_KEY']
     },
     'timeout_seconds': 2


### PR DESCRIPTION
I updated the deploy script as requested in #46. No every entry is fetched (this may take a while) and every local entry is compared with the existing entries before uploading. As usually only a very little number of entries is changed, this should speed up deployment.
Also, entries that are not available any more are deleted.