### PR TITLE
Make German greeting more respectful and inclusive

### DIFF
--- a/templates/de/access-bundesjustizamt.txt
+++ b/templates/de/access-bundesjustizamt.txt
@@ -1,4 +1,4 @@
-Guten Tag,
+Sehr geehrte Damen, Herren und *,
 
 ich bitte hiermit um Auskunft gemäß Art. 15 DSGVO. Bitte bestätigen Sie mir, ob Sie mich betreffende personenbezogene Daten verarbeiten (vgl. Art. 4 Nr. 1 und 2 DSGVO).
 

--- a/templates/de/access-bundespolizei.txt
+++ b/templates/de/access-bundespolizei.txt
@@ -1,4 +1,4 @@
-Guten Tag,
+Sehr geehrte Damen, Herren und *,
 
 ich bitte hiermit um Auskunft gemäß Art. 15 DSGVO und §57 Abs. 1 BDSG. Bitte bestätigen Sie mir, ob Sie mich betreffende personenbezogene Daten verarbeiten (vgl. Art. 4 Nr. 1 und 2 DSGVO).
 

--- a/templates/de/access-default.txt
+++ b/templates/de/access-default.txt
@@ -1,4 +1,4 @@
-Guten Tag,
+Sehr geehrte Damen, Herren und *,
 
 ich bitte hiermit um Auskunft gemäß Art. 15 DSGVO. Bitte bestätigen Sie mir, ob Sie mich betreffende personenbezogene Daten verarbeiten (vgl. Art. 4 Nr. 1 und 2 DSGVO).
 

--- a/templates/de/access-lka-nds.txt
+++ b/templates/de/access-lka-nds.txt
@@ -1,4 +1,4 @@
-Guten Tag,
+Sehr geehrte Damen, Herren und *,
 
 ich bitte hiermit um Auskunft gemäß Art. 15 DSGVO iVm. §51 NDSG. Bitte bestätigen Sie mir, ob Sie mich betreffende personenbezogene Daten verarbeiten (vgl. Art. 4 Nr. 1 und 2 DSGVO).
 

--- a/templates/de/access-tracking.txt
+++ b/templates/de/access-tracking.txt
@@ -1,4 +1,4 @@
-Guten Tag,
+Sehr geehrte Damen, Herren und *,
 
 ich bitte hiermit um Auskunft gemäß Art. 15 DSGVO. Bitte bestätigen Sie mir, ob Sie mich betreffende personenbezogene Daten verarbeiten (vgl. Art. 4 Nr. 1 und 2 DSGVO).
 

--- a/templates/de/admonition.txt
+++ b/templates/de/admonition.txt
@@ -1,4 +1,4 @@
-Guten Tag,
+Sehr geehrte Damen, Herren und *,
 
 am {request_date} hatte ich bei Ihnen eine Anfrage nach Art. {request_article} DSGVO gestellt.
 {Beschreibung des Problems, z. B.: Leider erhielt ich bisher keine Antwort von Ihnen. Damit ist die Frist von einem Monat nach Art. 12 Abs. 3 S. 1 DSGVO überschritten.}

--- a/templates/de/complaint.txt
+++ b/templates/de/complaint.txt
@@ -1,4 +1,4 @@
-Guten Tag,
+Sehr geehrte Damen, Herren und *,
 
 hiermit möchte ich Beschwerde nach Art. 77 DSGVO einreichen. Am {request_date} hatte ich mich mit einer Anfrage nach Art. {request_article} DSGVO an folgenden Verantwortlichen gewandt:
 {request_recipient_address}

--- a/templates/de/erasure-default.txt
+++ b/templates/de/erasure-default.txt
@@ -1,4 +1,4 @@
-Guten Tag,
+Sehr geehrte Damen, Herren und *,
 
 ich stelle hiermit Antrag auf unverzügliche Löschung mich betreffender personenbezogener Daten gemäß Art. 17 Abs. 1 DSGVO.
 

--- a/templates/de/objection-default.txt
+++ b/templates/de/objection-default.txt
@@ -1,4 +1,4 @@
-Guten Tag,
+Sehr geehrte Damen, Herren und *,
 
 ich lege hiermit Widerspruch gegen die Verarbeitung meiner personenbezogenen Daten für Direktwerbung gemäß Art. 21 Abs. 2 DSGVO ein. Der Widerspruch betrifft auch Profiling, soweit es mit Direktwerbung in Verbindung steht.
 

--- a/templates/de/rectification-default.txt
+++ b/templates/de/rectification-default.txt
@@ -1,4 +1,4 @@
-Guten Tag,
+Sehr geehrte Damen, Herren und *,
 
 ich stelle hiermit Antrag auf Berichtigung mich betreffender unrichtiger personenbezogener Daten nach Art. 16 DSGVO.
 


### PR DESCRIPTION
One of the replies I've got criticized that the greeting "Guten Tag"
is disrespectful. A greeting like "Sehr geehrte Damen und Herren" may
be more appropiate. To also include people that neither identify as
"Damen" nor "Herren", I've added the asterisk (*) symbol. It is
commonly used to refer to other kinds of people.