### PR TITLE
Change invalid email of EfficientIP, SAS

### DIFF
--- a/companies/efficientip-com.json
+++ b/companies/efficientip-com.json
@@ -6,7 +6,7 @@
     "name": "EfficientIP, SAS",
     "address": "90 Boulevard National\n92250 La Garenne Colombes\nFrance",
     "phone": "+33 1 75 84 88 98",
-    "email": "privacy@efficientip.com",
+    "email": "info@efficientip.com",
     "web": "https://www.efficientip.com",
     "sources": [
         "https://www.efficientip.com/de/kontakt/",
@@ -26,6 +26,5 @@
             "desc": "Email",
             "type": "input"
         }
-    ],
-    "suggested-transport-medium": "email"
+    ]
 }


### PR DESCRIPTION
On their privacy statement, privacy@efficientip.com is listed as the
email address. However, when trying to send an email to that address,
you get a "Delivery Status Notification (Failure)" notification.