### PR TITLE
#349 Updated the web link of xiaomi

### DIFF
--- a/companies/mi-com.json
+++ b/companies/mi-com.json
@@ -10,7 +10,7 @@
     ],
     "address": "c/o Wework Room 04-106\nStrawinskylaan 4117 4th Floor\n1017 ZX Amsterdam\nNetherlands",
     "email": "privacy@xiaomi.com",
-    "web": "https://mi.com",
+    "web": "https://www.mi.com",
     "sources": [
         "https://privacy.mi.com/all/de_DE/",
         "https://www.wework.com/buildings/strawinskylaan-4117--amsterdam"


### PR DESCRIPTION
I copied the previous web link in browser but it returned a '403' Forbidden error. So updated it with the www prefix for the data record of the link to be functional.

![Screenshot (1346)](https://user-images.githubusercontent.com/26588969/67927850-ab327400-fbdf-11e9-9d30-01810c5cc1ae.png)
