### PR TITLE
Fix email of IFTTT Inc.

### DIFF
--- a/companies/ifttt.json
+++ b/companies/ifttt.json
@@ -7,7 +7,7 @@
     "address": "923 Market Street\nSuite #400\nSan Francisco\nCA 94103\nUnited States of America",
     "phone": "+49 40 999993430",
     "fax": "+49 40 999993332",
-    "email": "IFTTT@gdpr-rep.com",
+    "email": "privacy@ifttt.com",
     "web": "https://ifttt.com/",
     "sources": [
         "https://ifttt.com/terms",


### PR DESCRIPTION
The email in the terms is "IFTTT@gdpr-rep.com".
However, when sending a request to that email, you get the
following reply:
"We don't monitor emails sent directly to this email address, and
we won't be able to respond to this email."
Therefore, I've added the more general email address that can also
be found in the sources.