### PR TITLE
Add 4sigma GmbH

### DIFF
--- a/companies/4sigma
+++ b/companies/4sigma
@@ -1,0 +1,31 @@
+{
+    "slug": "4sigma",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "health",
+        "telecommunication"
+    ],
+    "name": "4sigma GmbH",
+    "address": "Bajuwarenring 9\n82041 Oberhaching\nDeutschland",
+    "phone": "+49 89 9500840",
+    "fax": "+49 89 95008410 ",
+    "email": "info@4sigma.de",
+    "web": "https://www.4sigma.de",
+    "sources": [
+        "https://www.4sigma.de/j/privacy",
+        "https://www.4sigma.de/about"
+    ],
+    "required-elements": [
+        {
+            "desc": "Name",
+            "type": "name"
+        },
+        {
+            "desc": "Adresse",
+            "type": "address"
+        }
+    ],
+    "suggested-transport-medium": "email"
+}


### PR DESCRIPTION
Added 4sigma GmbH which provides telephone and digital health service support to i.a. health insurance companies. The Siemens Betriebskrankenkasse (SBK) uses 4sigma GmbH to organize appointments for a suitable doctor for their customers.