### PR TITLE
[DigiTrust] Update email address

### DIFF
--- a/companies/digitrust.json
+++ b/companies/digitrust.json
@@ -8,7 +8,7 @@
     ],
     "name": "DigiTrust",
     "address": "c/o IAB Technology Laboratory, Inc.\n116 East 27th Street\n7th Floor\nNew York\nNew York 10016\nUnited States of America",
-    "email": "privacy@digitru.st",
+    "email": "support@iab.com",
     "web": "https://www.digitru.st/",
     "sources": [
         "https://www.digitru.st/privacy-policy/"


### PR DESCRIPTION
Change DigiTrust Email Address to point to the new IAB support Email.

Fix #465