### PR TITLE
Clarify newline fail string

### DIFF
--- a/test-records.js
+++ b/test-records.js
@@ -30,7 +30,7 @@ const validator = (dir, schema, additional_checks = null) => {
         files.forEach((_f) => {
             f = _f;
             const file_content = fs.readFileSync(f);
-            if (!file_content.toString().endsWith('}\n')) fail("File doesn't end with a newline.");
+            if (!file_content.toString().endsWith('}\n')) fail("File doesn't end with '}\\n'");
 
             const json = JSON.parse(file_content);
             if (!schema(json)) fail('Schema validation failed.\n', schema.errors);

--- a/test-records.js
+++ b/test-records.js
@@ -30,7 +30,7 @@ const validator = (dir, schema, additional_checks = null) => {
         files.forEach((_f) => {
             f = _f;
             const file_content = fs.readFileSync(f);
-            if (!file_content.toString().endsWith('}\n')) fail("File doesn't end with '}\\n'");
+            if (!file_content.toString().endsWith('}\n')) fail("File doesn't end with exactly one newline.");
 
             const json = JSON.parse(file_content);
             if (!schema(json)) fail('Schema validation failed.\n', schema.errors);


### PR DESCRIPTION
It checked for `}\\n`, but only states that the file doesn't end with a newline on fail. Confused me for a second in #729.