### PR TITLE
Add BITel, T.W.O. and Stadtwerke Bielefeld

### DIFF
--- a/companies/bitel.json
+++ b/companies/bitel.json
@@ -1,0 +1,19 @@
+{
+    "slug": "bitel",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "telecommunication"
+    ],
+    "name": "BITel Gesellschaft für Telekommunikation mbH",
+    "address": "Schildescher Straße 16\n33611 Bielefeld\nDeutschland",
+    "phone": "+49 521 514600",
+    "email": "datenschutz@bitel.de",
+    "web": "https://www.bitel.de/",
+    "sources": [
+        "https://www.bitel.de/datenschutz/"
+    ],
+    "suggested-transport-medium": "email",
+    "quality": "verified"
+}

--- a/companies/stadtwerke-bielefeld.json
+++ b/companies/stadtwerke-bielefeld.json
@@ -1,0 +1,19 @@
+{
+    "slug": "stadtwerke-bielefeld",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "utility"
+    ],
+    "name": "Stadtwerke Bielefeld GmbH",
+    "address": "Schildescher Straße 16\n33611 Bielefeld\nDeutschland",
+    "phone": "+49 521 514600",
+    "email": "datenschutz@stadtwerke-bielefeld.de",
+    "web": "https://www.stadtwerke-bielefeld.de/",
+    "sources": [
+        "https://www.stadtwerke-bielefeld.de/datenschutz/"
+    ],
+    "suggested-transport-medium": "email",
+    "quality": "verified"
+}

--- a/companies/technische-werke-osning.json
+++ b/companies/technische-werke-osning.json
@@ -1,5 +1,5 @@
 {
-    "slug": "two",
+    "slug": "technische-werke-osning",
     "relevant-countries": [
         "de"
     ],
@@ -7,7 +7,7 @@
         "utility"
     ],
     "name": "T.W.O. Technische Werke Osning GmbH",
-    "address": "Hopfengarten 10\n33775 Versmold\nDeutschland",
+    "address": "c/o EDV-Unternehmensberatung Floß GmbH\nHopfengarten 10\n33775 Versmold\nDeutschland",
     "phone": "+49 5423 964900",
     "email": "datenschutz@two.de",
     "web": "https://two.de/",

--- a/companies/two.json
+++ b/companies/two.json
@@ -1,0 +1,19 @@
+{
+    "slug": "two",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "utility"
+    ],
+    "name": "T.W.O. Technische Werke Osning GmbH",
+    "address": "Hopfengarten 10\n33775 Versmold\nDeutschland",
+    "phone": "+49 5423 964900",
+    "email": "datenschutz@two.de",
+    "web": "https://two.de/",
+    "sources": [
+        "https://two.de/datenschutz/"
+    ],
+    "suggested-transport-medium": "email",
+    "quality": "verified"
+}


### PR DESCRIPTION
T.W.O. and Stadtwerke Bielefeld are utility companies. BITel is a telco.

I'm unsure about the super short slug for T.W.O. ("two"), but it's not yet used. Alternatively "two-de" or "technische-werke-osning" could be used.