### PR TITLE
Add "Volkswagen"

### DIFF
--- a/companies/volkswagen-ag.json
+++ b/companies/volkswagen-ag.json
@@ -1,0 +1,20 @@
+{
+    "slug": "volkswagen-ag",
+    "relevant-countries": [
+        "all"
+    ],
+    "categories": [
+        "travel",
+        "commerce"
+    ],
+    "name": "Volkswagen AG",
+    "address": "Berliner Ring 2\n38440 Wolfsburg\nGermany",
+    "phone": "+49 800 8932836724889",
+    "email": "privacy@volkswagen.de",
+    "web": "https://www.volkswagenag.com/",
+    "sources": [
+        "https://datenschutz.volkswagen.de/impressum"
+    ],
+    "suggested-transport-medium": "email",
+    "quality": "verified"
+}


### PR DESCRIPTION
Hello!

I've collected information about the Volkswagen Group (aka Volkswagen AG) & generated the JSON file via the webtool. The main source of info: "https://datenschutz.volkswagen.de/". Also, perhaps the "slug" would be better if named as volkswagen-group or volkswagen-ag? Let me know your thoughts. 