### PR TITLE
Add Tinder

### DIFF
--- a/companies/tinder.json
+++ b/companies/tinder.json
@@ -1,0 +1,20 @@
+{
+    "slug": "tinder",
+    "relevant-countries": [
+        "all"
+    ],
+    "categories": [
+        "social media"
+    ],
+    "name": "Match Group, LLC",
+    "runs": [
+        "Tinder"
+    ],
+    "address": "Match Group, LLC\n8750 North Central Expressway\nSuite 1400\nDallas, TX 75231\nUnited States\n\nMTCH Technology Services Limited\nTinder\nWeWork Charlemont Exchange\n42 Charlemont Street\nDublin 2, D02 R593\nIreland",
+    "web": "https://tinder.com/",
+    "suggested-transport-medium": "letter",
+    "comments": [
+        "Web form: https://account.gotinder.com/data"
+    ],
+    "quality": "verified"
+}


### PR DESCRIPTION
It's unfortunate that they do not even list a mail in their privacy policy: https://policies.tinder.com/privacy/

Also the Match Group has a lot of more companies that belong to them, but they do partially have separate privacy policies and contacts so let's not include OkCupid etc. in here.

As for `suggested-transport-medium` I would suggest to use the web form, but that is not really possible.