### PR TITLE
Add web form for Beitragsservice

### DIFF
--- a/companies/beitragsservice.json
+++ b/companies/beitragsservice.json
@@ -18,6 +18,7 @@
         "https://www.rundfunkbeitrag.de/impressum/index_ger.html"
     ],
     "comments": [
+        "Webformular: https://www.rundfunkbeitrag.de/der_rundfunkbeitrag/beitragsservice/datenschutz/datenschutzkontaktformular/index_ger.html",
         "Faxnummer eigentlich +49 1806 999 555 01 (20 Cent/Anruf aus dem dt. Festnetz, 60 Cent/Anruf aus den dt. Mobilfunknetzen). Alternative Nummer übernommen von: https://www.0180.info/suche.html?s=0180699955501"
     ],
     "relevant-countries": [


### PR DESCRIPTION
They currently do have the problem that their mail server does not support SSL/TLS. I'm going to fill a complaint.

However, they at least referred me to their contact form, which is quite nice, actually.
They do also have a special one for art. 15 requests, but as Datenanfragen.de also allows other requests, I've used this one. The other one would be:
https://www.rundfunkbeitrag.de/der_rundfunkbeitrag/beitragsservice/datenschutz/datenauskunft/index_ger.html