### PR TITLE
Add 'G2A.COM Limited' (community contribution)

### DIFF
--- a/companies/g2a.json
+++ b/companies/g2a.json
@@ -6,12 +6,15 @@
     "categories": [
         "entertainment"
     ],
-    "name": "G2A.COM Limited",
-    "address": "DPO\nG2A.COM Limited\n31/F, Tower Two,\nTimes Square,\n1 Matheson Street,\nCauseway Bay,\nHong Kong",
+    "name": "G2A PL sp. z o.o.",
+    "runs": [
+        "G2A.COM Limited"
+    ],
+    "address": "Emili Plater 53 Street\n00-113 Warsaw\nPoland",
     "email": "dpo@g2a.com",
     "web": "https://g2a.com",
     "sources": [
-        "https://www.g2a.com/privacy-policy?___store=english",
+        "https://www.g2a.com/privacy-policy",
         "https://github.com/datenanfragen/data/pull/768"
     ],
     "needs-id-document": false,

--- a/companies/g2a.json
+++ b/companies/g2a.json
@@ -1,0 +1,20 @@
+{
+    "slug": "g2a",
+    "relevant-countries": [
+        "all"
+    ],
+    "categories": [
+        "entertainment"
+    ],
+    "name": "G2A.COM Limited",
+    "address": "DPO\nG2A.COM Limited\n31/F, Tower Two,\nTimes Square,\n1 Matheson Street,\nCauseway Bay,\nHong Kong",
+    "email": "dpo@g2a.com",
+    "web": "https://g2a.com",
+    "sources": [
+        "https://www.g2a.com/privacy-policy?___store=english",
+        "https://github.com/datenanfragen/data/pull/768"
+    ],
+    "needs-id-document": false,
+    "suggested-transport-medium": "email",
+    "quality": "verified"
+}


### PR DESCRIPTION
This suggestion was submitted through the website.

**[Edit](https://company-json.netlify.com/#!doc=%7B%22slug%22%3A%22g2a%22%2C%22relevant-countries%22%3A%5B%22all%22%5D%2C%22categories%22%3A%5B%22entertainment%22%5D%2C%22name%22%3A%22G2A.COM%20Limited%22%2C%22address%22%3A%22DPO%5CnG2A.COM%20Limited%5Cn31%2FF%2C%20Tower%20Two%2C%5CnTimes%20Square%2C%5Cn1%20Matheson%20Street%2C%5CnCauseway%20Bay%2C%5CnHong%20Kong%22%2C%22email%22%3A%22dpo%40g2a.com%22%2C%22web%22%3A%22https%3A%2F%2Fg2a.com%22%2C%22sources%22%3A%5B%22https%3A%2F%2Fwww.g2a.com%2Fprivacy-policy%3F___store%3Denglish%22%2C%22https%3A%2F%2Fgithub.com%2Fdatenanfragen%2Fdata%2Fpull%2F768%22%5D%2C%22needs-id-document%22%3Afalse%2C%22suggested-transport-medium%22%3A%22email%22%2C%22quality%22%3A%22verified%22%7D)**