### PR TITLE
Add 'StarzPlay Direct UK Limited' (community contribution)

### DIFF
--- a/companies/starz.json
+++ b/companies/starz.json
@@ -3,8 +3,11 @@
     "relevant-countries": [
         "all"
     ],
+    "categories": [
+        "entertainment"
+    ],
     "name": "StarzPlay Direct UK Limited",
-    "address": "StarzPlay Direct UK Limited,\n45 Mortimer Street,\nLondon, W1W 8HJ,\nUnited Kingdom",
+    "address": "45 Mortimer Street\nLondon\nW1W 8HJ\nUnited Kingdom",
     "email": "privacy@starz.com",
     "web": "https://starz.com",
     "sources": [

--- a/companies/starz.json
+++ b/companies/starz.json
@@ -1,0 +1,17 @@
+{
+    "slug": "starz",
+    "relevant-countries": [
+        "all"
+    ],
+    "name": "StarzPlay Direct UK Limited",
+    "address": "StarzPlay Direct UK Limited,\n45 Mortimer Street,\nLondon, W1W 8HJ,\nUnited Kingdom",
+    "email": "privacy@starz.com",
+    "web": "https://starz.com",
+    "sources": [
+        "https://www.starz.com/gb/en/privacy",
+        "https://github.com/datenanfragen/data/pull/770"
+    ],
+    "needs-id-document": false,
+    "suggested-transport-medium": "email",
+    "quality": "verified"
+}


### PR DESCRIPTION
This suggestion was submitted through the website.

**[Edit](https://company-json.netlify.com/#!doc=%7B%22slug%22%3A%22starz%22%2C%22relevant-countries%22%3A%5B%22all%22%5D%2C%22name%22%3A%22StarzPlay%20Direct%20UK%20Limited%22%2C%22address%22%3A%22StarzPlay%20Direct%20UK%20Limited%2C%5Cn45%20Mortimer%20Street%2C%5CnLondon%2C%20W1W%208HJ%2C%5CnUnited%20Kingdom%22%2C%22email%22%3A%22privacy%40starz.com%22%2C%22web%22%3A%22https%3A%2F%2Fstarz.com%22%2C%22sources%22%3A%5B%22https%3A%2F%2Fwww.starz.com%2Fgb%2Fen%2Fprivacy%22%2C%22https%3A%2F%2Fgithub.com%2Fdatenanfragen%2Fdata%2Fpull%2F770%22%5D%2C%22needs-id-document%22%3Afalse%2C%22suggested-transport-medium%22%3A%22email%22%2C%22quality%22%3A%22verified%22%7D)**