### PR TITLE
Add all churches from the "Evangelisch-lutherische Landeskirche in Braunschweig"

### DIFF
--- a/companies/apostelgemeinde-in-salzgitter-lebenstedt.json
+++ b/companies/apostelgemeinde-in-salzgitter-lebenstedt.json
@@ -1,0 +1,21 @@
+{
+    "slug": "apostelgemeinde-in-salzgitter-lebenstedt",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Apostelgemeinde in Salzgitter-Lebenstedt",
+    "address": "Neißestraße 33-35\n38226 Salzgitter\nDeutschland",
+    "phone": "+49 5341 61140",
+    "email": "apostelgemeinde.sz.buero@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=897"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/apostelkirchengemeinde-frellstedt-wolsdorf.json
+++ b/companies/apostelkirchengemeinde-frellstedt-wolsdorf.json
@@ -1,0 +1,21 @@
+{
+    "slug": "apostelkirchengemeinde-frellstedt-wolsdorf",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Apostelkirchengemeinde Frellstedt-Wolsdorf",
+    "address": "Elmstraße 1\n38373 Frellstedt\nDeutschland",
+    "phone": "+49 5355 1656",
+    "email": "frellstedt.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=834"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/christusgemeinde-berklingen-klein-vahlberg-in-vahlberg.json
+++ b/companies/christusgemeinde-berklingen-klein-vahlberg-in-vahlberg.json
@@ -1,0 +1,23 @@
+{
+    "slug": "christusgemeinde-berklingen-klein-vahlberg-in-vahlberg",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Christusgemeinde Berklingen-Klein Vahlberg in Vahlberg",
+    "address": "Kirchweg 4\n38327 Semmenstedt\nDeutschland",
+    "phone": "+49 5336 397",
+    "fax": "+49 5336 948214",
+    "email": "asse.pfa@lk-bs.de",
+    "web": "http://www.gesamtpfarrverband-asse.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=943"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/christuskirchengemeinde-gitter-und-hohenrode-in-salzgitter.json
+++ b/companies/christuskirchengemeinde-gitter-und-hohenrode-in-salzgitter.json
@@ -1,0 +1,22 @@
+{
+    "slug": "christuskirchengemeinde-gitter-und-hohenrode-in-salzgitter",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Christuskirchengemeinde Gitter und Hohenrode in Salzgitter",
+    "address": "Altstadtweg 6\n38259 Salzgitter\nDeutschland",
+    "phone": "+49 5341 81620",
+    "fax": "+49 5341 816231",
+    "email": "salzgitterbad-gitter.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=878"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/dreieinigkeitsgemeinde-salzdahlum-apelnstedt-volzum-in-wolfenbuettel.json
+++ b/companies/dreieinigkeitsgemeinde-salzdahlum-apelnstedt-volzum-in-wolfenbuettel.json
@@ -1,0 +1,23 @@
+{
+    "slug": "dreieinigkeitsgemeinde-salzdahlum-apelnstedt-volzum-in-wolfenbuettel",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Dreieinigkeitsgemeinde Salzdahlum-Apelnstedt-Volzum in Wolfenbüttel",
+    "address": "Jahnstraße 5\n38302 Wolfenbüttel\nDeutschland",
+    "phone": "+49 5331 72413",
+    "fax": "+49 5331 340546",
+    "email": "maria-magdala.wf.pfa@lk-bs.de",
+    "web": "http://www.salzdahlum-apelnstedt-volzum-evangelisch.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1068"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/dreifaltigkeitsgemeinde-kissenbrueck-biewende.json
+++ b/companies/dreifaltigkeitsgemeinde-kissenbrueck-biewende.json
@@ -1,0 +1,23 @@
+{
+    "slug": "dreifaltigkeitsgemeinde-kissenbrueck-biewende",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Dreifaltigkeitsgemeinde Kissenbrück-Biewende",
+    "address": "Hinter der Kirche 3\n38324 Kissenbrück\nDeutschland",
+    "phone": "+49 5337 226",
+    "fax": "+49 5337 926958",
+    "email": "kissenbrueck-biewende.buero@lk-bs.de",
+    "web": "http://www.kirche-kissenbrueck-biewende.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1059"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/gethsemane-michaelis-in-wolfenbuettel.json
+++ b/companies/gethsemane-michaelis-in-wolfenbuettel.json
@@ -1,0 +1,22 @@
+{
+    "slug": "gethsemane-michaelis-in-wolfenbuettel",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Gethsemane-Michaelis in Wolfenbüttel",
+    "address": "Glockengasse 2\n38304 Wolfenbüttel\nDeutschland",
+    "phone": "+49 5331 298544",
+    "fax": "+49 5331 9028906",
+    "email": "johannis.wf.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1054"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/harzkirchengemeinde-trinitatis.json
+++ b/companies/harzkirchengemeinde-trinitatis.json
@@ -1,0 +1,22 @@
+{
+    "slug": "harzkirchengemeinde-trinitatis",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Harzkirchengemeinde Trinitatis",
+    "address": "Heimburger Kirchstraße 4\n38889 Blankenburg (Harz)\nDeutschland",
+    "phone": "+49 3944 63614",
+    "fax": "+49 3944 367088",
+    "email": "heimburg.buero@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=709"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/johannesgemeinde-saalsdorf-in-bahrdorf.json
+++ b/companies/johannesgemeinde-saalsdorf-in-bahrdorf.json
@@ -1,0 +1,22 @@
+{
+    "slug": "johannesgemeinde-saalsdorf-in-bahrdorf",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Johannesgemeinde Saalsdorf in Bahrdorf",
+    "address": "An der Kirche 2\n38446 Wolfsburg\nDeutschland",
+    "phone": "+49 5363 976034",
+    "fax": "+49 5363 72426",
+    "email": "aller.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1030"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/johannesgemeinde-schladen-werla.json
+++ b/companies/johannesgemeinde-schladen-werla.json
@@ -1,0 +1,22 @@
+{
+    "slug": "johannesgemeinde-schladen-werla",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Johannesgemeinde Schladen-Werla",
+    "address": "Westendorf 1\n38315 Werlaburgdorf\nDeutschland",
+    "phone": "+49 5335 343",
+    "fax": "+49 5335 905184",
+    "email": "schladen-werla.buero@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=962"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/johannisgemeinde-am-sandbach-cremlingen.json
+++ b/companies/johannisgemeinde-am-sandbach-cremlingen.json
@@ -1,0 +1,22 @@
+{
+    "slug": "johannisgemeinde-am-sandbach-cremlingen",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Johannisgemeinde am Sandbach / Cremlingen",
+    "address": "Kirchstraße 16\n38162 Cremlingen\nDeutschland",
+    "phone": "+49 5306 4157",
+    "fax": "+49 5306 4089",
+    "email": "zwoelf-apostel-cremlingen.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=111672"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/katharinengemeinde-in-bahrdorf.json
+++ b/companies/katharinengemeinde-in-bahrdorf.json
@@ -1,0 +1,22 @@
+{
+    "slug": "katharinengemeinde-in-bahrdorf",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Katharinengemeinde in Bahrdorf",
+    "address": "An der Kirche 2\n38446 Wolfsburg\nDeutschland",
+    "phone": "+49 5363 976034",
+    "fax": "+49 5363 72426",
+    "email": "aller.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1027"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-ackenhausen-wolperode-in-bad-gandersheim.json
+++ b/companies/kirchengemeinde-ackenhausen-wolperode-in-bad-gandersheim.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-ackenhausen-wolperode-in-bad-gandersheim",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Ackenhausen-Wolperode in Bad Gandersheim",
+    "address": "Stiftsfreiheit 1\n37581 Bad Gandersheim\nDeutschland",
+    "phone": "+49 5382 2714",
+    "fax": "+49 5382 790416",
+    "email": "gandersheim.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=670"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-ahlshausen-in-kreiensen.json
+++ b/companies/kirchengemeinde-ahlshausen-in-kreiensen.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-ahlshausen-in-kreiensen",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Ahlshausen in Kreiensen",
+    "address": "Schulstraße 7\n37574 Einbeck\nDeutschland",
+    "phone": "+49 5563 248",
+    "fax": "+49 5563 6383",
+    "email": "opperhausen.buero@lk-bs.de",
+    "web": "http://www.pfarrverband-opperhausen.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=697"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-ahlum-atzum-wendessen-in-wolfenbuettel.json
+++ b/companies/kirchengemeinde-ahlum-atzum-wendessen-in-wolfenbuettel.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-ahlum-atzum-wendessen-in-wolfenbuettel",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Ahlum-Atzum-Wendessen in Wolfenbüttel",
+    "address": "Jahnstraße 5\n38302 Wolfenbüttel\nDeutschland",
+    "phone": "+49 5331 72413",
+    "fax": "+49 5331 340546",
+    "email": "maria-magdala.wf.pfa@lk-bs.de",
+    "web": "http://www.ahlum-atzum-wendessen-evangelisch.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1053"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-allrode.json
+++ b/companies/kirchengemeinde-allrode.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-allrode",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Allrode",
+    "address": "Blumenaustraße 7\n38899 Oberharz am Brocken\nDeutschland",
+    "phone": "+49 39459 71371",
+    "fax": "+49 39459 18845",
+    "email": "hasselfelde.buero@lk-bs.de",
+    "web": "http://www.hasselfelde-evangelisch.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=721"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-alt-wallmoden.json
+++ b/companies/kirchengemeinde-alt-wallmoden.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-alt-wallmoden",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Alt Wallmoden",
+    "address": "An der Kirche 2\n38271 Baddeckenstedt\nDeutschland",
+    "phone": "+49 5345 4040",
+    "fax": "+49 5345 929956",
+    "email": "baddeckenstedt.buero@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=791"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-altenbrak-treseburg.json
+++ b/companies/kirchengemeinde-altenbrak-treseburg.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-altenbrak-treseburg",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Altenbrak-Treseburg",
+    "address": "Lange Straße 9\n38889 Blankenburg (Harz) OT Wienrode\nDeutschland",
+    "phone": "+49 3944 366581",
+    "fax": "+49 3944 366622",
+    "email": "wienrode.buero@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=713"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-am-elm-cremlingen.json
+++ b/companies/kirchengemeinde-am-elm-cremlingen.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-am-elm-cremlingen",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde am Elm/Cremlingen",
+    "address": "An der Oberburg 14\n38162 Cremlingen\nDeutschland",
+    "phone": "+49 5306 1854",
+    "fax": "+49 5306 930596",
+    "email": "destedt.buero@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=827"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-ammensen-in-delligsen.json
+++ b/companies/kirchengemeinde-ammensen-in-delligsen.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-ammensen-in-delligsen",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Ammensen in Delligsen",
+    "address": "Im Oberdorf 11\n37574 Einbeck\nDeutschland",
+    "phone": "+49 5563 6822",
+    "fax": "+49 5563 6868",
+    "email": "naensen.buero@lk-bs.de",
+    "web": "http://blog.kirche-naensen.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=694"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-an-der-ohe-sickte.json
+++ b/companies/kirchengemeinde-an-der-ohe-sickte.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-an-der-ohe-sickte",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde an der Ohe / Sickte",
+    "address": "Kirchstraße 1\n38173 Veltheim (Ohe)\nDeutschland",
+    "phone": "+49 5305 649",
+    "fax": "+49 5305 480",
+    "email": "veltheim.buero@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=111673"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-apostel-kirche-gross-stoeckheim-in-wolfenbuettel.json
+++ b/companies/kirchengemeinde-apostel-kirche-gross-stoeckheim-in-wolfenbuettel.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-apostel-kirche-gross-stoeckheim-in-wolfenbuettel",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Apostel-Kirche Groß Stöckheim in Wolfenbüttel",
+    "address": "Glockengasse 2\n38304 Wolfenbüttel\nDeutschland",
+    "phone": "+49 5331 298544",
+    "fax": "+49 5331 9028906",
+    "email": "johannis.wf.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1063"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-auferstehungskirche-in-braunschweig.json
+++ b/companies/kirchengemeinde-auferstehungskirche-in-braunschweig.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-auferstehungskirche-in-braunschweig",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Auferstehungskirche in Braunschweig",
+    "address": "Süntelstraße 1\n38122 Braunschweig\nDeutschland",
+    "phone": "+49 531 2872180",
+    "fax": "+49 531 2872181",
+    "email": "gartenstadt.buero@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=756"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-baddeckenstedt.json
+++ b/companies/kirchengemeinde-baddeckenstedt.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-baddeckenstedt",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Baddeckenstedt",
+    "address": "An der Kirche 2\n38271 Baddeckenstedt\nDeutschland",
+    "phone": "+49 5345 4040",
+    "fax": "+49 5345 929956",
+    "email": "baddeckenstedt.buero@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=767"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-badenhausen.json
+++ b/companies/kirchengemeinde-badenhausen.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-badenhausen",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Badenhausen",
+    "address": "Thüringer Straße 239\n37539 Bad Grund (Harz)\nDeutschland",
+    "phone": "+49 5522 83088",
+    "email": "badenhausen.pfa@lk-bs.de",
+    "web": "https://www.ek-bdh-wdh.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=966"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-barbecke-in-lengede.json
+++ b/companies/kirchengemeinde-barbecke-in-lengede.json
@@ -1,0 +1,21 @@
+{
+    "slug": "kirchengemeinde-barbecke-in-lengede",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Barbecke in Lengede",
+    "address": "Lebenstedter Straße 3\n38268 Lengede OT Broistedt\nDeutschland",
+    "phone": "+49 5344 1255",
+    "email": "woltwiesche.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=917"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-beinum-in-salzgitter.json
+++ b/companies/kirchengemeinde-beinum-in-salzgitter.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-beinum-in-salzgitter",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Beinum in Salzgitter",
+    "address": "Werkstraße 18\n38229 Salzgitter\nDeutschland",
+    "phone": "+49 5341 24018",
+    "fax": "+49 5341 229396",
+    "email": "lobmachtersen.pfa@lk-bs.de",
+    "web": "http://www.pfarrverband-lobmachtersen.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=874"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-bentierode.json
+++ b/companies/kirchengemeinde-bentierode.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-bentierode",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Bentierode",
+    "address": "Stiftsfreiheit 1\n37581 Bad Gandersheim\nDeutschland",
+    "phone": "+49 5382 2714",
+    "fax": "+49 5382 790416",
+    "email": "gandersheim.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=681"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-berel-burgdorf.json
+++ b/companies/kirchengemeinde-berel-burgdorf.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-berel-burgdorf",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Berel-Burgdorf",
+    "address": "Zum Hohen Tor 8\n38228 Salzgitter\nDeutschland",
+    "phone": "+49 5341 52617",
+    "email": "lesse.pfa@lk-bs.de",
+    "web": "http://www.kirchengemeinde-lesse.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=899"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-bettingerode-westerode-in-bad-harzburg.json
+++ b/companies/kirchengemeinde-bettingerode-westerode-in-bad-harzburg.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-bettingerode-westerode-in-bad-harzburg",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Bettingerode-Westerode in Bad Harzburg",
+    "address": "Bismarckstraße 13\n38690 Goslar\nDeutschland",
+    "phone": "+49 5324 2245",
+    "fax": "+49 5324 2059",
+    "email": "harz-harly.pfa@lk-bs.de",
+    "web": "https://www.kirche-harz-harly.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=705"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-binder-in-baddeckenstedt.json
+++ b/companies/kirchengemeinde-binder-in-baddeckenstedt.json
@@ -1,0 +1,21 @@
+{
+    "slug": "kirchengemeinde-binder-in-baddeckenstedt",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Binder in Baddeckenstedt",
+    "address": "Kasselberg 1\n38272 Burgdorf\nDeutschland",
+    "phone": "+49 5347 1917",
+    "email": "westerlinde.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=913"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-blankenburg.json
+++ b/companies/kirchengemeinde-blankenburg.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-blankenburg",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Blankenburg",
+    "address": "Herzogstraße 16\n38889 Blankenburg (Harz)\nDeutschland",
+    "phone": "+49 3944 980669",
+    "fax": "+49 3944 980670",
+    "email": "harzer-land.pfa@lk-bs.de",
+    "web": "http://www.evangelisch-in-blankenburg.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=706"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-bleckenstedt-in-salzgitter.json
+++ b/companies/kirchengemeinde-bleckenstedt-in-salzgitter.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-bleckenstedt-in-salzgitter",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Bleckenstedt in Salzgitter",
+    "address": "An der Kirche 4\n38239 Salzgitter\nDeutschland",
+    "phone": "+49 5300 260",
+    "fax": "+49 5300 495",
+    "email": "sauingen.buero@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=906"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-boimstorf-in-koenigslutter.json
+++ b/companies/kirchengemeinde-boimstorf-in-koenigslutter.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-boimstorf-in-koenigslutter",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Boimstorf in Königslutter",
+    "address": "An der Stadtkirche 6\n38154 Königslutter am Elm\nDeutschland",
+    "phone": "+49 5353 96278",
+    "fax": "+49 5353 951781",
+    "email": "koenigslutter.pfa@lk-bs.de",
+    "web": "https://www.kirchengemeindeverband-koenigslutter.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=837"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-bornhausen-in-seesen.json
+++ b/companies/kirchengemeinde-bornhausen-in-seesen.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-bornhausen-in-seesen",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Bornhausen in Seesen",
+    "address": "Klingenhagener Straße 17\n38723 Seesen\nDeutschland",
+    "phone": "+49 5381 5083",
+    "fax": "+49 5381 9409765",
+    "email": "bornhausen.buero@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=992"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-bornum-in-koenigslutter.json
+++ b/companies/kirchengemeinde-bornum-in-koenigslutter.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-bornum-in-koenigslutter",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Bornum in Königslutter",
+    "address": "An der Stadtkirche 6\n38154 Königslutter am Elm\nDeutschland",
+    "phone": "+49 5353 96278",
+    "fax": "+49 5353 951781",
+    "email": "koenigslutter.pfa@lk-bs.de",
+    "web": "https://www.kirchengemeindeverband-koenigslutter.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=822"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-bornum-jerze-ortshausen-im-ambergau.json
+++ b/companies/kirchengemeinde-bornum-jerze-ortshausen-im-ambergau.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-bornum-jerze-ortshausen-im-ambergau",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Bornum-Jerze-Ortshausen im Ambergau",
+    "address": "Heerstraße 44\n31167 Bockenem\nDeutschland",
+    "phone": "+49 5067 6441",
+    "email": "bornum.harz.buero@lk-bs.de",
+    "web": "http://www.kirchengemeinde-bornum.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=968"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-brackstedt-in-wolfsburg.json
+++ b/companies/kirchengemeinde-brackstedt-in-wolfsburg.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-brackstedt-in-wolfsburg",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Brackstedt in Wolfsburg",
+    "address": "Im Wiesengrund 19\n38448 Wolfsburg\nDeutschland",
+    "phone": "+49 5361 61441",
+    "email": "johannes-kaestorf.buero@lk-bs.de",
+    "web": "http://www.kirche-kaestorf.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1039"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-braunlage.json
+++ b/companies/kirchengemeinde-braunlage.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-braunlage",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Braunlage",
+    "address": "Pfarrstraße 1\n38700 Braunlage\nDeutschland",
+    "phone": "+49 5520 93010",
+    "fax": "+49 5520 930122",
+    "email": "braunlage.buero@lk-bs.de",
+    "web": "http://www.trinitatis.info/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=707"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-braunschweig-mascherode.json
+++ b/companies/kirchengemeinde-braunschweig-mascherode.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-braunschweig-mascherode",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Braunschweig-Mascherode",
+    "address": "Schulgasse 1\n38126 Braunschweig\nDeutschland",
+    "phone": "+49 531 692718",
+    "fax": "+49 531 2886824",
+    "email": "mascherode.buero@lk-bs.de",
+    "web": "http://www.kirche-mascherode.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=762"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-broistedt-in-lengede.json
+++ b/companies/kirchengemeinde-broistedt-in-lengede.json
@@ -1,0 +1,21 @@
+{
+    "slug": "kirchengemeinde-broistedt-in-lengede",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Broistedt in Lengede",
+    "address": "Lebenstedter Straße 3\n38268 Lengede\nDeutschland",
+    "phone": "+49 5344 1255",
+    "email": "broistedt.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=887"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-broitzem-in-braunschweig.json
+++ b/companies/kirchengemeinde-broitzem-in-braunschweig.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-broitzem-in-braunschweig",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Broitzem in Braunschweig",
+    "address": "Große Grubestraße 2 A\n38122 Braunschweig\nDeutschland",
+    "phone": "+49 531 875756",
+    "email": "broitzem.pfa@lk-bs.de",
+    "web": "http://www.kirchebroitzem.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1004"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-bruchmachtersen-in-salzgitter.json
+++ b/companies/kirchengemeinde-bruchmachtersen-in-salzgitter.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-bruchmachtersen-in-salzgitter",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Bruchmachtersen in Salzgitter",
+    "address": "Museumstraße 9\n38229 Salzgitter\nDeutschland",
+    "phone": "+49 5341 41113",
+    "fax": "+49 5341 1860462",
+    "email": "salder.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=903"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-brunsen-wenzen-eimen-in-einbeck.json
+++ b/companies/kirchengemeinde-brunsen-wenzen-eimen-in-einbeck.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-brunsen-wenzen-eimen-in-einbeck",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Brunsen-Wenzen-Eimen in Einbeck",
+    "address": "Jacobiplatz 1\n37574 Einbeck\nDeutschland",
+    "phone": "+49 5565 240",
+    "fax": "+49 5565 1365",
+    "email": "wenzen.buero@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=112333"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-bueddenstedt.json
+++ b/companies/kirchengemeinde-bueddenstedt.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-bueddenstedt",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Büddenstedt",
+    "address": "Niedernstraße 47\n38364 Schöningen\nDeutschland",
+    "phone": "+49 5352 4764",
+    "fax": "+49 5352 4745",
+    "email": "helmstedt-sued.pfa@lk-bs.de",
+    "web": "http://www.kirchengemeinde-bueddenstedt.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=815"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-burgdorf-assel.json
+++ b/companies/kirchengemeinde-burgdorf-assel.json
@@ -1,0 +1,21 @@
+{
+    "slug": "kirchengemeinde-burgdorf-assel",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Burgdorf-Assel",
+    "address": "Kasselberg 1\n38272 Burgdorf\nDeutschland",
+    "phone": "+49 5347 1917",
+    "email": "westerlinde.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=889"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-christus-kirche-gustedt-in-elbe.json
+++ b/companies/kirchengemeinde-christus-kirche-gustedt-in-elbe.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-christus-kirche-gustedt-in-elbe",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Christus-Kirche Gustedt in Elbe",
+    "address": "Am Pfarrgarten 5\n38274 Elbe\nDeutschland",
+    "phone": "+49 5345 330",
+    "fax": "+49 5345 1773",
+    "email": "elbe.buero@lk-bs.de",
+    "web": "http://www.kirche-in-elbe.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=781"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-christuskirche-weddel-in-cremlingen.json
+++ b/companies/kirchengemeinde-christuskirche-weddel-in-cremlingen.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-christuskirche-weddel-in-cremlingen",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Christuskirche Weddel in Cremlingen",
+    "address": "Kirchstraße 16\n38162 Cremlingen\nDeutschland",
+    "phone": "+49 5306 4157",
+    "fax": "+49 5306 4089",
+    "email": "zwoelf-apostel-cremlingen.pfa@lk-bs.de",
+    "web": "http://www.christuskirche-weddel.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=863"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-christuskirche-zu-parsau-mit-ahnebeck-und-bergfeld.json
+++ b/companies/kirchengemeinde-christuskirche-zu-parsau-mit-ahnebeck-und-bergfeld.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-christuskirche-zu-parsau-mit-ahnebeck-und-bergfeld",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Christuskirche zu Parsau mit Ahnebeck und Bergfeld",
+    "address": "Bergfelder Straße 1\n38470 Parsau\nDeutschland",
+    "phone": "+49 5368 256",
+    "fax": "+49 5368 977991",
+    "email": "christuskirche-parsau.buero@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1045"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-clus-und-st-andreas-esbeck-in-schoeningen.json
+++ b/companies/kirchengemeinde-clus-und-st-andreas-esbeck-in-schoeningen.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-clus-und-st-andreas-esbeck-in-schoeningen",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Clus und St. Andreas Esbeck in Schöningen",
+    "address": "Niedernstraße 47\n38364 Schöningen\nDeutschland",
+    "phone": "+49 5352 4764",
+    "fax": "+49 5352 4745",
+    "email": "helmstedt-sued.pfa@lk-bs.de",
+    "web": "http://www.clus-kirche.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=818"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-dahlum.json
+++ b/companies/kirchengemeinde-dahlum.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-dahlum",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Dahlum",
+    "address": "Voigtsdahlumer Straße 1\n38170 Dahlum\nDeutschland",
+    "phone": "+49 5332 3342",
+    "fax": "+49 5332 3347",
+    "email": "dahlum.buero@lk-bs.de",
+    "web": "http://www.dahlum-evangelisch.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=930"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-dankelsheim-clus-brunshausen-in-bad-gandersheim.json
+++ b/companies/kirchengemeinde-dankelsheim-clus-brunshausen-in-bad-gandersheim.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-dankelsheim-clus-brunshausen-in-bad-gandersheim",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Dankelsheim-Clus-Brunshausen in Bad Gandersheim",
+    "address": "Stiftsfreiheit 1\n37581 Bad Gandersheim\nDeutschland",
+    "phone": "+49 5382 2714",
+    "fax": "+49 5382 790416",
+    "email": "gandersheim.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=112388"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-danndorf-grafhorst.json
+++ b/companies/kirchengemeinde-danndorf-grafhorst.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-danndorf-grafhorst",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Danndorf-Grafhorst",
+    "address": "Kirchstraße 30\n38462 Grafhorst\nDeutschland",
+    "phone": "+49 5364 4822",
+    "fax": "+49 5364 4822",
+    "email": "danndorf-grafhorst.buero@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1034"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-dannhausen-in-bad-gandersheim.json
+++ b/companies/kirchengemeinde-dannhausen-in-bad-gandersheim.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-dannhausen-in-bad-gandersheim",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Dannhausen in Bad Gandersheim",
+    "address": "Hinter der Kirche 1 A\n38723 Seesen\nDeutschland",
+    "phone": "+49 5381 942929",
+    "fax": "+49 5381 942917",
+    "email": "herrhausen.buero@lk-bs.de",
+    "web": "http://www.kirche-herrhausen.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=974"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-denstorf-klein-und-gross-gleidingen-in-vechelde.json
+++ b/companies/kirchengemeinde-denstorf-klein-und-gross-gleidingen-in-vechelde.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-denstorf-klein-und-gross-gleidingen-in-vechelde",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Denstorf-Klein und Groß Gleidingen in Vechelde",
+    "address": "St.-Johannes-Straße 7\n38159 Vechelde\nDeutschland",
+    "phone": "+49 5302 1408",
+    "fax": "+49 5302 902971",
+    "email": "denstorf.pfa@lk-bs.de",
+    "web": "http://www.denstorf.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=112385"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-die-bruecke-in-braunschweig.json
+++ b/companies/kirchengemeinde-die-bruecke-in-braunschweig.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-die-bruecke-in-braunschweig",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Die Brücke in Braunschweig",
+    "address": "Am Schwarzen Berge 18\n38112 Braunschweig\nDeutschland",
+    "phone": "+49 531 323924",
+    "fax": "+49 531 303090",
+    "email": "diebruecke.bs.pfa@lk-bs.de",
+    "web": "http://www.kirchengemeinde-die-bruecke.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=736"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-dietrich-bonhoeffer-zu-melverode-in-braunschweig.json
+++ b/companies/kirchengemeinde-dietrich-bonhoeffer-zu-melverode-in-braunschweig.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-dietrich-bonhoeffer-zu-melverode-in-braunschweig",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Dietrich Bonhoeffer zu Melverode in Braunschweig",
+    "address": "Görlitzstraße 17\n38124 Braunschweig\nDeutschland",
+    "phone": "+49 531 603167",
+    "fax": "+49 531 603167",
+    "email": "melverode.buero@lk-bs.de",
+    "web": "http://www.kirchengemeinde-melverode.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=757"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-doernten-in-liebenburg.json
+++ b/companies/kirchengemeinde-doernten-in-liebenburg.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-doernten-in-liebenburg",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Dörnten in Liebenburg",
+    "address": "Ringstraße 11\n38704 Liebenburg\nDeutschland",
+    "phone": "+49 5346 4280",
+    "fax": "+49 5346 6137",
+    "email": "doernten.pfa@lk-bs.de",
+    "web": "https://www.kirchengemeinde-doernten-ostharingen-upen.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=770"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-dreieinigkeit-zu-schoeppenstedt.json
+++ b/companies/kirchengemeinde-dreieinigkeit-zu-schoeppenstedt.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-dreieinigkeit-zu-schoeppenstedt",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Dreieinigkeit zu Schöppenstedt",
+    "address": "An der Kirche 1\n38170 Schöppenstedt\nDeutschland",
+    "phone": "+49 5332 968040",
+    "fax": "+49 5332 968033",
+    "email": "schoeppenstedt.buero@lk-bs.de",
+    "web": "https://www.dreieinigkeit-schoeppenstedt.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=946"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-duttenstedt-essinghausen-meerdorf-in-wendeburg.json
+++ b/companies/kirchengemeinde-duttenstedt-essinghausen-meerdorf-in-wendeburg.json
@@ -1,0 +1,21 @@
+{
+    "slug": "kirchengemeinde-duttenstedt-essinghausen-meerdorf-in-wendeburg",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Duttenstedt-Essinghausen-Meerdorf in Wendeburg",
+    "address": "Am Pfarrhaus 3\n38176 Wendeburg\nDeutschland",
+    "phone": "+49 5171 17587",
+    "email": "meerdorf.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=112331"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-elsebeck-berenbrock.json
+++ b/companies/kirchengemeinde-elsebeck-berenbrock.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-elsebeck-berenbrock",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Elsebeck-Berenbrock",
+    "address": "An der Kirche 1\n39359 Calvörde\nDeutschland",
+    "phone": "+49 39051 259",
+    "fax": "+49 39051 98225",
+    "email": "calvoerde.pfa@lk-bs.de",
+    "web": "https://www.pfarrverband-calvoerde-uthmoeden.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1025"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-engelade-in-seesen.json
+++ b/companies/kirchengemeinde-engelade-in-seesen.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-engelade-in-seesen",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Engelade in Seesen",
+    "address": "Hinter der Kirche 1 A\n38723 Seesen\nDeutschland",
+    "phone": "+49 5381 942929",
+    "fax": "+49 5381 942917",
+    "email": "herrhausen.buero@lk-bs.de",
+    "web": "http://www.kirche-herrhausen.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=975"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-erzhausen-in-kreiensen.json
+++ b/companies/kirchengemeinde-erzhausen-in-kreiensen.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-erzhausen-in-kreiensen",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Erzhausen in Kreiensen",
+    "address": "Friedhofsweg 3\n37574 Einbeck\nDeutschland",
+    "phone": "+49 5563 259",
+    "fax": "+49 5563 919894",
+    "email": "kreiensen.buero@lk-bs.de",
+    "web": "http://www.kirche-kreiensen.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=690"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-flachstoeckheim-in-salzgitter.json
+++ b/companies/kirchengemeinde-flachstoeckheim-in-salzgitter.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-flachstoeckheim-in-salzgitter",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Flachstöckheim in Salzgitter",
+    "address": "Oderwaldstraße 5\n38312 Flöthe\nDeutschland",
+    "phone": "+49 5341 9650",
+    "fax": "+49 5341 30265",
+    "email": "salzgitter-bad.pr@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=873"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-floethe.json
+++ b/companies/kirchengemeinde-floethe.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-floethe",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Flöthe",
+    "address": "Oderwaldstraße 5\n38312 Flöthe\nDeutschland",
+    "phone": "+49 5341 9650",
+    "fax": "+49 5341 30265",
+    "email": "salzgitter-bad.pr@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=865"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-friedenskirche-in-salzgitter-lebenstedt.json
+++ b/companies/kirchengemeinde-friedenskirche-in-salzgitter-lebenstedt.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-friedenskirche-in-salzgitter-lebenstedt",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Friedenskirche in Salzgitter-Lebenstedt",
+    "address": "Hans-Böckler-Ring 1\n38228 Salzgitter\nDeutschland",
+    "phone": "+49 5341 85370",
+    "fax": "+49 5341 853725",
+    "email": "friedenskirche.pfa@lk-bs.de",
+    "web": "http://www.friedenskirchengemeinde.net/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=891"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-gebhardshagen-calbecht-engerode-in-salzgitter.json
+++ b/companies/kirchengemeinde-gebhardshagen-calbecht-engerode-in-salzgitter.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-gebhardshagen-calbecht-engerode-in-salzgitter",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Gebhardshagen-Calbecht-Engerode in Salzgitter",
+    "address": "Pastorenberg 6\n38229 Salzgitter\nDeutschland",
+    "phone": "+49 5341 70179",
+    "fax": "+49 5341 871131",
+    "email": "gebhardshagen.pfa@lk-bs.de",
+    "web": "http://www.pfarrverband-gebhardshagen-calbecht-engerode.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=875"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-gehrenrode-in-bad-gandersheim.json
+++ b/companies/kirchengemeinde-gehrenrode-in-bad-gandersheim.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-gehrenrode-in-bad-gandersheim",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Gehrenrode in Bad Gandersheim",
+    "address": "Stiftsfreiheit 1\n37581 Bad Gandersheim\nDeutschland",
+    "phone": "+49 5382 2714",
+    "fax": "+49 5382 790415",
+    "email": "gandersheim.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=676"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-geitelde-in-braunschweig.json
+++ b/companies/kirchengemeinde-geitelde-in-braunschweig.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-geitelde-in-braunschweig",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Geitelde in Braunschweig",
+    "address": "Geiteldestraße 39\n38122 Braunschweig\nDeutschland",
+    "phone": "+49 5300 372",
+    "email": "geitelde.pfa@lk-bs.de",
+    "web": "http://www.kirche-geitelde.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1056"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-georg-calixt-in-helmstedt.json
+++ b/companies/kirchengemeinde-georg-calixt-in-helmstedt.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-georg-calixt-in-helmstedt",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Georg Calixt in Helmstedt",
+    "address": "Klosterstraße 11\n38350 Helmstedt\nDeutschland",
+    "phone": "+49 5351 7499",
+    "fax": "+49 5351 523711",
+    "email": "helmstedtnord.pfa@lk-bs.de",
+    "web": "http://www.georg-calixt-helmstedt.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1592"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-glentorf-in-koenigslutter.json
+++ b/companies/kirchengemeinde-glentorf-in-koenigslutter.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-glentorf-in-koenigslutter",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Glentorf in Königslutter",
+    "address": "An der Stadtkirche 6\n38154 Königslutter am Elm\nDeutschland",
+    "phone": "+49 5353 96278",
+    "fax": "+49 5353 951781",
+    "email": "koenigslutter.pfa@lk-bs.de",
+    "web": "https://www.kirchengemeindeverband-koenigslutter.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=836"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-gremsheim-in-bad-gandersheim.json
+++ b/companies/kirchengemeinde-gremsheim-in-bad-gandersheim.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-gremsheim-in-bad-gandersheim",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Gremsheim in Bad Gandersheim",
+    "address": "Stiftsfreiheit 1\n37581 Bad Gandersheim\nDeutschland",
+    "phone": "+49 5382 2714",
+    "fax": "+49 5382 790416",
+    "email": "gandersheim.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=677"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-gross-denkte-in-denkte.json
+++ b/companies/kirchengemeinde-gross-denkte-in-denkte.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-gross-denkte-in-denkte",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Groß Denkte in Denkte",
+    "address": "Kirchstraße 7\n38321 Denkte\nDeutschland",
+    "phone": "+49 5331 906130",
+    "fax": "+49 5331 906132",
+    "email": "denkte.buero@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=938"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-gross-steinum-in-koenigslutter.json
+++ b/companies/kirchengemeinde-gross-steinum-in-koenigslutter.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-gross-steinum-in-koenigslutter",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Groß Steinum in Königslutter",
+    "address": "An der Stadtkirche 6\n38154 Königslutter am Elm\nDeutschland",
+    "phone": "+49 5353 96278",
+    "fax": "+49 5353 951781",
+    "email": "koenigslutter.pfa@lk-bs.de",
+    "web": "https://www.kirchengemeindeverband-koenigslutter.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=843"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-gross-u-klein-doehren-in-liebenburg.json
+++ b/companies/kirchengemeinde-gross-u-klein-doehren-in-liebenburg.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-gross-u-klein-doehren-in-liebenburg",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Groß u. Klein Döhren in Liebenburg",
+    "address": "Pfarrwinkel 6\n38704 Liebenburg\nDeutschland",
+    "phone": "+49 5346 1335",
+    "fax": "+49 5346 1013",
+    "email": "doehren.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=779"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-gross-vahlberg-in-vahlberg.json
+++ b/companies/kirchengemeinde-gross-vahlberg-in-vahlberg.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-gross-vahlberg-in-vahlberg",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Groß Vahlberg in Vahlberg",
+    "address": "Kirchweg 4\n38327 Semmenstedt\nDeutschland",
+    "phone": "+49 5336 397",
+    "fax": "+49 5336 948214",
+    "email": "asse.pfa@lk-bs.de",
+    "web": "http://www.gesamtpfarrverband-asse.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=941"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-hachenhausen-bad-gandersheim.json
+++ b/companies/kirchengemeinde-hachenhausen-bad-gandersheim.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-hachenhausen-bad-gandersheim",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Hachenhausen Bad Gandersheim",
+    "address": "Kirchenbrink 2\n37581 Bad Gandersheim\nDeutschland",
+    "phone": "+49 5382 3415",
+    "fax": "+49 5382 790811",
+    "email": "harriehausen.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=686"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-halchter-in-wolfenbuettel.json
+++ b/companies/kirchengemeinde-halchter-in-wolfenbuettel.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-halchter-in-wolfenbuettel",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Halchter in Wolfenbüttel",
+    "address": "Harzburger Straße 13\n38304 Wolfenbüttel\nDeutschland",
+    "phone": "+49 5331 61423",
+    "fax": "+49 5331 966667",
+    "email": "halchter.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1064"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-harvesse-in-wendeburg.json
+++ b/companies/kirchengemeinde-harvesse-in-wendeburg.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-harvesse-in-wendeburg",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Harvesse in Wendeburg",
+    "address": "Schulstraße 9\n38176 Wendeburg\nDeutschland",
+    "phone": "+49 5303 2356",
+    "fax": "+49 5303 2085",
+    "email": "wendeburg.pfa@lk-bs.de",
+    "web": "http://www.kirche-harvesse.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1022"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-heckenbeck-in-bad-gandersheim.json
+++ b/companies/kirchengemeinde-heckenbeck-in-bad-gandersheim.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-heckenbeck-in-bad-gandersheim",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Heckenbeck in Bad Gandersheim",
+    "address": "Stiftsfreiheit 1\n37581 Bad Gandersheim\nDeutschland",
+    "phone": "+49 5382 2714",
+    "fax": "+49 5382 790416",
+    "email": "gandersheim.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=674"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-hedeper.json
+++ b/companies/kirchengemeinde-hedeper.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-hedeper",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Hedeper",
+    "address": "Kirchweg 4\n38327 Semmenstedt\nDeutschland",
+    "phone": "+49 5336 397",
+    "fax": "+49 5336 948214",
+    "email": "asse.pfa@lk-bs.de",
+    "web": "http://www.gesamtpfarrverband-asse.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=956"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-heere.json
+++ b/companies/kirchengemeinde-heere.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-heere",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Heere",
+    "address": "An der Kirche 1\n38279 Sehlde\nDeutschland",
+    "phone": "+49 5341 33633",
+    "fax": "+49 5341 941646",
+    "email": "sehlde.buero@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=794"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-heilig-kreuz-flechtorf-in-lehre.json
+++ b/companies/kirchengemeinde-heilig-kreuz-flechtorf-in-lehre.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-heilig-kreuz-flechtorf-in-lehre",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Heilig Kreuz Flechtorf in Lehre",
+    "address": "Kirchtwete 2\n38165 Lehre\nDeutschland",
+    "phone": "+49 5308 2268",
+    "fax": "+49 5308 921546",
+    "email": "flechtorf.buero@lk-bs.de",
+    "web": "http://www.flechtorfbeienrode-evangelisch.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=832"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-heilige-dreifaltigkeit-salzgitter-bad.json
+++ b/companies/kirchengemeinde-heilige-dreifaltigkeit-salzgitter-bad.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-heilige-dreifaltigkeit-salzgitter-bad",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Heilige Dreifaltigkeit Salzgitter-Bad",
+    "address": "Altstadtweg 6\n38259 Salzgitter\nDeutschland",
+    "phone": "+49 5341 81620",
+    "fax": "+49 5341 816231",
+    "email": "salzgitterbad-gitter.pfa@lk-bs.de",
+    "web": "http://www.heilige-dreifaltigkeit-sz.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=868"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-herrhausen-in-seesen.json
+++ b/companies/kirchengemeinde-herrhausen-in-seesen.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-herrhausen-in-seesen",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Herrhausen in Seesen",
+    "address": "Hinter der Kirche 1 A\n38723 Seesen\nDeutschland",
+    "phone": "+49 5381 942929",
+    "fax": "+49 5381 942917",
+    "email": "herrhausen.buero@lk-bs.de",
+    "web": "http://www.kirche-herrhausen.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=973"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-hoetzum-in-sickte.json
+++ b/companies/kirchengemeinde-hoetzum-in-sickte.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-hoetzum-in-sickte",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Hötzum in Sickte",
+    "address": "Jahnstraße 5\n38302 Wolfenbüttel\nDeutschland",
+    "phone": "+49 5331 72413",
+    "fax": "+49 5331 340546",
+    "email": "maria-magdala.wf.pfa@lk-bs.de",
+    "web": "http://www.kirche-sickte-hoetzum.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1072"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-hohegeiss.json
+++ b/companies/kirchengemeinde-hohegeiss.json
@@ -1,0 +1,21 @@
+{
+    "slug": "kirchengemeinde-hohegeiss",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Hohegeiß",
+    "address": "Kirchstraße 7 A\n38700 Braunlage\nDeutschland",
+    "phone": "+49 5583 834",
+    "email": "hohegeiss.buero@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=711"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-hordorf-essehof-wendhausen-in-cremlingen.json
+++ b/companies/kirchengemeinde-hordorf-essehof-wendhausen-in-cremlingen.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-hordorf-essehof-wendhausen-in-cremlingen",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Hordorf-Essehof-Wendhausen in Cremlingen",
+    "address": "Kirchweg 1\n38162 Cremlingen\nDeutschland",
+    "phone": "+49 5306 2387",
+    "fax": "+49 5306 7974",
+    "email": "hordorf.buero@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=840"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-hornburg.json
+++ b/companies/kirchengemeinde-hornburg.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-hornburg",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Hornburg",
+    "address": "Pfarrhofstraße 3\n38315 Hornburg\nDeutschland",
+    "phone": "+49 5334 1328",
+    "fax": "+49 5334 2780",
+    "email": "hornburg.buero@lk-bs.de",
+    "web": "http://www.kirchehornburg.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=948"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-ildehausen-in-seesen.json
+++ b/companies/kirchengemeinde-ildehausen-in-seesen.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-ildehausen-in-seesen",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Ildehausen in Seesen",
+    "address": "Alte Dorfstraße 4\n38723 Seesen\nDeutschland",
+    "phone": "+49 5381 8602",
+    "fax": "+49 5381 989667",
+    "email": "kirchberg.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=977"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-immenrode-in-vienenburg.json
+++ b/companies/kirchengemeinde-immenrode-in-vienenburg.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-immenrode-in-vienenburg",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Immenrode in Vienenburg",
+    "address": "Bismarckstraße 13\n38690 Goslar\nDeutschland",
+    "phone": "+49 5324 2245",
+    "fax": "+49 5324 2059",
+    "email": "harz-harly.pfa@lk-bs.de",
+    "web": "http://www.immenrode-kirche.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=716"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-jeseritz-parleib-altmark.json
+++ b/companies/kirchengemeinde-jeseritz-parleib-altmark.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-jeseritz-parleib-altmark",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Jeseritz-Parleib/Altmark",
+    "address": "An der Kirche 1\n39359 Calvörde\nDeutschland",
+    "phone": "+49 39051 259",
+    "fax": "+49 39051 98225",
+    "email": "calvoerde.pfa@lk-bs.de",
+    "web": "https://www.pfarrverband-calvoerde-uthmoeden.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1026"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-johannes-vorsfelde-in-wolfsburg.json
+++ b/companies/kirchengemeinde-johannes-vorsfelde-in-wolfsburg.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-johannes-vorsfelde-in-wolfsburg",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Johannes Vorsfelde in Wolfsburg",
+    "address": "Schlesierstraße 3\n38448 Wolfsburg\nDeutschland",
+    "phone": "+49 5363 7770",
+    "fax": "+49 5363 7706",
+    "email": "johannes-vorsfelde.buero@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1052"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-kaierde.json
+++ b/companies/kirchengemeinde-kaierde.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-kaierde",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Kaierde",
+    "address": "Rothöfen 1\n31073 Delligsen\nDeutschland",
+    "phone": "+49 5187 2405",
+    "fax": "+49 5187 3481",
+    "email": "kaierde.buero@lk-bs.de",
+    "web": "http://www.kirche-kaierde.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=682"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-kirchberg-in-seesen.json
+++ b/companies/kirchengemeinde-kirchberg-in-seesen.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-kirchberg-in-seesen",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Kirchberg in Seesen",
+    "address": "Alte Dorfstraße 4\n38723 Seesen\nDeutschland",
+    "phone": "+49 5381 8602",
+    "fax": "+49 5381 989667",
+    "email": "kirchberg.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=976"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-klein-denkte-in-denkte.json
+++ b/companies/kirchengemeinde-klein-denkte-in-denkte.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-klein-denkte-in-denkte",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Klein Denkte in Denkte",
+    "address": "Kirchstraße 7\n38321 Denkte\nDeutschland",
+    "phone": "+49 5331 906130",
+    "fax": "+49 5331 906132",
+    "email": "denkte.buero@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=939"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-kreiensen-billerbeck.json
+++ b/companies/kirchengemeinde-kreiensen-billerbeck.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-kreiensen-billerbeck",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Kreiensen-Billerbeck",
+    "address": "Friedhofsweg 3\n37574 Einbeck\nDeutschland",
+    "phone": "+49 5563 259",
+    "fax": "+49 5563 919894",
+    "email": "kreiensen.buero@lk-bs.de",
+    "web": "http://www.kirche-kreiensen.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=691"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-kreiensen.json
+++ b/companies/kirchengemeinde-kreiensen.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-kreiensen",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Kreiensen",
+    "address": "Friedhofsweg 3\n37574 Einbeck\nDeutschland",
+    "phone": "+49 5563 259",
+    "fax": "+49 5563 919894",
+    "email": "kreiensen.buero@lk-bs.de",
+    "web": "http://www.kirche-kreiensen.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=688"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-kreuzkirche-alt-lehndorf-in-braunschweig.json
+++ b/companies/kirchengemeinde-kreuzkirche-alt-lehndorf-in-braunschweig.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-kreuzkirche-alt-lehndorf-in-braunschweig",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Kreuzkirche Alt Lehndorf in Braunschweig",
+    "address": "Sulzbacher Straße 41\n38116 Braunschweig\nDeutschland",
+    "phone": "+49 531 54594",
+    "fax": "+49 531 54569",
+    "email": "nordwest.bs.pfa@lk-bs.de",
+    "web": "http://www.kreuzgemeinde.com/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=740"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-lauingen-in-koenigslutter.json
+++ b/companies/kirchengemeinde-lauingen-in-koenigslutter.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-lauingen-in-koenigslutter",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Lauingen in Königslutter",
+    "address": "An der Stadtkirche 6\n38154 Königslutter am Elm\nDeutschland",
+    "phone": "+49 5353 96278",
+    "fax": "+49 5353 951781",
+    "email": "koenigslutter.pfa@lk-bs.de",
+    "web": "https://www.kirchengemeindeverband-koenigslutter.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=823"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-lehre-brunsrode.json
+++ b/companies/kirchengemeinde-lehre-brunsrode.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-lehre-brunsrode",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Lehre-Brunsrode",
+    "address": "Mühlenwinkel 1\n38165 Lehre\nDeutschland",
+    "phone": "+49 5308 6306",
+    "fax": "+49 5308 6084",
+    "email": "lehre.buero@lk-bs.de",
+    "web": "http://www.kirchengemeinde-lehre.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=847"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-leiferde-in-braunschweig.json
+++ b/companies/kirchengemeinde-leiferde-in-braunschweig.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-leiferde-in-braunschweig",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Leiferde in Braunschweig",
+    "address": "Geiteldestraße 39\n38122 Braunschweig\nDeutschland",
+    "phone": "+49 5300 372",
+    "email": "geitelde.pfa@lk-bs.de",
+    "web": "http://www.kirche-leiferde.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1058"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-leinde-in-wolfenbuettel.json
+++ b/companies/kirchengemeinde-leinde-in-wolfenbuettel.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-leinde-in-wolfenbuettel",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Leinde in Wolfenbüttel",
+    "address": "Schulring 4-6\n38239 Salzgitter\nDeutschland",
+    "phone": "+49 5341 264616",
+    "fax": "+49 5341 260540",
+    "email": "salzgitters-norden.pfa@lk-bs.de",
+    "web": "http://www.stiftskirche-steterburg.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=885"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-lengde-in-vienenburg.json
+++ b/companies/kirchengemeinde-lengde-in-vienenburg.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-lengde-in-vienenburg",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Lengde in Vienenburg",
+    "address": "Bismarckstraße 13\n38690 Goslar\nDeutschland",
+    "phone": "+49 5324 2245",
+    "fax": "+49 5324 2059",
+    "email": "harz-harly.pfa@lk-bs.de",
+    "web": "https://www.kirche-harz-harly.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=718"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-liebenburg-klein-mahner.json
+++ b/companies/kirchengemeinde-liebenburg-klein-mahner.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-liebenburg-klein-mahner",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Liebenburg - Klein Mahner",
+    "address": "Martin-Luther-Straße 1\n38704 Liebenburg\nDeutschland",
+    "phone": "+49 5346 91119",
+    "fax": "+49 5346 91118",
+    "email": "liebenburg.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=883"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-maria-und-martha-in-vechelde.json
+++ b/companies/kirchengemeinde-maria-und-martha-in-vechelde.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-maria-und-martha-in-vechelde",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Maria und Martha in Vechelde",
+    "address": "Godehardistraße 1\n38159 Vechelde\nDeutschland",
+    "phone": "+49 5302 1040",
+    "email": "bodenstedt.pfa@lk-bs.de",
+    "web": "http://www.kirche-bodenstedt.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=999"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-mariental-barmke.json
+++ b/companies/kirchengemeinde-mariental-barmke.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-mariental-barmke",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Mariental-Barmke",
+    "address": "Klosterstraße 11\n38350 Helmstedt\nDeutschland",
+    "phone": "+49 5351 7499",
+    "fax": "+49 5351 523711",
+    "email": "helmstedtnord.pfa@lk-bs.de",
+    "web": "http://www.ev-kirche-grasleben.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=813"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-martin-chemnitz-in-braunschweig.json
+++ b/companies/kirchengemeinde-martin-chemnitz-in-braunschweig.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-martin-chemnitz-in-braunschweig",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Martin Chemnitz in Braunschweig",
+    "address": "Möncheweg 56\n38126 Braunschweig\nDeutschland",
+    "phone": "+49 531 691896",
+    "fax": "+49 531 2621163",
+    "email": "martinchemnitz.buero@lk-bs.de",
+    "web": "http://www.martin-chemnitz-bs.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=751"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-martin-luther-bad-harzburg.json
+++ b/companies/kirchengemeinde-martin-luther-bad-harzburg.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-martin-luther-bad-harzburg",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Martin Luther Bad Harzburg",
+    "address": "Lutherstraße 7\n38667 Bad Harzburg\nDeutschland",
+    "phone": "+49 5322 4823",
+    "fax": "+49 5322 54692",
+    "email": "harzburg.pfa@lk-bs.de",
+    "web": "http://www.luthergemeinde-evangelisch.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=704"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-martin-luther-dettum.json
+++ b/companies/kirchengemeinde-martin-luther-dettum.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-martin-luther-dettum",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Martin-Luther Dettum",
+    "address": "Hauptstraße 1\n38173 Dettum\nDeutschland",
+    "phone": "+49 5333 316",
+    "fax": "+49 5333 312",
+    "email": "dettum.buero@lk-bs.de",
+    "web": "http://www.kirche-dettum.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=921"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-martin-luther-salzgitter-lebenstedt.json
+++ b/companies/kirchengemeinde-martin-luther-salzgitter-lebenstedt.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-martin-luther-salzgitter-lebenstedt",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Martin Luther Salzgitter-Lebenstedt",
+    "address": "Berliner Straße 182\n38226 Salzgitter\nDeutschland",
+    "phone": "+49 5341 65793",
+    "fax": "+49 5341 62754",
+    "email": "lebenstedt.pfa@lk-bs.de",
+    "web": "http://www.martin-luther-salzgitter.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=895"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-martin-luther-wieda.json
+++ b/companies/kirchengemeinde-martin-luther-wieda.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-martin-luther-wieda",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Martin Luther Wieda",
+    "address": "Otto-Haberland-Straße 10\n37445 Walkenried OT Wieda\nDeutschland",
+    "phone": "+49 5586 225",
+    "email": "wieda.buero@lk-bs.de",
+    "web": "http://www.lutherkirche-wieda.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=733"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-mechtshausen-bilderlahe.json
+++ b/companies/kirchengemeinde-mechtshausen-bilderlahe.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-mechtshausen-bilderlahe",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Mechtshausen-Bilderlahe",
+    "address": "Klingenhagener Straße 17\n38723 Seesen\nDeutschland",
+    "phone": "+49 5381 5083",
+    "fax": "+49 5381 9409765",
+    "email": "bornhausen.buero@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=993"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-naensen-in-einbeck.json
+++ b/companies/kirchengemeinde-naensen-in-einbeck.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-naensen-in-einbeck",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Naensen in Einbeck",
+    "address": "Im Oberdorf 11\n37574 Einbeck\nDeutschland",
+    "phone": "+49 5563 6822",
+    "fax": "+49 5563 6868",
+    "email": "naensen.buero@lk-bs.de",
+    "web": "http://blog.kirche-naensen.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=693"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-neindorf-in-denkte.json
+++ b/companies/kirchengemeinde-neindorf-in-denkte.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-neindorf-in-denkte",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Neindorf in Denkte",
+    "address": "Neuer Weg 90\n38302 Wolfenbüttel\nDeutschland",
+    "phone": "+49 5331 972850",
+    "fax": "+49 5331 978958",
+    "email": "wf-mitte-sued.pfa@lk-bs.de",
+    "web": "http://www.kirche-neindorf.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1062"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-neuenkirchen-in-liebenburg.json
+++ b/companies/kirchengemeinde-neuenkirchen-in-liebenburg.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-neuenkirchen-in-liebenburg",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Neuenkirchen in Liebenburg",
+    "address": "Pfarrwinkel 6\n38704 Liebenburg\nDeutschland",
+    "phone": "+49 5346 1335",
+    "fax": "+49 5346 1013",
+    "email": "doehren.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=937"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-neuhof-in-bad-sachsa.json
+++ b/companies/kirchengemeinde-neuhof-in-bad-sachsa.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-neuhof-in-bad-sachsa",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Neuhof in Bad Sachsa",
+    "address": "Pfarrplatz 6\n37445 Walkenried\nDeutschland",
+    "phone": "+49 5525 800",
+    "fax": "+49 5525 959645",
+    "email": "kapellenfleck-harz.pfa@lk-bs.de",
+    "web": "http://www.kirchengemeinde-walkenried.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=725"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-neuwerk-in-goslar.json
+++ b/companies/kirchengemeinde-neuwerk-in-goslar.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-neuwerk-in-goslar",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Neuwerk in Goslar",
+    "address": "Gemeindehof 8\n38640 Goslar\nDeutschland",
+    "phone": "+49 5321 347351",
+    "fax": "+49 5321 23745",
+    "email": "goslar.pfa@lk-bs.de",
+    "web": "http://www.neuwerkkirche-goslar.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=776"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-noah-in-salzgitter-bad.json
+++ b/companies/kirchengemeinde-noah-in-salzgitter-bad.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-noah-in-salzgitter-bad",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Noah in Salzgitter-Bad",
+    "address": "Altstadtweg 6\n38259 Salzgitter\nDeutschland",
+    "phone": "+49 5341 81620",
+    "fax": "+49 5341 816231",
+    "email": "salzgitterbad-gitter.pfa@lk-bs.de",
+    "web": "http://www.noah-sz-bad.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=870"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-oelber-a-w-wege-in-baddeckenstedt.json
+++ b/companies/kirchengemeinde-oelber-a-w-wege-in-baddeckenstedt.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-oelber-a-w-wege-in-baddeckenstedt",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Oelber a. w. Wege in Baddeckenstedt",
+    "address": "An der Kirche 2\n38271 Baddeckenstedt\nDeutschland",
+    "phone": "+49 5345 4040",
+    "fax": "+49 5345 929956",
+    "email": "baddeckenstedt.buero@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=768"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-ohrum.json
+++ b/companies/kirchengemeinde-ohrum.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-ohrum",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Ohrum",
+    "address": "Harzburger Straße 13\n38304 Wolfenbüttel\nDeutschland",
+    "phone": "+49 5331 61423",
+    "fax": "+49 5331 966667",
+    "email": "halchter.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1065"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-oker-in-goslar.json
+++ b/companies/kirchengemeinde-oker-in-goslar.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-oker-in-goslar",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Oker in Goslar",
+    "address": "Gemeindehof 8\n38640 Goslar\nDeutschland",
+    "phone": "+49 5321 347351",
+    "fax": "+49 5321 23745",
+    "email": "goslar.pfa@lk-bs.de",
+    "web": "http://www.kirchengemeinde-oker.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=787"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-opperhausen-olxheim-in-einbeck.json
+++ b/companies/kirchengemeinde-opperhausen-olxheim-in-einbeck.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-opperhausen-olxheim-in-einbeck",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Opperhausen-Olxheim in Einbeck",
+    "address": "Schulstraße 7\n37574 Einbeck\nDeutschland",
+    "phone": "+49 5563 248",
+    "fax": "+49 5563 6383",
+    "email": "opperhausen.buero@lk-bs.de",
+    "web": "http://www.pfarrverband-opperhausen.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=696"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-osterlinde-in-salzgitter.json
+++ b/companies/kirchengemeinde-osterlinde-in-salzgitter.json
@@ -1,0 +1,21 @@
+{
+    "slug": "kirchengemeinde-osterlinde-in-salzgitter",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Osterlinde in Salzgitter",
+    "address": "Kasselberg 1\n38272 Burgdorf\nDeutschland",
+    "phone": "+49 5347 1917",
+    "email": "westerlinde.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=914"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-ostharingen-in-liebenburg.json
+++ b/companies/kirchengemeinde-ostharingen-in-liebenburg.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-ostharingen-in-liebenburg",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Ostharingen in Liebenburg",
+    "address": "Ringstraße 11\n38704 Liebenburg\nDeutschland",
+    "phone": "+49 5346 4280",
+    "fax": "+49 5346 6137",
+    "email": "doernten.pfa@lk-bs.de",
+    "web": "https://www.kirchengemeinde-doernten-ostharingen-upen.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=771"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-othfresen-heissum.json
+++ b/companies/kirchengemeinde-othfresen-heissum.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-othfresen-heissum",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Othfresen-Heißum",
+    "address": "Sölg 4\n38704 Liebenburg\nDeutschland",
+    "phone": "+49 5346 4355",
+    "fax": "+49 5346 5635",
+    "email": "othfresen.pfa@lk-bs.de",
+    "web": "http://www.kircheothfresen.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=789"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-papenrode-in-gross-twuelpstedt.json
+++ b/companies/kirchengemeinde-papenrode-in-gross-twuelpstedt.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-papenrode-in-gross-twuelpstedt",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Papenrode in Groß Twülpstedt",
+    "address": "An der Kirche 2\n38446 Wolfsburg\nDeutschland",
+    "phone": "+49 5363 976034",
+    "fax": "+49 5363 72426",
+    "email": "aller.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1037"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-rautheim-in-braunschweig.json
+++ b/companies/kirchengemeinde-rautheim-in-braunschweig.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-rautheim-in-braunschweig",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Rautheim in Braunschweig",
+    "address": "Zum Ackerberg 16\n38126 Braunschweig\nDeutschland",
+    "phone": "+49 531 691434",
+    "fax": "+49 531 682315",
+    "email": "rautheim.buero@lk-bs.de",
+    "web": "http://www.kirche-rautheim.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=852"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-rhene-in-baddeckenstedt.json
+++ b/companies/kirchengemeinde-rhene-in-baddeckenstedt.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-rhene-in-baddeckenstedt",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Rhene in Baddeckenstedt",
+    "address": "An der Kirche 2\n38271 Baddeckenstedt\nDeutschland",
+    "phone": "+49 5345 4040",
+    "fax": "+49 5345 929956",
+    "email": "baddeckenstedt.buero@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=769"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-rhueden-wohlenhausen-in-seesen.json
+++ b/companies/kirchengemeinde-rhueden-wohlenhausen-in-seesen.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-rhueden-wohlenhausen-in-seesen",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Rhüden-Wohlenhausen in Seesen",
+    "address": "Pfarrstraße 7\n38723 Seesen\nDeutschland",
+    "phone": "+49 5384 387",
+    "fax": "+49 5384 8244",
+    "email": "ambergau-neiletal.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=978"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-riddagshausen-gliesmarode-in-braunschweig.json
+++ b/companies/kirchengemeinde-riddagshausen-gliesmarode-in-braunschweig.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-riddagshausen-gliesmarode-in-braunschweig",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Riddagshausen-Gliesmarode in Braunschweig",
+    "address": "Klostergang 57\n38104 Braunschweig\nDeutschland",
+    "phone": "+49 531 372900",
+    "fax": "+49 531 372922",
+    "email": "riddagshausen-gliesmarode.pfa@lk-bs.de",
+    "web": "http://www.bugenhagen-kirche.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=755"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-rieseberg-in-koenigslutter.json
+++ b/companies/kirchengemeinde-rieseberg-in-koenigslutter.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-rieseberg-in-koenigslutter",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Rieseberg in Königslutter",
+    "address": "An der Stadtkirche 6\n38154 Königslutter am Elm\nDeutschland",
+    "phone": "+49 5353 96278",
+    "fax": "+49 5353 951781",
+    "email": "koenigslutter.pfa@lk-bs.de",
+    "web": "https://www.kirchengemeindeverband-koenigslutter.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=824"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-ringelheim-in-salzgitter.json
+++ b/companies/kirchengemeinde-ringelheim-in-salzgitter.json
@@ -1,0 +1,21 @@
+{
+    "slug": "kirchengemeinde-ringelheim-in-salzgitter",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Ringelheim in Salzgitter",
+    "address": "Goslarsche Straße 38\n38259 Salzgitter\nDeutschland",
+    "phone": "+49 5341 33295",
+    "email": "ringelheim.buero@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=790"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-rittierode-in-kreiensen.json
+++ b/companies/kirchengemeinde-rittierode-in-kreiensen.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-rittierode-in-kreiensen",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Rittierode in Kreiensen",
+    "address": "Schulstraße 7\n37574 Einbeck\nDeutschland",
+    "phone": "+49 5563 248",
+    "fax": "+49 5563 6383",
+    "email": "opperhausen.buero@lk-bs.de",
+    "web": "http://www.pfarrverband-opperhausen.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=699"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-roklum.json
+++ b/companies/kirchengemeinde-roklum.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-roklum",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Roklum",
+    "address": "Kirchweg 4\n38327 Semmenstedt\nDeutschland",
+    "phone": "+49 5336 397",
+    "fax": "+49 5336 948214",
+    "email": "asse.pfa@lk-bs.de",
+    "web": "http://www.gesamtpfarrverband-asse.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=955"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-rotenkamp-in-koenigslutter.json
+++ b/companies/kirchengemeinde-rotenkamp-in-koenigslutter.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-rotenkamp-in-koenigslutter",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Rotenkamp in Königslutter",
+    "address": "An der Stadtkirche 6\n38154 Königslutter am Elm\nDeutschland",
+    "phone": "+49 5353 96278",
+    "fax": "+49 5353 951781",
+    "email": "koenigslutter.pfa@lk-bs.de",
+    "web": "https://www.kirchengemeindeverband-koenigslutter.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=838"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-rottorf-in-koenigslutter.json
+++ b/companies/kirchengemeinde-rottorf-in-koenigslutter.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-rottorf-in-koenigslutter",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Rottorf in Königslutter",
+    "address": "An der Stadtkirche 6\n38154 Königslutter am Elm\nDeutschland",
+    "phone": "+49 5353 96278",
+    "fax": "+49 5353 951781",
+    "email": "koenigslutter.pfa@lk-bs.de",
+    "web": "https://www.kirchengemeindeverband-koenigslutter.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=844"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-ruehen-brechtorf-eischott.json
+++ b/companies/kirchengemeinde-ruehen-brechtorf-eischott.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-ruehen-brechtorf-eischott",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Rühen-Brechtorf-Eischott",
+    "address": "Hauptstraße 16\n38471 Rühen\nDeutschland",
+    "phone": "+49 5367 1843",
+    "fax": "+49 5367 982619",
+    "email": "paulus-ruehen.buero@lk-bs.de",
+    "web": "http://www.kirche-ruehen-brechtorf-eischott.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1046"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-salder-in-salzgitter.json
+++ b/companies/kirchengemeinde-salder-in-salzgitter.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-salder-in-salzgitter",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Salder in Salzgitter",
+    "address": "Museumstraße 9\n38229 Salzgitter\nDeutschland",
+    "phone": "+49 5341 41113",
+    "email": "salder.pfa@lk-bs.de",
+    "web": "http://www.kircheinsalder.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=902"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-salzgitter-engelnstedt.json
+++ b/companies/kirchengemeinde-salzgitter-engelnstedt.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-salzgitter-engelnstedt",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Salzgitter-Engelnstedt",
+    "address": "Lebenstedter Straße 3\n38268 Lengede\nDeutschland",
+    "phone": "+49 5344 1255",
+    "fax": "+49 5344 202693",
+    "email": "broistedt.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=888"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-salzgitter-gross-mahner.json
+++ b/companies/kirchengemeinde-salzgitter-gross-mahner.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-salzgitter-gross-mahner",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Salzgitter-Groß Mahner",
+    "address": "Oderwaldstraße 5\n38312 Flöthe\nDeutschland",
+    "phone": "+49 5341 9650",
+    "fax": "+49 5341 30265",
+    "email": "salzgitter-bad.pr@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=882"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-salzgitter-immendorf.json
+++ b/companies/kirchengemeinde-salzgitter-immendorf.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-salzgitter-immendorf",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Salzgitter-Immendorf",
+    "address": "Frankfurter Straße 76\n38239 Salzgitter\nDeutschland",
+    "phone": "+49 5341 26241",
+    "fax": "+49 5341 265462",
+    "email": "thiede.buero@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=886"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-salzgitter-lobmachtersen.json
+++ b/companies/kirchengemeinde-salzgitter-lobmachtersen.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-salzgitter-lobmachtersen",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Salzgitter-Lobmachtersen",
+    "address": "Werkstraße 18\n38229 Salzgitter\nDeutschland",
+    "phone": "+49 5341 24018",
+    "fax": "+49 5341 229396",
+    "email": "lobmachtersen.pfa@lk-bs.de",
+    "web": "http://www.pfarrverband-lobmachtersen.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=879"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-salzgitter-ohlendorf.json
+++ b/companies/kirchengemeinde-salzgitter-ohlendorf.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-salzgitter-ohlendorf",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Salzgitter-Ohlendorf",
+    "address": "Oderwaldstraße 5\n38312 Flöthe\nDeutschland",
+    "phone": "+49 5341 9650",
+    "fax": "+49 5341 30265",
+    "email": "salzgitter-bad.pr@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=880"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-scheppau-in-koenigslutter.json
+++ b/companies/kirchengemeinde-scheppau-in-koenigslutter.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-scheppau-in-koenigslutter",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Scheppau in Königslutter",
+    "address": "An der Stadtkirche 6\n38154 Königslutter am Elm\nDeutschland",
+    "phone": "+49 5353 96278",
+    "fax": "+49 5353 951781",
+    "email": "koenigslutter.pfa@lk-bs.de",
+    "web": "https://www.kirchengemeindeverband-koenigslutter.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=839"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-schladen.json
+++ b/companies/kirchengemeinde-schladen.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-schladen",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Schladen",
+    "address": "An der Kirche 7\n38315 Schladen\nDeutschland",
+    "phone": "+49 5335 361",
+    "fax": "+49 5335 6755",
+    "email": "schoeppenstedt-sued.pfa@lk-bs.de",
+    "web": "http://www.kirchepunktwir.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=950"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-schlewecke-goettingerode-in-bad-harzburg.json
+++ b/companies/kirchengemeinde-schlewecke-goettingerode-in-bad-harzburg.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-schlewecke-goettingerode-in-bad-harzburg",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Schlewecke-Göttingerode in Bad Harzburg",
+    "address": "Amtsgarten 26\n38667 Bad Harzburg\nDeutschland",
+    "phone": "+49 5322 8581",
+    "fax": "+49 5322 8789059",
+    "email": "schlewecke-goettingerode.buero@lk-bs.de",
+    "web": "http://www.schlewecke-kirche.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=720"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-sehlde.json
+++ b/companies/kirchengemeinde-sehlde.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-sehlde",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Sehlde",
+    "address": "An der Kirche 1\n38279 Sehlde\nDeutschland",
+    "phone": "+49 5341 33633",
+    "fax": "+49 5341 941646",
+    "email": "sehlde.buero@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=793"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-seinstedt.json
+++ b/companies/kirchengemeinde-seinstedt.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-seinstedt",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Seinstedt",
+    "address": "Kirchweg 4\n38327 Semmenstedt\nDeutschland",
+    "phone": "+49 5336 397",
+    "fax": "+49 5336 948214",
+    "email": "asse.pfa@lk-bs.de",
+    "web": "http://www.gesamtpfarrverband-asse.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=958"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-semmenstedt-timmern-kalme-in-semmenstedt.json
+++ b/companies/kirchengemeinde-semmenstedt-timmern-kalme-in-semmenstedt.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-semmenstedt-timmern-kalme-in-semmenstedt",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Semmenstedt-Timmern-Kalme in Semmenstedt",
+    "address": "Kirchweg 4\n38327 Semmenstedt\nDeutschland",
+    "phone": "+49 5336 397",
+    "fax": "+49 5336 948214",
+    "email": "asse.pfa@lk-bs.de",
+    "web": "http://www.gesamtpfarrverband-asse.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=952"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-sickte.json
+++ b/companies/kirchengemeinde-sickte.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-sickte",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Sickte",
+    "address": "Jahnstraße 5\n38302 Wolfenbüttel\nDeutschland",
+    "phone": "+49 5331 72413",
+    "fax": "+49 5331 340546",
+    "email": "maria-magdala.wf.pfa@lk-bs.de",
+    "web": "http://www.kirche-sickte-hoetzum.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1071"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-sonnenberg-in-vechelde.json
+++ b/companies/kirchengemeinde-sonnenberg-in-vechelde.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-sonnenberg-in-vechelde",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Sonnenberg in Vechelde",
+    "address": "Kirchstraße 12\n38120 Braunschweig\nDeutschland",
+    "phone": "+49 531 842208",
+    "fax": "+49 531 842205",
+    "email": "timmerlah.pfa@lk-bs.de",
+    "web": "http://www.kitiso.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1012"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-sottmar-in-denkte.json
+++ b/companies/kirchengemeinde-sottmar-in-denkte.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-sottmar-in-denkte",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Sottmar in Denkte",
+    "address": "Kirchstraße 7\n38321 Denkte\nDeutschland",
+    "phone": "+49 5331 906130",
+    "fax": "+49 5331 906132",
+    "email": "denkte.buero@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=940"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-andreas-in-bad-harzburg-buendheim.json
+++ b/companies/kirchengemeinde-st-andreas-in-bad-harzburg-buendheim.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-andreas-in-bad-harzburg-buendheim",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Andreas in Bad Harzburg (Bündheim)",
+    "address": "An der Kirche 14\n38667 Bad Harzburg\nDeutschland",
+    "phone": "+49 5322 3124",
+    "fax": "+49 5322 29117552",
+    "email": "buendheim.buero@lk-bs.de",
+    "web": "http://www.st-andreas-buendheim.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=703"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-andreas-in-braunschweig.json
+++ b/companies/kirchengemeinde-st-andreas-in-braunschweig.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-st-andreas-in-braunschweig",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Andreas in Braunschweig",
+    "address": "An der Andreaskirche 1\n38100 Braunschweig\nDeutschland",
+    "phone": "+49 531 44358",
+    "email": "andreas.bs.buero@lk-bs.de",
+    "web": "http://www.standreas.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=735"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-andreas-in-cramme.json
+++ b/companies/kirchengemeinde-st-andreas-in-cramme.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-andreas-in-cramme",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Andreas in Cramme",
+    "address": "Werkstraße 18\n38229 Salzgitter\nDeutschland",
+    "phone": "+49 5341 24018",
+    "fax": "+49 5341 229396",
+    "email": "lobmachtersen.pfa@lk-bs.de",
+    "web": "http://www.pfarrverband-lobmachtersen.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=872"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-andreas-langelsheim.json
+++ b/companies/kirchengemeinde-st-andreas-langelsheim.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-st-andreas-langelsheim",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Andreas Langelsheim",
+    "address": "Kirchstraße 5\n38685 Langelsheim\nDeutschland",
+    "phone": "+49 5326 2023",
+    "fax": "+49 5326 3109",
+    "email": "langelsheim.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=981"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-andreas-tettenborn.json
+++ b/companies/kirchengemeinde-st-andreas-tettenborn.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-st-andreas-tettenborn",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Andreas Tettenborn",
+    "address": "Otto-Haberland-Straße 10\n37445 Walkenried OT Wieda\nDeutschland",
+    "phone": "+49 5586 225",
+    "email": "wieda.buero@lk-bs.de",
+    "web": "http://www.lutherkirche-wieda.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=724"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-andreas-velpke.json
+++ b/companies/kirchengemeinde-st-andreas-velpke.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-andreas-velpke",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Andreas Velpke",
+    "address": "Marktplatz 18\n38458 Velpke\nDeutschland",
+    "phone": "+49 5364 2332",
+    "fax": "+49 5364 8598",
+    "email": "velpke.buero@lk-bs.de",
+    "web": "http://www.ev-kirchengemeinde-velpke.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1033"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-andreas-zu-salzgitter-lebenstedt.json
+++ b/companies/kirchengemeinde-st-andreas-zu-salzgitter-lebenstedt.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-st-andreas-zu-salzgitter-lebenstedt",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Andreas zu Salzgitter-Lebenstedt",
+    "address": "St.-Andreas-Weg 4\n38226 Salzgitter\nDeutschland",
+    "phone": "+49 5341 49875",
+    "fax": "+49 5341 175300",
+    "email": "andreas.sz.buero@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=890"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-angelus-am-elm.json
+++ b/companies/kirchengemeinde-st-angelus-am-elm.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-st-angelus-am-elm",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Angelus am Elm",
+    "address": "Niedernstraße 47\n38364 Schöningen\nDeutschland",
+    "phone": "+49 5352 4764",
+    "fax": "+49 5352 4745",
+    "email": "helmstedt-sued.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=802"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-antonius-hasselfelde.json
+++ b/companies/kirchengemeinde-st-antonius-hasselfelde.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-antonius-hasselfelde",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Antonius Hasselfelde",
+    "address": "Blumenaustraße 7\n38899 Oberharz am Brocken\nDeutschland",
+    "phone": "+49 39459 71371",
+    "fax": "+49 39459 18845",
+    "email": "hasselfelde.buero@lk-bs.de",
+    "web": "http://www.hasselfelde-evangelisch.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=722"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-antonius-muenchehof-zu-seesen.json
+++ b/companies/kirchengemeinde-st-antonius-muenchehof-zu-seesen.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-st-antonius-muenchehof-zu-seesen",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Antonius Münchehof zu Seesen",
+    "address": "Lange Straße 42\n37539 Bad Grund (Harz)\nDeutschland",
+    "phone": "+49 5327 4243",
+    "fax": "+49 5327 859263",
+    "email": "gittelde.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=987"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-barbara-hallendorf-watenstedt-in-salzgitter.json
+++ b/companies/kirchengemeinde-st-barbara-hallendorf-watenstedt-in-salzgitter.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-barbara-hallendorf-watenstedt-in-salzgitter",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Barbara Hallendorf-Watenstedt in Salzgitter",
+    "address": "Maangarten 22 A\n38229 Salzgitter\nDeutschland",
+    "phone": "+49 5341 44927",
+    "fax": "+49 5341 223847",
+    "email": "hallendorf-watenstedt.pfa@lk-bs.de",
+    "web": "http://www.kirche-hallendorf.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=907"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-barbara-in-wittmar.json
+++ b/companies/kirchengemeinde-st-barbara-in-wittmar.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-barbara-in-wittmar",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Barbara in Wittmar",
+    "address": "Forstweg 14\n38329 Wittmar\nDeutschland",
+    "phone": "+49 5337 538",
+    "fax": "+49 5337 948488",
+    "email": "wittmar.buero@lk-bs.de",
+    "web": "http://www.stbarbara-wittmar.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=964"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-bartholomaeus-dorstadt.json
+++ b/companies/kirchengemeinde-st-bartholomaeus-dorstadt.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-st-bartholomaeus-dorstadt",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Bartholomäus Dorstadt",
+    "address": "Harzburger Straße 13\n38304 Wolfenbüttel\nDeutschland",
+    "phone": "+49 5331 61423",
+    "fax": "+49 5331 966667",
+    "email": "halchter.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1066"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-blasius-in-braunschweig.json
+++ b/companies/kirchengemeinde-st-blasius-in-braunschweig.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-blasius-in-braunschweig",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Blasius in Braunschweig",
+    "address": "Domplatz 5\n38100 Braunschweig\nDeutschland",
+    "phone": "+49 531 243350",
+    "fax": "+49 531 2433524",
+    "email": "dom.bs.buero@lk-bs.de",
+    "web": "http://www.braunschweigerdom.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=746"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-brictius-linden-in-wolfenbuettel.json
+++ b/companies/kirchengemeinde-st-brictius-linden-in-wolfenbuettel.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-brictius-linden-in-wolfenbuettel",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Brictius Linden in Wolfenbüttel",
+    "address": "Neuer Weg 90\n38302 Wolfenbüttel\nDeutschland",
+    "phone": "+49 5331 972850",
+    "fax": "+49 5331 978958",
+    "email": "wf-mitte-sued.pfa@lk-bs.de",
+    "web": "http://www.kirche-linden.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1067"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-christophorus-in-helmstedt.json
+++ b/companies/kirchengemeinde-st-christophorus-in-helmstedt.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-christophorus-in-helmstedt",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Christophorus in Helmstedt",
+    "address": "Klosterstraße 11\n38350 Helmstedt\nDeutschland",
+    "phone": "+49 5351 7499",
+    "fax": "+49 5351 523711",
+    "email": "helmstedtnord.pfa@lk-bs.de",
+    "web": "http://www.stchristophorus.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=667"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-georg-calvoerde.json
+++ b/companies/kirchengemeinde-st-georg-calvoerde.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-georg-calvoerde",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Georg Calvörde",
+    "address": "An der Kirche 1\n39359 Calvörde\nDeutschland",
+    "phone": "+49 39051 259",
+    "fax": "+49 39051 98225",
+    "email": "calvoerde.pfa@lk-bs.de",
+    "web": "https://www.pfarrverband-calvoerde-uthmoeden.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1023"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-georg-goslar.json
+++ b/companies/kirchengemeinde-st-georg-goslar.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-georg-goslar",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Georg Goslar",
+    "address": "Gemeindehof 8\n38640 Goslar\nDeutschland",
+    "phone": "+49 5321 347351",
+    "fax": "+49 5321 23745",
+    "email": "goslar.pfa@lk-bs.de",
+    "web": "http://www.st-georg-goslar.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=773"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-georg-in-delligsen.json
+++ b/companies/kirchengemeinde-st-georg-in-delligsen.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-georg-in-delligsen",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Georg in Delligsen",
+    "address": "Hilsstraße 26\n31073 Delligsen\nDeutschland",
+    "phone": "+49 5187 2194",
+    "fax": "+49 5187 75005",
+    "email": "delligsen.buero@lk-bs.de",
+    "web": "http://www.st-georg-delligsen.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=675"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-georg-in-warberg.json
+++ b/companies/kirchengemeinde-st-georg-in-warberg.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-georg-in-warberg",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Georg in Warberg",
+    "address": "Hauptstraße 14\n38154 Königslutter am Elm\nDeutschland",
+    "phone": "+49 5353 8413",
+    "fax": "+49 5353 913112",
+    "email": "lelm.pfa@lk-bs.de",
+    "web": "http://www.kirche-warberg.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=851"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-georg-salzgitter-thiede.json
+++ b/companies/kirchengemeinde-st-georg-salzgitter-thiede.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-st-georg-salzgitter-thiede",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Georg Salzgitter-Thiede",
+    "address": "Frankfurter Straße 76\n38239 Salzgitter\nDeutschland",
+    "phone": "+49 5341 26241",
+    "fax": "+49 5341 265462",
+    "email": "thiede.buero@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=911"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-georg-zu-bortfeld-in-wendeburg.json
+++ b/companies/kirchengemeinde-st-georg-zu-bortfeld-in-wendeburg.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-georg-zu-bortfeld-in-wendeburg",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Georg zu Bortfeld in Wendeburg",
+    "address": "Pastor-Graffam-Weg 1\n38176 Wendeburg\nDeutschland",
+    "phone": "+49 5302 1424",
+    "fax": "+49 5302 804947",
+    "email": "bortfeld.pfa@lk-bs.de",
+    "web": "http://www.kirche-bortfeld.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1002"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-georg-zu-lutter-am-barenberge.json
+++ b/companies/kirchengemeinde-st-georg-zu-lutter-am-barenberge.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-st-georg-zu-lutter-am-barenberge",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Georg zu Lutter am Barenberge",
+    "address": "Teichdamm 7\n38729 Lutter a. Bbge.\nDeutschland",
+    "phone": "+49 5383 326",
+    "fax": "+49 5383 907380",
+    "email": "lutter.buero@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=982"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-jacobi-adersheim-in-wolfenbuettel.json
+++ b/companies/kirchengemeinde-st-jacobi-adersheim-in-wolfenbuettel.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-st-jacobi-adersheim-in-wolfenbuettel",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Jacobi Adersheim in Wolfenbüttel",
+    "address": "Glockengasse 2\n38304 Wolfenbüttel\nDeutschland",
+    "phone": "+49 5331 298544",
+    "fax": "+49 5331 9028906",
+    "email": "johannis.wf.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=884"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-jacobi-reppner-in-salzgitter.json
+++ b/companies/kirchengemeinde-st-jacobi-reppner-in-salzgitter.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-st-jacobi-reppner-in-salzgitter",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Jacobi Reppner in Salzgitter",
+    "address": "Zum Hohen Tor 8\n38228 Salzgitter\nDeutschland",
+    "phone": "+49 5341 52617",
+    "email": "lesse.pfa@lk-bs.de",
+    "web": "http://www.kirchengemeinde-lesse.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=900"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-jakobi-in-braunschweig.json
+++ b/companies/kirchengemeinde-st-jakobi-in-braunschweig.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-jakobi-in-braunschweig",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Jakobi in Braunschweig",
+    "address": "Goslarsche Straße 31\n38118 Braunschweig\nDeutschland",
+    "phone": "+49 531 5808070",
+    "fax": "+49 531 5808079",
+    "email": "jakobi.bs.buero@lk-bs.de",
+    "web": "http://www.jakobi-bs.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=739"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-jakobus-im-ambergau.json
+++ b/companies/kirchengemeinde-st-jakobus-im-ambergau.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-st-jakobus-im-ambergau",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Jakobus im Ambergau",
+    "address": "Georgsberg 5\n31167 Bockenem\nDeutschland",
+    "phone": "+49 5067 2263",
+    "fax": "+49 5067 246513",
+    "email": "jakobus-ambergau.buero@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=989"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-johannes-hondelage-in-braunschweig.json
+++ b/companies/kirchengemeinde-st-johannes-hondelage-in-braunschweig.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-johannes-hondelage-in-braunschweig",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Johannes Hondelage in Braunschweig",
+    "address": "Johannesweg 4\n38108 Braunschweig\nDeutschland",
+    "phone": "+49 5309 5143",
+    "fax": "+49 5309 2713",
+    "email": "hondelage.pfa@lk-bs.de",
+    "web": "http://www.kirche-hondelage.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=747"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-johannes-in-goslar.json
+++ b/companies/kirchengemeinde-st-johannes-in-goslar.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-st-johannes-in-goslar",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Johannes in Goslar",
+    "address": "Gemeindehof 8\n38640 Goslar\nDeutschland",
+    "phone": "+49 5321 347351",
+    "fax": "+49 5321 23745",
+    "email": "goslar.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=774"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-johannes-salzgitter-lebenstedt.json
+++ b/companies/kirchengemeinde-st-johannes-salzgitter-lebenstedt.json
@@ -1,0 +1,21 @@
+{
+    "slug": "kirchengemeinde-st-johannes-salzgitter-lebenstedt",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Johannes Salzgitter-Lebenstedt",
+    "address": "Am Saldergraben 54\n38226 Salzgitter\nDeutschland",
+    "phone": "+49 5341 45500",
+    "email": "johannes.sz.buero@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=892"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-johannes-und-mauritius-gittelde.json
+++ b/companies/kirchengemeinde-st-johannes-und-mauritius-gittelde.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-st-johannes-und-mauritius-gittelde",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Johannes und Mauritius Gittelde",
+    "address": "Lange Straße 42\n37539 Bad Grund (Harz)\nDeutschland",
+    "phone": "+49 5327 4243",
+    "fax": "+49 5327 859263",
+    "email": "gittelde.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=994"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-johannes-zu-nauen.json
+++ b/companies/kirchengemeinde-st-johannes-zu-nauen.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-st-johannes-zu-nauen",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Johannes zu Nauen",
+    "address": "Teichdamm 7\n38729 Lutter a. Bbge.\nDeutschland",
+    "phone": "+49 5383 326",
+    "fax": "+49 5383 907380",
+    "email": "lutter.buero@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=972"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-johannis-in-braunschweig.json
+++ b/companies/kirchengemeinde-st-johannis-in-braunschweig.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-johannis-in-braunschweig",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Johannis in Braunschweig",
+    "address": "Leonhardstraße 39\n38102 Braunschweig\nDeutschland",
+    "phone": "+49 531 7017830",
+    "fax": "+49 531 7017858",
+    "email": "johannis.bs.buero@lk-bs.de",
+    "web": "http://www.johannis-bs.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=748"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-johannis-wolfenbuettel.json
+++ b/companies/kirchengemeinde-st-johannis-wolfenbuettel.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-johannis-wolfenbuettel",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Johannis Wolfenbüttel",
+    "address": "Glockengasse 2\n38304 Wolfenbüttel\nDeutschland",
+    "phone": "+49 5331 298544",
+    "fax": "+49 5331 9028906",
+    "email": "johannis.wf.pfa@lk-bs.de",
+    "web": "http://www.propstei-wf.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1075"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-juergen-zu-beienrode-in-lehre.json
+++ b/companies/kirchengemeinde-st-juergen-zu-beienrode-in-lehre.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-juergen-zu-beienrode-in-lehre",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Jürgen zu Beienrode in Lehre",
+    "address": "Kirchtwete 2\n38165 Lehre\nDeutschland",
+    "phone": "+49 5308 2268",
+    "fax": "+49 5308 921546",
+    "email": "flechtorf.buero@lk-bs.de",
+    "web": "http://www.flechtorfbeienrode-evangelisch.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=833"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-juergen-zu-oelper-in-braunschweig.json
+++ b/companies/kirchengemeinde-st-juergen-zu-oelper-in-braunschweig.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-juergen-zu-oelper-in-braunschweig",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Jürgen zu Ölper in Braunschweig",
+    "address": "Sulzbacher Straße 41\n38116 Braunschweig\nDeutschland",
+    "phone": "+49 531 54594",
+    "fax": "+49 531 54569",
+    "email": "nordwest.bs.pfa@lk-bs.de",
+    "web": "http://www.kirche-sanktjuergen-oelper.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=742"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-katharinen-braunschweig.json
+++ b/companies/kirchengemeinde-st-katharinen-braunschweig.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-katharinen-braunschweig",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Katharinen Braunschweig",
+    "address": "An der Katharinenkirche 4\n38100 Braunschweig\nDeutschland",
+    "phone": "+49 531 44669",
+    "fax": "+49 531 13718",
+    "email": "katharinen.bs.buero@lk-bs.de",
+    "web": "http://www.katharinenbraunschweig.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=749"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-katharinen-in-steinlah.json
+++ b/companies/kirchengemeinde-st-katharinen-in-steinlah.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-katharinen-in-steinlah",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Katharinen in Steinlah",
+    "address": "Am Pfarrgarten 5\n38274 Elbe\nDeutschland",
+    "phone": "+49 5345 330",
+    "fax": "+49 5345 1773",
+    "email": "elbe.buero@lk-bs.de",
+    "web": "http://www.kirche-in-elbe.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=795"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-kilian-hahndorf-in-goslar.json
+++ b/companies/kirchengemeinde-st-kilian-hahndorf-in-goslar.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-kilian-hahndorf-in-goslar",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Kilian Hahndorf in Goslar",
+    "address": "Gemeindehof 8\n38640 Goslar\nDeutschland",
+    "phone": "+49 5321 347351",
+    "fax": "+49 5321 23745",
+    "email": "goslar.pfa@lk-bs.de",
+    "web": "http://www.sanktkilian.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=783"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-lambertus-suepplingen.json
+++ b/companies/kirchengemeinde-st-lambertus-suepplingen.json
@@ -1,0 +1,21 @@
+{
+    "slug": "kirchengemeinde-st-lambertus-suepplingen",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Lambertus Süpplingen",
+    "address": "Breite Straße 45\n38373 Süpplingen\nDeutschland",
+    "phone": "+49 5355 342",
+    "email": "suepplingen.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=856"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-laurentius-astfeld-in-langelsheim.json
+++ b/companies/kirchengemeinde-st-laurentius-astfeld-in-langelsheim.json
@@ -1,0 +1,21 @@
+{
+    "slug": "kirchengemeinde-st-laurentius-astfeld-in-langelsheim",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Laurentius Astfeld in Langelsheim",
+    "address": "Am Plan 1\n38685 Langelsheim\nDeutschland",
+    "phone": "+49 5326 2016",
+    "email": "astfeld.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=965"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-lukas-querum-in-braunschweig.json
+++ b/companies/kirchengemeinde-st-lukas-querum-in-braunschweig.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-lukas-querum-in-braunschweig",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Lukas Querum in Braunschweig",
+    "address": "Bevenroder Straße 118\n38108 Braunschweig\nDeutschland",
+    "phone": "+49 531 371177",
+    "fax": "+49 531 377895",
+    "email": "querum.pfa@lk-bs.de",
+    "web": "http://www.st-lukas-querum.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=754"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-lukas-salzgitter-lebenstedt.json
+++ b/companies/kirchengemeinde-st-lukas-salzgitter-lebenstedt.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-st-lukas-salzgitter-lebenstedt",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Lukas Salzgitter-Lebenstedt",
+    "address": "Wildkamp 34\n38226 Salzgitter\nDeutschland",
+    "phone": "+49 5341 61659",
+    "fax": "+49 5341 67150",
+    "email": "lukas.sz.buero@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=893"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-lukas-zu-jerstedt-in-goslar.json
+++ b/companies/kirchengemeinde-st-lukas-zu-jerstedt-in-goslar.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-st-lukas-zu-jerstedt-in-goslar",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Lukas zu Jerstedt in Goslar",
+    "address": "Kirchstraße 5\n38644 Goslar\nDeutschland",
+    "phone": "+49 5321 81219",
+    "fax": "+49 5321 85492",
+    "email": "jerstedt.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=784"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-magni-in-braunschweig.json
+++ b/companies/kirchengemeinde-st-magni-in-braunschweig.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-magni-in-braunschweig",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Magni in Braunschweig",
+    "address": "Hinter der Magnikirche 7\n38100 Braunschweig\nDeutschland",
+    "phone": "+49 531 46804",
+    "fax": "+49 531 1218521",
+    "email": "magni.bs.buero@lk-bs.de",
+    "web": "http://www.magni-kirche.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=750"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-maria-in-grasleben.json
+++ b/companies/kirchengemeinde-st-maria-in-grasleben.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-maria-in-grasleben",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Maria in Grasleben",
+    "address": "Klosterstraße 11\n38350 Helmstedt\nDeutschland",
+    "phone": "+49 5351 7499",
+    "fax": "+49 5351 523711",
+    "email": "helmstedtnord.pfa@lk-bs.de",
+    "web": "http://www.ev-kirche-grasleben.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=666"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-maria-lelm-in-koenigslutter.json
+++ b/companies/kirchengemeinde-st-maria-lelm-in-koenigslutter.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-maria-lelm-in-koenigslutter",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Maria Lelm in Königslutter",
+    "address": "Hauptstraße 14\n38154 Königslutter am Elm\nDeutschland",
+    "phone": "+49 5353 8413",
+    "fax": "+49 5353 913112",
+    "email": "lelm.pfa@lk-bs.de",
+    "web": "http://www.kirche-lelm.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=849"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-maria-lochtum-in-vienenburg.json
+++ b/companies/kirchengemeinde-st-maria-lochtum-in-vienenburg.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-maria-lochtum-in-vienenburg",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Maria Lochtum in Vienenburg",
+    "address": "Bismarckstraße 13\n38690 Goslar\nDeutschland",
+    "phone": "+49 5324 2245",
+    "fax": "+49 5324 2059",
+    "email": "harz-harly.pfa@lk-bs.de",
+    "web": "https://www.kirche-harz-harly.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=731"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-maria-st-cyriakus-gross-twuelpstedt.json
+++ b/companies/kirchengemeinde-st-maria-st-cyriakus-gross-twuelpstedt.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-st-maria-st-cyriakus-gross-twuelpstedt",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Maria St. Cyriakus Groß Twülpstedt",
+    "address": "Langer Berg 3\n38464 Groß Twülpstedt\nDeutschland",
+    "phone": "+49 5364 2380",
+    "fax": "+49 5364 8488",
+    "email": "twuelpstedt.buero@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1036"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-mariae-jakobi-salzgitter-bad.json
+++ b/companies/kirchengemeinde-st-mariae-jakobi-salzgitter-bad.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-st-mariae-jakobi-salzgitter-bad",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Mariae-Jakobi Salzgitter-Bad",
+    "address": "Altstadtweg 6\n38259 Salzgitter\nDeutschland",
+    "phone": "+49 5341 81620",
+    "fax": "+49 5341 816231",
+    "email": "salzgitterbad-gitter.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=866"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-marien-harlingerode-in-bad-harzburg.json
+++ b/companies/kirchengemeinde-st-marien-harlingerode-in-bad-harzburg.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-marien-harlingerode-in-bad-harzburg",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Marien Harlingerode in Bad Harzburg",
+    "address": "Meinigstraße 43\n38667 Bad Harzburg\nDeutschland",
+    "phone": "+49 5322 81586",
+    "fax": "+49 5322 877994",
+    "email": "harlingerode.buero@lk-bs.de",
+    "web": "http://www.st.-marien-harlingerode.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=708"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-marien-lamme.json
+++ b/companies/kirchengemeinde-st-marien-lamme.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-marien-lamme",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Marien Lamme",
+    "address": "Sulzbacher Straße 41\n38116 Braunschweig\nDeutschland",
+    "phone": "+49 531 54594",
+    "fax": "+49 531 54569",
+    "email": "nordwest.bs.pfa@lk-bs.de",
+    "web": "http://www.st-marien-lamme.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=741"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-marien-und-st-trinitatis-in-wolfenbuettel.json
+++ b/companies/kirchengemeinde-st-marien-und-st-trinitatis-in-wolfenbuettel.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-marien-und-st-trinitatis-in-wolfenbuettel",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Marien und St. Trinitatis in Wolfenbüttel",
+    "address": "Neuer Weg 90\n38302 Wolfenbüttel\nDeutschland",
+    "phone": "+49 5331 972850",
+    "fax": "+49 5331 972858",
+    "email": "wf-mitte-sued.pfa@lk-bs.de",
+    "web": "http://www.marien-trinitatis-wf.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1077"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-markus-in-braunschweig.json
+++ b/companies/kirchengemeinde-st-markus-in-braunschweig.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-st-markus-in-braunschweig",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Markus in Braunschweig",
+    "address": "Heidehöhe 28\n38126 Braunschweig\nDeutschland",
+    "phone": "+49 531 691453",
+    "email": "braunschweigersueden.pfa@lk-bs.de",
+    "web": "http://www.markus-bs.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=759"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-markus-reislingen-neuhaus-in-wolfsburg.json
+++ b/companies/kirchengemeinde-st-markus-reislingen-neuhaus-in-wolfsburg.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-markus-reislingen-neuhaus-in-wolfsburg",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Markus Reislingen-Neuhaus in Wolfsburg",
+    "address": "Kantor-Wurm-Straße 1\n38446 Wolfsburg\nDeutschland",
+    "phone": "+49 5363 4134",
+    "fax": "+49 5363 1887",
+    "email": "markus-reislingen.buero@lk-bs.de",
+    "web": "http://www.kirche-reislingen-neuhaus.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1044"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-markus-salzgitter-lebenstedt.json
+++ b/companies/kirchengemeinde-st-markus-salzgitter-lebenstedt.json
@@ -1,0 +1,21 @@
+{
+    "slug": "kirchengemeinde-st-markus-salzgitter-lebenstedt",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Markus Salzgitter-Lebenstedt",
+    "address": "Nebelflucht 42\n38226 Salzgitter\nDeutschland",
+    "phone": "+49 5341 46323",
+    "email": "markus.sz.buero@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=894"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-martin-greene-in-einbeck.json
+++ b/companies/kirchengemeinde-st-martin-greene-in-einbeck.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-martin-greene-in-einbeck",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Martin Greene in Einbeck",
+    "address": "Kirchplatz 3\n37574 Einbeck\nDeutschland",
+    "phone": "+49 5563 320",
+    "fax": "+49 5563 6009",
+    "email": "greene.buero@lk-bs.de",
+    "web": "http://www.stmartin-greene.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=684"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-martin-gross-elbe.json
+++ b/companies/kirchengemeinde-st-martin-gross-elbe.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-martin-gross-elbe",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Martin Groß Elbe",
+    "address": "Am Pfarrgarten 5\n38274 Elbe\nDeutschland",
+    "phone": "+49 5345 330",
+    "fax": "+49 5345 1773",
+    "email": "elbe.buero@lk-bs.de",
+    "web": "http://www.kirche-in-elbe.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=780"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-martini-in-braunschweig.json
+++ b/companies/kirchengemeinde-st-martini-in-braunschweig.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-martini-in-braunschweig",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Martini in Braunschweig",
+    "address": "Eiermarkt 3\n38100 Braunschweig\nDeutschland",
+    "phone": "+49 531 82834",
+    "fax": "+49 531 890090",
+    "email": "braunschweigwest.pfa@lk-bs.de",
+    "web": "http://www.martini-kirche.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=761"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-martini-st-nikolai-st-urban-in-vechelde.json
+++ b/companies/kirchengemeinde-st-martini-st-nikolai-st-urban-in-vechelde.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-martini-st-nikolai-st-urban-in-vechelde",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Martini-St. Nikolai-St. Urban in Vechelde",
+    "address": "St.-Martins-Straße 9\n38159 Vechelde\nDeutschland",
+    "phone": "+49 5300 363",
+    "fax": "+49 5300 933630",
+    "email": "vallstedt.pfa@lk-bs.de",
+    "web": "https://www.kirche-vallstedt.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1013"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-matthaeus-zu-bredelem-in-langelsheim.json
+++ b/companies/kirchengemeinde-st-matthaeus-zu-bredelem-in-langelsheim.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-st-matthaeus-zu-bredelem-in-langelsheim",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Matthäus zu Bredelem in Langelsheim",
+    "address": "Kirchstraße 5\n38644 Goslar\nDeutschland",
+    "phone": "+49 5321 81219",
+    "fax": "+49 5321 85492",
+    "email": "jerstedt.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=785"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-matthias-wedtlenstedt-in-vechelde.json
+++ b/companies/kirchengemeinde-st-matthias-wedtlenstedt-in-vechelde.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-st-matthias-wedtlenstedt-in-vechelde",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Matthias Wedtlenstedt in Vechelde",
+    "address": "Pastor-Graffam-Weg 1\n38176 Wendeburg\nDeutschland",
+    "phone": "+49 5302 1424",
+    "fax": "+49 5302 804947",
+    "email": "bortfeld.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1003"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-michael-cremlingen-klein-schoeppenstedt.json
+++ b/companies/kirchengemeinde-st-michael-cremlingen-klein-schoeppenstedt.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-st-michael-cremlingen-klein-schoeppenstedt",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Michael Cremlingen - Klein Schöppenstedt",
+    "address": "Kirchstraße 16\n38162 Cremlingen\nDeutschland",
+    "phone": "+49 5306 4157",
+    "fax": "+49 5306 4089",
+    "email": "zwoelf-apostel-cremlingen.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=111674"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-michaelis-braunschweig.json
+++ b/companies/kirchengemeinde-st-michaelis-braunschweig.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-michaelis-braunschweig",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Michaelis Braunschweig",
+    "address": "Eiermarkt 3\n38100 Braunschweig\nDeutschland",
+    "phone": "+49 531 82834",
+    "fax": "+49 531 890090",
+    "email": "braunschweigwest.pfa@lk-bs.de",
+    "web": "http://www.st-michaelis-bs.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=763"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-nikolai-barum-in-salzgitter.json
+++ b/companies/kirchengemeinde-st-nikolai-barum-in-salzgitter.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-nikolai-barum-in-salzgitter",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Nikolai Barum in Salzgitter",
+    "address": "Werkstraße 18\n38229 Salzgitter\nDeutschland",
+    "phone": "+49 5341 24018",
+    "fax": "+49 5341 229396",
+    "email": "lobmachtersen.pfa@lk-bs.de",
+    "web": "http://www.pfarrverband-lobmachtersen.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=871"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-nikolaus-klein-elbe.json
+++ b/companies/kirchengemeinde-st-nikolaus-klein-elbe.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-nikolaus-klein-elbe",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Nikolaus Klein Elbe",
+    "address": "Am Pfarrgarten 5\n38274 Elbe\nDeutschland",
+    "phone": "+49 5345 330",
+    "fax": "+49 5345 1773",
+    "email": "elbe.buero@lk-bs.de",
+    "web": "http://www.kirche-in-elbe.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=782"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-pauli-matthaeus-in-braunschweig.json
+++ b/companies/kirchengemeinde-st-pauli-matthaeus-in-braunschweig.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-pauli-matthaeus-in-braunschweig",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Pauli-Matthäus in Braunschweig",
+    "address": "Herzogin-Elisabeth-Str. 80 A\n38104 Braunschweig\nDeutschland",
+    "phone": "+49 531 341344",
+    "fax": "+49 531 39079889",
+    "email": "braunschweigost.pfa@lk-bs.de",
+    "web": "http://www.pauli-matthaeus.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=753"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-paulus-sauingen-in-salzgitter.json
+++ b/companies/kirchengemeinde-st-paulus-sauingen-in-salzgitter.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-st-paulus-sauingen-in-salzgitter",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Paulus Sauingen in Salzgitter",
+    "address": "An der Kirche 4\n38239 Salzgitter\nDeutschland",
+    "phone": "+49 5300 260",
+    "fax": "+49 5300 495",
+    "email": "sauingen.buero@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=904"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-peter-und-paul-auf-dem-frankenberge-in-goslar.json
+++ b/companies/kirchengemeinde-st-peter-und-paul-auf-dem-frankenberge-in-goslar.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-peter-und-paul-auf-dem-frankenberge-in-goslar",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Peter und Paul auf dem Frankenberge in Goslar",
+    "address": "Gemeindehof 8\n38640 Goslar\nDeutschland",
+    "phone": "+49 5321 347351",
+    "fax": "+49 5321 23745",
+    "email": "goslar.pfa@lk-bs.de",
+    "web": "http://www.frankenberg-goslar.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=772"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-peter-und-paul-bevenrode-in-braunschweig.json
+++ b/companies/kirchengemeinde-st-peter-und-paul-bevenrode-in-braunschweig.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-st-peter-und-paul-bevenrode-in-braunschweig",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Peter und Paul Bevenrode in Braunschweig",
+    "address": "Kirchblick 3\n38110 Braunschweig\nDeutschland",
+    "phone": "+49 5307 5765",
+    "fax": "+49 5307 8262",
+    "email": "waggum.buero@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=862"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-peter-und-paul-zu-lesse-in-salzgitter.json
+++ b/companies/kirchengemeinde-st-peter-und-paul-zu-lesse-in-salzgitter.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-st-peter-und-paul-zu-lesse-in-salzgitter",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Peter und Paul zu Lesse in Salzgitter",
+    "address": "Zum Hohen Tor 8\n38228 Salzgitter\nDeutschland",
+    "phone": "+49 5341 52617",
+    "email": "lesse.pfa@lk-bs.de",
+    "web": "http://www.kirchengemeinde-lesse.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=898"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-peter-zu-goslar-sudmerberg.json
+++ b/companies/kirchengemeinde-st-peter-zu-goslar-sudmerberg.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-st-peter-zu-goslar-sudmerberg",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Peter zu Goslar (Sudmerberg)",
+    "address": "Gemeindehof 8\n38640 Goslar\nDeutschland",
+    "phone": "+49 5321 347351",
+    "fax": "+49 5321 23745",
+    "email": "goslar.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=777"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-petri-beddingen-in-salzgitter.json
+++ b/companies/kirchengemeinde-st-petri-beddingen-in-salzgitter.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-st-petri-beddingen-in-salzgitter",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Petri Beddingen in Salzgitter",
+    "address": "An der Kirche 4\n38239 Salzgitter\nDeutschland",
+    "phone": "+49 5300 260",
+    "fax": "+49 5300 495",
+    "email": "sauingen.buero@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=910"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-petri-boernecke.json
+++ b/companies/kirchengemeinde-st-petri-boernecke.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-st-petri-boernecke",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Petri Börnecke",
+    "address": "Lange Straße 9\n38889 Blankenburg (Harz) OT Wienrode\nDeutschland",
+    "phone": "+49 3944 366581",
+    "fax": "+49 3944 366622",
+    "email": "wienrode.buero@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=727"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-petri-braunschweig-rueningen.json
+++ b/companies/kirchengemeinde-st-petri-braunschweig-rueningen.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-petri-braunschweig-rueningen",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Petri Braunschweig-Rüningen",
+    "address": "Thiedestraße 28\n38122 Braunschweig\nDeutschland",
+    "phone": "+49 531 873908",
+    "fax": "+49 531 8669606",
+    "email": "petri.rueningen.pfa@lk-bs.de",
+    "web": "http://www.petri-rueningen.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1010"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-petri-emmerstedt-in-helmstedt.json
+++ b/companies/kirchengemeinde-st-petri-emmerstedt-in-helmstedt.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-petri-emmerstedt-in-helmstedt",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Petri Emmerstedt in Helmstedt",
+    "address": "Klosterstraße 11\n38350 Helmstedt\nDeutschland",
+    "phone": "+49 5351 7499",
+    "fax": "+49 5351 523711",
+    "email": "helmstedtnord.pfa@lk-bs.de",
+    "web": "http://www.emmerstedt-kirche.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=798"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-petri-erkerode-lucklum.json
+++ b/companies/kirchengemeinde-st-petri-erkerode-lucklum.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-st-petri-erkerode-lucklum",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Petri Erkerode-Lucklum",
+    "address": "An der Oberburg 14\n38162 Cremlingen\nDeutschland",
+    "phone": "+49 5306 1854",
+    "fax": "+49 5306 930596",
+    "email": "destedt.buero@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=830"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-petri-in-braunschweig.json
+++ b/companies/kirchengemeinde-st-petri-in-braunschweig.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-petri-in-braunschweig",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Petri in Braunschweig",
+    "address": "Lange Straße 33\n38100 Braunschweig\nDeutschland",
+    "phone": "+49 531 45681",
+    "fax": "+49 531 12167655",
+    "email": "petri.bs.buero@lk-bs.de",
+    "web": "http://www.petri-braunschweig.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=743"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-petri-johannis-waggum-in-braunschweig.json
+++ b/companies/kirchengemeinde-st-petri-johannis-waggum-in-braunschweig.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-st-petri-johannis-waggum-in-braunschweig",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Petri Johannis Waggum in Braunschweig",
+    "address": "Kirchblick 3\n38110 Braunschweig\nDeutschland",
+    "phone": "+49 5307 5765",
+    "fax": "+49 5307 8262",
+    "email": "waggum.buero@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=861"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-petri-remlingen.json
+++ b/companies/kirchengemeinde-st-petri-remlingen.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-petri-remlingen",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Petri Remlingen",
+    "address": "Kirchweg 4\n38327 Semmenstedt\nDeutschland",
+    "phone": "+49 5336 397",
+    "fax": "+49 5336 948214",
+    "email": "asse.pfa@lk-bs.de",
+    "web": "http://www.gesamtpfarrverband-asse.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=951"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-petri-zu-heerte-in-salzgitter.json
+++ b/companies/kirchengemeinde-st-petri-zu-heerte-in-salzgitter.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-petri-zu-heerte-in-salzgitter",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Petri zu Heerte in Salzgitter",
+    "address": "Werkstraße 18\n38229 Salzgitter\nDeutschland",
+    "phone": "+49 5341 24018",
+    "fax": "+49 5341 229396",
+    "email": "lobmachtersen.pfa@lk-bs.de",
+    "web": "http://www.pfarrverband-lobmachtersen.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=881"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-petrus-am-heeseberg.json
+++ b/companies/kirchengemeinde-st-petrus-am-heeseberg.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-st-petrus-am-heeseberg",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Petrus am Heeseberg",
+    "address": "Niedernstraße 47\n38364 Schöningen\nDeutschland",
+    "phone": "+49 5352 4764",
+    "fax": "+49 5352 4745",
+    "email": "helmstedt-sued.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=810"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-petrus-heiliggeist-vorsfelde-in-wolfsburg.json
+++ b/companies/kirchengemeinde-st-petrus-heiliggeist-vorsfelde-in-wolfsburg.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-petrus-heiliggeist-vorsfelde-in-wolfsburg",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Petrus/Heiliggeist Vorsfelde in Wolfsburg",
+    "address": "Amtsstraße 31\n38448 Wolfsburg\nDeutschland",
+    "phone": "+49 5363 7773",
+    "fax": "+49 5363 73497",
+    "email": "petrus-vorsfelde.buero@lk-bs.de",
+    "web": "http://www.kirche-vorsfelde.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1051"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-petrus-zu-lichtenberg-in-salzgitter.json
+++ b/companies/kirchengemeinde-st-petrus-zu-lichtenberg-in-salzgitter.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-petrus-zu-lichtenberg-in-salzgitter",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Petrus zu Lichtenberg in Salzgitter",
+    "address": "Fredener Straße 14 A\n38228 Salzgitter\nDeutschland",
+    "phone": "+49 5341 58250",
+    "fax": "+49 5341 1861518",
+    "email": "lichtenberg.pfa@lk-bs.de",
+    "web": "http://www.evangelisch-in-lichtenberg.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=901"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-remigius-harriehausen.json
+++ b/companies/kirchengemeinde-st-remigius-harriehausen.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-st-remigius-harriehausen",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Remigius Harriehausen",
+    "address": "Kirchenbrink 2\n37581 Bad Gandersheim\nDeutschland",
+    "phone": "+49 5382 3415",
+    "fax": "+49 5382 5899060",
+    "email": "harriehausen.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=685"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-romanus-in-hahausen.json
+++ b/companies/kirchengemeinde-st-romanus-in-hahausen.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-st-romanus-in-hahausen",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Romanus in Hahausen",
+    "address": "Teichdamm 7\n38729 Lutter a. Bbge.\nDeutschland",
+    "phone": "+49 5383 326",
+    "fax": "+49 5383 907380",
+    "email": "lutter.buero@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=971"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-salvator-trautenstein.json
+++ b/companies/kirchengemeinde-st-salvator-trautenstein.json
@@ -1,0 +1,21 @@
+{
+    "slug": "kirchengemeinde-st-salvator-trautenstein",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Salvator Trautenstein",
+    "address": "Kirchstraße 7 A\n38700 Braunlage\nDeutschland",
+    "phone": "+49 5583 834",
+    "email": "hohegeiss.buero@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=712"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-servatius-in-haverlah.json
+++ b/companies/kirchengemeinde-st-servatius-in-haverlah.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-st-servatius-in-haverlah",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Servatius in Haverlah",
+    "address": "An der Kirche 1\n38279 Sehlde\nDeutschland",
+    "phone": "+49 5341 33633",
+    "fax": "+49 5341 941646",
+    "email": "sehlde.buero@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=796"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-servatius-und-st-nicolai-in-wolfsburg.json
+++ b/companies/kirchengemeinde-st-servatius-und-st-nicolai-in-wolfsburg.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-servatius-und-st-nicolai-in-wolfsburg",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Servatius und St. Nicolai in Wolfsburg",
+    "address": "An der Kirche 2\n38446 Wolfsburg\nDeutschland",
+    "phone": "+49 5363 976034",
+    "fax": "+49 5363 72426",
+    "email": "aller.pfa@lk-bs.de",
+    "web": "http://www.kirche-nordsteimke.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1042"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-stephan-am-grossen-bruch.json
+++ b/companies/kirchengemeinde-st-stephan-am-grossen-bruch.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-st-stephan-am-grossen-bruch",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Stephan am Großen Bruch",
+    "address": "Niedernstraße 47\n38364 Schöningen\nDeutschland",
+    "phone": "+49 5352 4764",
+    "fax": "+49 5352 4745",
+    "email": "helmstedt-sued.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=807"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-stephani-in-raebke.json
+++ b/companies/kirchengemeinde-st-stephani-in-raebke.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-stephani-in-raebke",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Stephani in Räbke",
+    "address": "Hauptstraße 14\n38154 Königslutter am Elm\nDeutschland",
+    "phone": "+49 5353 8413",
+    "fax": "+49 5353 913112",
+    "email": "lelm.pfa@lk-bs.de",
+    "web": "http://www.kirche-raebke.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=850"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-stephani-zu-goslar.json
+++ b/companies/kirchengemeinde-st-stephani-zu-goslar.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-stephani-zu-goslar",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Stephani zu Goslar",
+    "address": "Gemeindehof 8\n38640 Goslar\nDeutschland",
+    "phone": "+49 5321 347351",
+    "fax": "+49 5321 23745",
+    "email": "goslar.pfa@lk-bs.de",
+    "web": "https://www.stephani-goslar.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=778"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-stephanus-ellierode-bad-gandersheim.json
+++ b/companies/kirchengemeinde-st-stephanus-ellierode-bad-gandersheim.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-st-stephanus-ellierode-bad-gandersheim",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Stephanus Ellierode Bad Gandersheim",
+    "address": "Kirchenbrink 2\n37581 Bad Gandersheim\nDeutschland",
+    "phone": "+49 5382 3415",
+    "fax": "+49 5382 790811",
+    "email": "harriehausen.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=687"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-thomas-im-heidberg-braunschweig.json
+++ b/companies/kirchengemeinde-st-thomas-im-heidberg-braunschweig.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-thomas-im-heidberg-braunschweig",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Thomas im Heidberg Braunschweig",
+    "address": "Bautzenstraße 26\n38124 Braunschweig\nDeutschland",
+    "phone": "+49 531 691055",
+    "fax": "+49 531 691059",
+    "email": "heidberg.bs.buero@lk-bs.de",
+    "web": "http://www.st-thomas-bs.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=758"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-thomas-in-wolfenbuettel.json
+++ b/companies/kirchengemeinde-st-thomas-in-wolfenbuettel.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-thomas-in-wolfenbuettel",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Thomas in Wolfenbüttel",
+    "address": "Jahnstraße 5\n38302 Wolfenbüttel\nDeutschland",
+    "phone": "+49 5331 72413",
+    "fax": "+49 5331 340546",
+    "email": "maria-magdala.wf.pfa@lk-bs.de",
+    "web": "http://www.thomaskirche-wf.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1076"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-thomas-volkmarode-in-braunschweig.json
+++ b/companies/kirchengemeinde-st-thomas-volkmarode-in-braunschweig.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-thomas-volkmarode-in-braunschweig",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Thomas Volkmarode in Braunschweig",
+    "address": "Kirchstraße 16\n38162 Cremlingen\nDeutschland",
+    "phone": "+49 5306 4157",
+    "fax": "+49 5306 4089",
+    "email": "zwoelf-apostel-cremlingen.pfa@lk-bs.de",
+    "web": "http://www.kirche-volkmarode.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=860"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-thomas-wolfshagen-im-harz.json
+++ b/companies/kirchengemeinde-st-thomas-wolfshagen-im-harz.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-thomas-wolfshagen-im-harz",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Thomas Wolfshagen im Harz",
+    "address": "Heinrich-Steinweg-Straße 16\n38685 Langelsheim\nDeutschland",
+    "phone": "+49 5326 969208",
+    "fax": "+49 5326 969345",
+    "email": "wolfshagen.pfa@lk-bs.de",
+    "web": "http://www.kirche-wolfshagen.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=991"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-trinitatis-in-liebenburg.json
+++ b/companies/kirchengemeinde-st-trinitatis-in-liebenburg.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-trinitatis-in-liebenburg",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Trinitatis in Liebenburg",
+    "address": "Martin-Luther-Straße 1\n38704 Liebenburg\nDeutschland",
+    "phone": "+49 5346 91119",
+    "fax": "+49 5346 91118",
+    "email": "liebenburg.pfa@lk-bs.de",
+    "web": "http://www.kircheliebenburg.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=786"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-ulrici-in-braunschweig.json
+++ b/companies/kirchengemeinde-st-ulrici-in-braunschweig.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-st-ulrici-in-braunschweig",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Ulrici in Braunschweig",
+    "address": "Alter Zeughof 3\n38100 Braunschweig\nDeutschland",
+    "phone": "+49 531 44223",
+    "fax": "+49 531 1232804",
+    "email": "ulrici.buero@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=765"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-vincenz-und-st-lorenz-in-schoeningen.json
+++ b/companies/kirchengemeinde-st-vincenz-und-st-lorenz-in-schoeningen.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-vincenz-und-st-lorenz-in-schoeningen",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Vincenz und St. Lorenz in Schöningen",
+    "address": "Niedernstraße 47\n38364 Schöningen\nDeutschland",
+    "phone": "+49 5352 4764",
+    "fax": "+49 5352 4745",
+    "email": "helmstedt-sued.pfa@lk-bs.de",
+    "web": "http://www.stvincenz-schoeningen.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=819"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-vitus-und-st-andreas-in-seesen.json
+++ b/companies/kirchengemeinde-st-vitus-und-st-andreas-in-seesen.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-st-vitus-und-st-andreas-in-seesen",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Vitus und St. Andreas in Seesen",
+    "address": "Hinter der Kirche 1 A\n38723 Seesen\nDeutschland",
+    "phone": "+49 5381 94290",
+    "fax": "+49 5381 942911",
+    "email": "seesen.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=988"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-st-walpurgis-in-helmstedt.json
+++ b/companies/kirchengemeinde-st-walpurgis-in-helmstedt.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-st-walpurgis-in-helmstedt",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde St. Walpurgis in Helmstedt",
+    "address": "Klosterstraße 11\n38350 Helmstedt\nDeutschland",
+    "phone": "+49 5351 7499",
+    "fax": "+49 5351 523711",
+    "email": "helmstedtnord.pfa@lk-bs.de",
+    "web": "http://www.kirchengemeinde-walpurgis.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=801"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-stadtkirche-koenigslutter.json
+++ b/companies/kirchengemeinde-stadtkirche-koenigslutter.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-stadtkirche-koenigslutter",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Stadtkirche Königslutter",
+    "address": "An der Stadtkirche 6\n38154 Königslutter am Elm\nDeutschland",
+    "phone": "+49 5353 96278",
+    "fax": "+49 5353 951781",
+    "email": "koenigslutter.pfa@lk-bs.de",
+    "web": "https://www.kirchengemeindeverband-koenigslutter.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=842"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-steterburg-in-salzgitter.json
+++ b/companies/kirchengemeinde-steterburg-in-salzgitter.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-steterburg-in-salzgitter",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Steterburg in Salzgitter",
+    "address": "Schulring 4-6\n38239 Salzgitter\nDeutschland",
+    "phone": "+49 5341 264616",
+    "fax": "+49 5341 260540",
+    "email": "salzgitters-norden.pfa@lk-bs.de",
+    "web": "http://www.stiftskirche-steterburg.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=909"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-stiddien-in-braunschweig.json
+++ b/companies/kirchengemeinde-stiddien-in-braunschweig.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-stiddien-in-braunschweig",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Stiddien in Braunschweig",
+    "address": "Geiteldestraße 39\n38122 Braunschweig\nDeutschland",
+    "phone": "+49 5300 372",
+    "email": "geitelde.pfa@lk-bs.de",
+    "web": "http://www.krche-stiddien.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1057"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-stiftskirche-in-koenigslutter.json
+++ b/companies/kirchengemeinde-stiftskirche-in-koenigslutter.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-stiftskirche-in-koenigslutter",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Stiftskirche in Königslutter",
+    "address": "Vor dem Kaiserdom 1\n38154 Königslutter am Elm\nDeutschland",
+    "phone": "+49 5353 2247",
+    "fax": "+49 5353 96878",
+    "email": "stiftskirche.koe.buero@lk-bs.de",
+    "web": "http://www.kaiserdom-koenigslutter.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=845"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-stroit-in-einbeck.json
+++ b/companies/kirchengemeinde-stroit-in-einbeck.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-stroit-in-einbeck",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Stroit in Einbeck",
+    "address": "Im Oberdorf 11\n37574 Einbeck\nDeutschland",
+    "phone": "+49 5563 6822",
+    "fax": "+49 5563 6868",
+    "email": "naensen.buero@lk-bs.de",
+    "web": "http://blog.kirche-naensen.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=695"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-suepplingenburg.json
+++ b/companies/kirchengemeinde-suepplingenburg.json
@@ -1,0 +1,21 @@
+{
+    "slug": "kirchengemeinde-suepplingenburg",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Süpplingenburg",
+    "address": "Breite Straße 45\n38373 Süpplingen\nDeutschland",
+    "phone": "+49 5355 342",
+    "email": "suepplingen.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=857"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-sunstedt-in-koenigslutter.json
+++ b/companies/kirchengemeinde-sunstedt-in-koenigslutter.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-sunstedt-in-koenigslutter",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Sunstedt in Königslutter",
+    "address": "An der Stadtkirche 6\n38154 Königslutter am Elm\nDeutschland",
+    "phone": "+49 5353 96278",
+    "fax": "+49 5353 951781",
+    "email": "koenigslutter.pfa@lk-bs.de",
+    "web": "http://www.kaiserdom-koenigslutter.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=846"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-tanne.json
+++ b/companies/kirchengemeinde-tanne.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-tanne",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Tanne",
+    "address": "Pfarrstraße 1\n38700 Braunlage\nDeutschland",
+    "phone": "+49 5520 93010",
+    "fax": "+49 5520 930122",
+    "email": "braunlage.buero@lk-bs.de",
+    "web": "http://www.trinitatis.info/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1079"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-timmerlah-in-braunschweig.json
+++ b/companies/kirchengemeinde-timmerlah-in-braunschweig.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-timmerlah-in-braunschweig",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Timmerlah in Braunschweig",
+    "address": "Kirchstraße 12\n38120 Braunschweig\nDeutschland",
+    "phone": "+49 531 842208",
+    "fax": "+49 531 842205",
+    "email": "timmerlah.pfa@lk-bs.de",
+    "web": "http://www.kitiso.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1011"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-trinitatiskirche-schapen-in-braunschweig.json
+++ b/companies/kirchengemeinde-trinitatiskirche-schapen-in-braunschweig.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-trinitatiskirche-schapen-in-braunschweig",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Trinitatiskirche Schapen in Braunschweig",
+    "address": "Kirchstraße 16\n38162 Cremlingen\nDeutschland",
+    "phone": "+49 5306 4157",
+    "fax": "+49 5306 4089",
+    "email": "zwoelf-apostel-cremlingen.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=855"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-uefingen-in-salzgitter.json
+++ b/companies/kirchengemeinde-uefingen-in-salzgitter.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-uefingen-in-salzgitter",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Üfingen in Salzgitter",
+    "address": "An der Kirche 4\n38239 Salzgitter\nDeutschland",
+    "phone": "+49 5300 260",
+    "fax": "+49 5300 495",
+    "email": "sauingen.buero@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=905"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-upen-in-liebenburg.json
+++ b/companies/kirchengemeinde-upen-in-liebenburg.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-upen-in-liebenburg",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Upen in Liebenburg",
+    "address": "Ringstraße 11\n38704 Liebenburg\nDeutschland",
+    "phone": "+49 5346 4280",
+    "fax": "+49 5346 6137",
+    "email": "doernten.pfa@lk-bs.de",
+    "web": "https://www.kirchengemeinde-doernten-ostharingen-upen.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=792"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-uthmoeden.json
+++ b/companies/kirchengemeinde-uthmoeden.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-uthmoeden",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Uthmöden",
+    "address": "An der Kirche 1\n39359 Calvörde\nDeutschland",
+    "phone": "+49 39051 259",
+    "fax": "+49 39051 98225",
+    "email": "calvoerde.pfa@lk-bs.de",
+    "web": "https://www.pfarrverband-calvoerde-uthmoeden.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1049"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-varrigsen.json
+++ b/companies/kirchengemeinde-varrigsen.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-varrigsen",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Varrigsen",
+    "address": "Rothöfen 1\n31073 Delligsen\nDeutschland",
+    "phone": "+49 5187 2405",
+    "fax": "+49 5187 3481",
+    "email": "kaierde.buero@lk-bs.de",
+    "web": "http://www.kirche-kaierde.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=683"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-vechelde.json
+++ b/companies/kirchengemeinde-vechelde.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-vechelde",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Vechelde",
+    "address": "Peiner Straße 7\n38159 Vechelde\nDeutschland",
+    "phone": "+49 5302 6511",
+    "email": "vechelde.pfa@lk-bs.de",
+    "web": "http://www.kirchengemeinde-vechelde.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1016"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-velstove-in-wolfsburg.json
+++ b/companies/kirchengemeinde-velstove-in-wolfsburg.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-velstove-in-wolfsburg",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Velstove in Wolfsburg",
+    "address": "Im Wiesengrund 19\n38448 Wolfsburg\nDeutschland",
+    "phone": "+49 5361 61441",
+    "email": "johannes-kaestorf.buero@lk-bs.de",
+    "web": "http://www.kirche-kaestorf.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1040"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-versoehnungskirche-wolfenbuettel.json
+++ b/companies/kirchengemeinde-versoehnungskirche-wolfenbuettel.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-versoehnungskirche-wolfenbuettel",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Versöhnungskirche Wolfenbüttel",
+    "address": "Glockengasse 2\n38304 Wolfenbüttel\nDeutschland",
+    "phone": "+49 5331 298544",
+    "fax": "+49 5331 9028906",
+    "email": "johannis.wf.pfa@lk-bs.de",
+    "web": "http://www.versoehnungskirche-wf.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1078"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-vienenburg.json
+++ b/companies/kirchengemeinde-vienenburg.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-vienenburg",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Vienenburg",
+    "address": "Bismarckstraße 13\n38690 Goslar\nDeutschland",
+    "phone": "+49 5324 2245",
+    "fax": "+49 5324 2059",
+    "email": "harz-harly.pfa@lk-bs.de",
+    "web": "http://www.kirche-harz-harly.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=730"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-voelkenrode-in-braunschweig.json
+++ b/companies/kirchengemeinde-voelkenrode-in-braunschweig.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-voelkenrode-in-braunschweig",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Völkenrode in Braunschweig",
+    "address": "Kirchgang 7\n38112 Braunschweig\nDeutschland",
+    "phone": "+49 531 511202",
+    "fax": "+49 531 2512120",
+    "email": "voelkenrode.pfa@lk-bs.de",
+    "web": "http://www.gemeinde-voewa.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1017"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-wahle-und-sophiental-mit-fuerstenau-in-vechelde.json
+++ b/companies/kirchengemeinde-wahle-und-sophiental-mit-fuerstenau-in-vechelde.json
@@ -1,0 +1,21 @@
+{
+    "slug": "kirchengemeinde-wahle-und-sophiental-mit-fuerstenau-in-vechelde",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Wahle und Sophiental mit Fürstenau in Vechelde",
+    "address": "Schulstraße 6\n38159 Vechelde\nDeutschland",
+    "phone": "+49 5302 1419",
+    "email": "wahle.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=112330"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-walkenried.json
+++ b/companies/kirchengemeinde-walkenried.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-walkenried",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Walkenried",
+    "address": "Pfarrplatz 6\n37445 Walkenried\nDeutschland",
+    "phone": "+49 5525 800",
+    "fax": "+49 5525 959645",
+    "email": "kapellenfleck-harz.pfa@lk-bs.de",
+    "web": "http://www.kirchengemeinde-walkenried.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=732"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-wartjenstedt-in-baddeckenstedt.json
+++ b/companies/kirchengemeinde-wartjenstedt-in-baddeckenstedt.json
@@ -1,0 +1,21 @@
+{
+    "slug": "kirchengemeinde-wartjenstedt-in-baddeckenstedt",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Wartjenstedt in Baddeckenstedt",
+    "address": "Kasselberg 1\n38272 Burgdorf\nDeutschland",
+    "phone": "+49 5347 1917",
+    "email": "westerlinde.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=915"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-watenbuettel-in-braunschweig.json
+++ b/companies/kirchengemeinde-watenbuettel-in-braunschweig.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-watenbuettel-in-braunschweig",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Watenbüttel in Braunschweig",
+    "address": "Kirchgang 7\n38112 Braunschweig\nDeutschland",
+    "phone": "+49 531 511202",
+    "fax": "+49 531 2512120",
+    "email": "voelkenrode.pfa@lk-bs.de",
+    "web": "http://www.gemeinde-voewa.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1018"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-watzum-in-uehrde.json
+++ b/companies/kirchengemeinde-watzum-in-uehrde.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-watzum-in-uehrde",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Watzum in Uehrde",
+    "address": "Hauptstraße 1\n38173 Dettum\nDeutschland",
+    "phone": "+49 5333 316",
+    "fax": "+49 5333 312",
+    "email": "dettum.buero@lk-bs.de",
+    "web": "http://www.kirche-dettum.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=936"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-weddingen-in-vienenburg.json
+++ b/companies/kirchengemeinde-weddingen-in-vienenburg.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-weddingen-in-vienenburg",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Weddingen in Vienenburg",
+    "address": "Bismarckstraße 13\n38690 Goslar\nDeutschland",
+    "phone": "+49 5324 2245",
+    "fax": "+49 5324 2059",
+    "email": "harz-harly.pfa@lk-bs.de",
+    "web": "http://www.weddingen-kirche.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=717"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-wendeburg.json
+++ b/companies/kirchengemeinde-wendeburg.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-wendeburg",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Wendeburg",
+    "address": "Schulstraße 9\n38176 Wendeburg\nDeutschland",
+    "phone": "+49 5303 2356",
+    "fax": "+49 5303 2085",
+    "email": "wendeburg.pfa@lk-bs.de",
+    "web": "http://www.kirche-wendeburg.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1021"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-wenden-in-braunschweig.json
+++ b/companies/kirchengemeinde-wenden-in-braunschweig.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-wenden-in-braunschweig",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Wenden in Braunschweig",
+    "address": "Im Winkel 5\n38110 Braunschweig\nDeutschland",
+    "phone": "+49 5307 2253",
+    "email": "wenden.buero@lk-bs.de",
+    "web": "http://www.kirche-wenden.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=864"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-westerlinde-in-burgdorf.json
+++ b/companies/kirchengemeinde-westerlinde-in-burgdorf.json
@@ -1,0 +1,21 @@
+{
+    "slug": "kirchengemeinde-westerlinde-in-burgdorf",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Westerlinde in Burgdorf",
+    "address": "Kasselberg 1\n38272 Burgdorf\nDeutschland",
+    "phone": "+49 5347 1917",
+    "email": "westerlinde.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=912"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-weststadt-in-braunschweig.json
+++ b/companies/kirchengemeinde-weststadt-in-braunschweig.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-weststadt-in-braunschweig",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Weststadt in Braunschweig",
+    "address": "Muldeweg 5\n38120 Braunschweig\nDeutschland",
+    "phone": "+49 531 841880",
+    "fax": "+49 531 842372",
+    "email": "weststadt.bs.buero@lk-bs.de",
+    "web": "https://www.emmaus-braunschweig.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=766"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-wetzleben-in-hedeper.json
+++ b/companies/kirchengemeinde-wetzleben-in-hedeper.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-wetzleben-in-hedeper",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Wetzleben in Hedeper",
+    "address": "Kirchweg 4\n38327 Semmenstedt\nDeutschland",
+    "phone": "+49 5336 397",
+    "fax": "+49 5336 948214",
+    "email": "asse.pfa@lk-bs.de",
+    "web": "http://www.gesamtpfarrverband-asse.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=959"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-wichern-braunschweig-lehndorf-kanzlerfeld.json
+++ b/companies/kirchengemeinde-wichern-braunschweig-lehndorf-kanzlerfeld.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-wichern-braunschweig-lehndorf-kanzlerfeld",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Wichern Braunschweig Lehndorf-Kanzlerfeld",
+    "address": "Sulzbacher Straße 41\n38116 Braunschweig\nDeutschland",
+    "phone": "+49 531 54594",
+    "fax": "+49 531 54569",
+    "email": "nordwest.bs.pfa@lk-bs.de",
+    "web": "http://www.wichern-bs.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=745"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-wiedelah-in-vienenburg.json
+++ b/companies/kirchengemeinde-wiedelah-in-vienenburg.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-wiedelah-in-vienenburg",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Wiedelah in Vienenburg",
+    "address": "Bismarckstraße 13\n38690 Goslar\nDeutschland",
+    "phone": "+49 5324 2245",
+    "fax": "+49 5324 2059",
+    "email": "harz-harly.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=719"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-wienrode-timmenrode-cattenstedt-am-harz.json
+++ b/companies/kirchengemeinde-wienrode-timmenrode-cattenstedt-am-harz.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-wienrode-timmenrode-cattenstedt-am-harz",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Wienrode-Timmenrode-Cattenstedt am Harz",
+    "address": "Lange Straße 9\n38889 Blankenburg (Harz) OT Wienrode\nDeutschland",
+    "phone": "+49 3944 366581",
+    "fax": "+49 3944 366622",
+    "email": "wienrode.buero@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=729"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-windhausen.json
+++ b/companies/kirchengemeinde-windhausen.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-windhausen",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Windhausen",
+    "address": "Thüringer Straße 239\n37539 Bad Grund (Harz)\nDeutschland",
+    "phone": "+49 5522 83088",
+    "email": "badenhausen.pfa@lk-bs.de",
+    "web": "https://www.ek-bdh-wdh.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=967"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-winnigstedt.json
+++ b/companies/kirchengemeinde-winnigstedt.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-winnigstedt",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Winnigstedt",
+    "address": "Kirchweg 4\n38327 Semmenstedt\nDeutschland",
+    "phone": "+49 5336 397",
+    "fax": "+49 5336 948214",
+    "email": "asse.pfa@lk-bs.de",
+    "web": "http://www.gesamtpfarrverband-asse.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=954"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-woltwiesche-in-lengede.json
+++ b/companies/kirchengemeinde-woltwiesche-in-lengede.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-woltwiesche-in-lengede",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Woltwiesche in Lengede",
+    "address": "Große Straße 12\n38268 Lengede\nDeutschland",
+    "phone": "+49 5344 7155",
+    "fax": "+49 5344 915450",
+    "email": "woltwiesche.pfa@lk-bs.de",
+    "web": "http://www.kirchewoltwiesche.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=916"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-wrescherode-in-bad-gandersheim.json
+++ b/companies/kirchengemeinde-wrescherode-in-bad-gandersheim.json
@@ -1,0 +1,22 @@
+{
+    "slug": "kirchengemeinde-wrescherode-in-bad-gandersheim",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Wrescherode in Bad Gandersheim",
+    "address": "Stiftsfreiheit 1\n37581 Bad Gandersheim\nDeutschland",
+    "phone": "+49 5382 2714",
+    "fax": "+49 5382 790416",
+    "email": "gandersheim.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=680"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-zobbenitz.json
+++ b/companies/kirchengemeinde-zobbenitz.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-zobbenitz",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Zobbenitz",
+    "address": "An der Kirche 1\n39359 Calvörde\nDeutschland",
+    "phone": "+49 39051 259",
+    "fax": "+49 39051 98225",
+    "email": "calvoerde.pfa@lk-bs.de",
+    "web": "https://www.pfarrverband-calvoerde-uthmoeden.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1050"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-zorge.json
+++ b/companies/kirchengemeinde-zorge.json
@@ -1,0 +1,21 @@
+{
+    "slug": "kirchengemeinde-zorge",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Zorge",
+    "address": "Kirchstraße 7 A\n38700 Braunlage\nDeutschland",
+    "phone": "+49 5583 834",
+    "email": "hohegeiss.buero@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=734"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-zum-heiligen-leiden-christi-zu-braunschweig-stoeckheim.json
+++ b/companies/kirchengemeinde-zum-heiligen-leiden-christi-zu-braunschweig-stoeckheim.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-zum-heiligen-leiden-christi-zu-braunschweig-stoeckheim",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Zum Heiligen Leiden Christi zu Braunschweig (Stöckheim)",
+    "address": "Kirchenbrink 3 C\n38124 Braunschweig\nDeutschland",
+    "phone": "+49 531 611272",
+    "fax": "+49 531 2615483",
+    "email": "stoeckheim.buero@lk-bs.de",
+    "web": "http://www.kircheinstoeckheim.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=764"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-zum-markte-in-goslar.json
+++ b/companies/kirchengemeinde-zum-markte-in-goslar.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-zum-markte-in-goslar",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Zum Markte in Goslar",
+    "address": "Gemeindehof 8\n38640 Goslar\nDeutschland",
+    "phone": "+49 5321 347351",
+    "fax": "+49 5321 23745",
+    "email": "goslar.pfa@lk-bs.de",
+    "web": "http://www.marktkirche-goslar.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=775"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-zur-heiligen-dreifaltigkeit-braunschweig-bienrode.json
+++ b/companies/kirchengemeinde-zur-heiligen-dreifaltigkeit-braunschweig-bienrode.json
@@ -1,0 +1,21 @@
+{
+    "slug": "kirchengemeinde-zur-heiligen-dreifaltigkeit-braunschweig-bienrode",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Zur Heiligen Dreifaltigkeit Braunschweig-Bienrode",
+    "address": "Dammwiese 8 A\n38110 Braunschweig\nDeutschland",
+    "phone": "+49 5307 5772",
+    "email": "bienrode.buero@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=821"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/kirchengemeinde-zur-hilfe-gottes-stiege.json
+++ b/companies/kirchengemeinde-zur-hilfe-gottes-stiege.json
@@ -1,0 +1,23 @@
+{
+    "slug": "kirchengemeinde-zur-hilfe-gottes-stiege",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Kirchengemeinde Zur Hilfe Gottes Stiege",
+    "address": "Blumenaustraße 7\n38899 Oberharz am Brocken\nDeutschland",
+    "phone": "+49 39459 71371",
+    "fax": "+49 39459 18845",
+    "email": "hasselfelde.buero@lk-bs.de",
+    "web": "http://www.hasselfelde-evangelisch.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=723"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/lukas-gemeinde-bettmar-siersse-in-vechelde.json
+++ b/companies/lukas-gemeinde-bettmar-siersse-in-vechelde.json
@@ -1,0 +1,23 @@
+{
+    "slug": "lukas-gemeinde-bettmar-siersse-in-vechelde",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Lukas-Gemeinde Bettmar-Sierße in Vechelde",
+    "address": "Kreuzstraße 2\n38159 Vechelde\nDeutschland",
+    "phone": "+49 5302 2127",
+    "fax": "+49 5302 805642",
+    "email": "bettmar.pfa@lk-bs.de",
+    "web": "http://www.kirche-bettmar-siersse.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=112332"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/markus-gemeinde-am-elm.json
+++ b/companies/markus-gemeinde-am-elm.json
@@ -1,0 +1,23 @@
+{
+    "slug": "markus-gemeinde-am-elm",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Markus-Gemeinde am Elm",
+    "address": "Pastorentwete 2\n38173 Evessen\nDeutschland",
+    "phone": "+49 5333 425",
+    "fax": "+49 5333 1090",
+    "email": "evessen.buero@lk-bs.de",
+    "web": "http://www.markus-gemeinde-am-elm.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=925"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/martin-luther-kirchengemeinde-wolfenbuettel.json
+++ b/companies/martin-luther-kirchengemeinde-wolfenbuettel.json
@@ -1,0 +1,23 @@
+{
+    "slug": "martin-luther-kirchengemeinde-wolfenbuettel",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Martin-Luther-Kirchengemeinde Wolfenbüttel",
+    "address": "Neuer Weg 90\n38302 Wolfenbüttel\nDeutschland",
+    "phone": "+49 5331 972850",
+    "fax": "+49 5331 978958",
+    "email": "wf-mitte-sued.pfa@lk-bs.de",
+    "web": "http://www.martinluthergemeinde.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1074"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/petrusgemeinde-boerssum.json
+++ b/companies/petrusgemeinde-boerssum.json
@@ -1,0 +1,23 @@
+{
+    "slug": "petrusgemeinde-boerssum",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Petrusgemeinde Börßum",
+    "address": "Hauptstraße 14\n38312 Börßum\nDeutschland",
+    "phone": "+49 5334 6180",
+    "fax": "+49 5334 958429",
+    "email": "boerssum.buero@lk-bs.de",
+    "web": "http://www.kirche-boerssum.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=918"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/propstei-bad-harzburg.json
+++ b/companies/propstei-bad-harzburg.json
@@ -1,0 +1,23 @@
+{
+    "slug": "propstei-bad-harzburg",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Propstei Bad Harzburg",
+    "address": "Lutherstraße 7\n38667 Bad Harzburg\nDeutschland",
+    "phone": "+49 5322 2501",
+    "fax": "+49 5322 8789472",
+    "email": "harzburg.pr@lk-bs.de",
+    "web": "http://www.propstei-badharzburg.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/bad-harzburg.html"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/propstei-braunschweig.json
+++ b/companies/propstei-braunschweig.json
@@ -1,0 +1,23 @@
+{
+    "slug": "propstei-braunschweig",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Propstei Braunschweig",
+    "address": "Schützenstraße 23\n38100 Braunschweig\nDeutschland",
+    "phone": "+49 531 471824",
+    "fax": "+49 531 471818",
+    "email": "braunschweig.pr@lk-bs.de",
+    "web": "http://www.braunschweig-evangelisch.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/braunschweig.html"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/propstei-gandersheim-seesen.json
+++ b/companies/propstei-gandersheim-seesen.json
@@ -1,0 +1,23 @@
+{
+    "slug": "propstei-gandersheim-seesen",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Propstei Gandersheim-Seesen",
+    "address": "Hinter der Kirche 1 A\n38723 Seesen\nDeutschland",
+    "phone": "+49 5381 942920",
+    "fax": "+49 5381 942922",
+    "email": "gandersheim-seesen.pr@lk-bs.de",
+    "web": "http://www.propstei-gandersheim-seesen.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/gandersheim-seesen.html"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/propstei-goslar.json
+++ b/companies/propstei-goslar.json
@@ -1,0 +1,23 @@
+{
+    "slug": "propstei-goslar",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Propstei Goslar",
+    "address": "Kaiserbleek 4\n38640 Goslar\nDeutschland",
+    "phone": "+49 5321 22921",
+    "fax": "+49 5321 41979",
+    "email": "goslar.pr@lk-bs.de",
+    "web": "http://www.propsteigoslar.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/goslar.html"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/propstei-helmstedt.json
+++ b/companies/propstei-helmstedt.json
@@ -1,0 +1,23 @@
+{
+    "slug": "propstei-helmstedt",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Propstei Helmstedt",
+    "address": "Großer Kirchhof 6\n38350 Helmstedt\nDeutschland",
+    "phone": "+49 5351 2093",
+    "fax": "+49 5351 2094",
+    "email": "helmstedt.pr@lk-bs.de",
+    "web": "http://www.propstei-helmstedt.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/helmstedt.html"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/propstei-koenigslutter.json
+++ b/companies/propstei-koenigslutter.json
@@ -1,0 +1,22 @@
+{
+    "slug": "propstei-koenigslutter",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Propstei Königslutter",
+    "address": "An der Stadtkirche 6\n38154 Königslutter am Elm\nDeutschland",
+    "phone": "+49 5353 95170",
+    "email": "koenigslutter.pr@lk-bs.de",
+    "web": "http://www.propstei-koenigslutter.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/koenigslutter.html"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/propstei-salzgitter-bad.json
+++ b/companies/propstei-salzgitter-bad.json
@@ -1,0 +1,23 @@
+{
+    "slug": "propstei-salzgitter-bad",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Propstei Salzgitter-Bad",
+    "address": "Oderwaldstraße 5\n38312 Flöthe\nDeutschland",
+    "phone": "+49 5341 32090",
+    "fax": "+49 5341 32065",
+    "email": "salzgitter-bad.pr@lk-bs.de",
+    "web": "http://www.propstei-salzgitter-bad.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/salzgitter-bad.html"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/propstei-salzgitter-lebenstedt.json
+++ b/companies/propstei-salzgitter-lebenstedt.json
@@ -1,0 +1,23 @@
+{
+    "slug": "propstei-salzgitter-lebenstedt",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Propstei Salzgitter-Lebenstedt",
+    "address": "Schumannstraße 1\n38226 Salzgitter\nDeutschland",
+    "phone": "+49 5341 846811",
+    "fax": "+49 5341 846888",
+    "email": "sz-lebenstedt.pr@lk-bs.de",
+    "web": "http://www.propstei-lebenstedt.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/salzgitter-lebenstedt.html"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/propstei-schoeppenstedt.json
+++ b/companies/propstei-schoeppenstedt.json
@@ -1,0 +1,23 @@
+{
+    "slug": "propstei-schoeppenstedt",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Propstei Schöppenstedt",
+    "address": "An der Kirche 1\n38170 Schöppenstedt\nDeutschland",
+    "phone": "+49 5332 968030",
+    "fax": "+49 5332 968033",
+    "email": "schoeppenstedt.pr@lk-bs.de",
+    "web": "http://www.propstei-schoeppenstedt.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/schoeppenstedt.html"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/propstei-vechelde.json
+++ b/companies/propstei-vechelde.json
@@ -1,0 +1,23 @@
+{
+    "slug": "propstei-vechelde",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Propstei Vechelde",
+    "address": "Peiner Straße 7 A\n38159 Vechelde\nDeutschland",
+    "phone": "+49 5302 1466",
+    "fax": "+49 5302 6578",
+    "email": "vechelde.pr@lk-bs.de",
+    "web": "http://www.propstei-vechelde.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/vechelde.html"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/propstei-vorsfelde.json
+++ b/companies/propstei-vorsfelde.json
@@ -1,0 +1,23 @@
+{
+    "slug": "propstei-vorsfelde",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Propstei Vorsfelde",
+    "address": "An der Propstei 2\n38448 Wolfsburg\nDeutschland",
+    "phone": "+49 5363 73064",
+    "fax": "+49 5363 73285",
+    "email": "vorsfelde.pr@lk-bs.de",
+    "web": "https://www.propstei-vorsfelde.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/vorsfelde.html"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/propstei-wolfenbuettel.json
+++ b/companies/propstei-wolfenbuettel.json
@@ -1,0 +1,23 @@
+{
+    "slug": "propstei-wolfenbuettel",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Propstei Wolfenbüttel",
+    "address": "Neuer Weg 90\n38302 Wolfenbüttel\nDeutschland",
+    "phone": "+49 5331 972830",
+    "fax": "+49 5331 972838",
+    "email": "wolfenbuettel.pr@lk-bs.de",
+    "web": "http://www.propstei-wf.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/wolfenbuettel.html"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/st-johannes-kirchengemeinde-kaestorf-warmenau-in-wolfsburg.json
+++ b/companies/st-johannes-kirchengemeinde-kaestorf-warmenau-in-wolfsburg.json
@@ -1,0 +1,22 @@
+{
+    "slug": "st-johannes-kirchengemeinde-kaestorf-warmenau-in-wolfsburg",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "St. Johannes-Kirchengemeinde Kästorf/Warmenau in Wolfsburg",
+    "address": "Im Wiesengrund 19\n38448 Wolfsburg\nDeutschland",
+    "phone": "+49 5361 61441",
+    "email": "johannes-kaestorf.buero@lk-bs.de",
+    "web": "http://www.kirche-kaestorf.de/",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1038"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/companies/stiftskirchengemeinde-bad-gandersheim.json
+++ b/companies/stiftskirchengemeinde-bad-gandersheim.json
@@ -1,0 +1,22 @@
+{
+    "slug": "stiftskirchengemeinde-bad-gandersheim",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "church"
+    ],
+    "name": "Stiftskirchengemeinde Bad Gandersheim",
+    "address": "Stiftsfreiheit 1\n37581 Bad Gandersheim\nDeutschland",
+    "phone": "+49 5382 2714",
+    "fax": "+49 5382 790416",
+    "email": "gandersheim.pfa@lk-bs.de",
+    "sources": [
+        "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=678"
+    ],
+    "custom-access-template": "access-evangelische-kirche",
+    "custom-erasure-template": "erasure-evangelische-kirche",
+    "custom-rectification-template": "rectification-evangelische-kirche",
+    "quality": "scraped",
+    "facet-group": "church"
+}

--- a/schema.json
+++ b/schema.json
@@ -28,7 +28,7 @@
             "uniqueItems": true,
             "items": {
                 "type": "string",
-                "enum": [ "addresses", "ads", "collection agency", "commerce", "credit agency", "entertainment", "finance", "health", "insurance", "nonprofit", "political party", "public body", "school", "social media", "telecommunication", "travel", "utility" ]
+                "enum": [ "addresses", "ads", "church", "collection agency", "commerce", "credit agency", "entertainment", "finance", "health", "insurance", "nonprofit", "political party", "public body", "school", "social media", "telecommunication", "travel", "utility" ]
             }
         },
         "name": {


### PR DESCRIPTION
This needs to be merged after datenanfragen/website#451.

---

This data was automatically scraped using the script in the datenanfragen/data-imports repository.

The data was scraped from the subpages of this website:  
<https://www.landeskirche-braunschweig.de/gemeinden/propsteien/>

A handful of email addresses containing personal data were manually swapped out.  
In addition, the email addresses for the "Propsteien" were added manually as they are 'protected' on the site and it didn't make sense to automate this process considering there are only twelve of them.