### PR TITLE
Explicitly state that the protocol is needed in the schema

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -84,7 +84,7 @@
         "web": {
             "type": "string",
             "title": "Website",
-            "description": "The company's main website.",
+            "description": "The company's main website. Include the protocol, i.e. 'https://'.",
             "format": "uri"
         },
         "sources": {

--- a/schema.json
+++ b/schema.json
@@ -84,7 +84,7 @@
         "web": {
             "type": "string",
             "title": "Website",
-            "description": "The company's main website. Include the protocol, i.e. 'https://'.",
+            "description": "The company's main website. Include the protocol, e.g. `https://`.",
             "format": "uri"
         },
         "sources": {


### PR DESCRIPTION
This makes the tooltip a bit more useful.
This is the old one:
![image](https://user-images.githubusercontent.com/45886910/96992276-f0a32c00-1529-11eb-8943-93315cd65a7a.png)

If you don't have the technical knowledge you might be confused why this is wrong. 

If we don't want something like this in the schema we could change the suggest-UI.
