### PR TITLE
Added corona-anmeldung and BarCov

### DIFF
--- a/companies/barcov-de.json
+++ b/companies/barcov-de.json
@@ -1,0 +1,18 @@
+{
+    "slug": "barcov-de",
+    "relevant-countries": [
+        "de"
+    ],
+    "name": "KnowHau Burkhard Hau Media e.K.",
+    "runs": [
+        "BarCov"
+    ],
+    "address": "Polcherstraße 48\n56727 Mayen",
+    "phone": "+49 174 3977138",
+    "email": "support@barcov.id",
+    "web": "https://barcov.id",
+    "sources": [
+        "https://barcov.id/privacypolicy"
+    ],
+    "quality": "verified"
+}

--- a/companies/barcov-de.json
+++ b/companies/barcov-de.json
@@ -7,7 +7,7 @@
     "runs": [
         "BarCov"
     ],
-    "address": "Polcherstraße 48\n56727 Mayen",
+    "address": "Polcherstraße 48\n56727 Mayen\nDeutschland",
     "phone": "+49 174 3977138",
     "email": "support@barcov.id",
     "web": "https://barcov.id",

--- a/companies/barcov-de.json
+++ b/companies/barcov-de.json
@@ -7,12 +7,13 @@
     "runs": [
         "BarCov"
     ],
-    "address": "Polcherstraße 48\n56727 Mayen\nDeutschland",
-    "phone": "+49 174 3977138",
+    "address": "Kolpingstrasse 36\n56729 Ettringen\nDeutschland",
+    "phone": "+49 6742 8289977",
     "email": "support@barcov.id",
     "web": "https://barcov.id",
     "sources": [
-        "https://barcov.id/privacypolicy"
+        "https://barcov.id/privacypolicy",
+        "https://barcov.id/impressum"
     ],
     "quality": "verified"
 }

--- a/companies/corona-anmeldung.json
+++ b/companies/corona-anmeldung.json
@@ -1,0 +1,23 @@
+{
+    "slug": "corona-anmeldung",
+    "relevant-countries": [
+        "at",
+        "de",
+        "ch"
+    ],
+    "categories": [
+        "health"
+    ],
+    "name": "Krola Consulting GmbH",
+    "runs": [
+        "corona-anmeldung.at",
+        "corona-anmeldung.de"
+    ],
+    "address": "Nördliche Münchner Str. 47\n82031 Grünwald\nDeutschland",
+	"email": "info@corona-anmeldung.de",
+    "web": "https://corona-anmeldung.at",
+    "sources": [
+        "https://corona-anmeldung.at/imprint"
+    ],
+    "quality": "verified"
+}


### PR DESCRIPTION
Small problem with BarCov:

The "verantwortliche Stelle " is given with name in the [PP](https://barcov.id/privacypolicy) and has a completly different address than the [company](https://barcov.id/impressum) itself. 

How do we make sure that letters arrive without storing the name in this repo?