### PR TITLE
Add 'Chase Debt Ltd' (community contribution)

### DIFF
--- a/companies/chasedebt-co.json
+++ b/companies/chasedebt-co.json
@@ -1,0 +1,24 @@
+{
+    "slug": "chasedebt-co",
+    "relevant-countries": [
+        "gb"
+    ],
+    "categories": [
+        "finance"
+    ],
+    "name": "Chase Debt Ltd",
+    "address": "1st Floor, 54 Watling Street Radlett, Hertfordshire",
+    "phone": "0203 780 7141",
+    "email": " info@chasedebt.co.uk",
+    "web": "https://chasedebt.co.uk/",
+    "sources": [
+        "https://chasedebt.co.uk/",
+        "https://github.com/datenanfragen/data/pull/821"
+    ],
+    "needs-id-document": true,
+    "suggested-transport-medium": "email",
+    "comments": [
+        "Chase Debt will provide you all the services you need to recover what’s owed to you beginning with tracing a debtor who has absconded, to assisting you issue proceeding and enforcing a judgment in your favour, whether you are an individual or business, we can definitely help you."
+    ],
+    "quality": "verified"
+}

--- a/companies/chasedebt-co.json
+++ b/companies/chasedebt-co.json
@@ -7,18 +7,14 @@
         "finance"
     ],
     "name": "Chase Debt Ltd",
-    "address": "1st Floor, 54 Watling Street Radlett, Hertfordshire",
-    "phone": "0203 780 7141",
-    "email": " info@chasedebt.co.uk",
+    "address": "1st Floor\n54 Watling Street Radlett\nHertfordshire\nUnited Kingdom",
+    "phone": "+44 20 3780 7141",
+    "email": "info@chasedebt.co.uk",
     "web": "https://chasedebt.co.uk/",
     "sources": [
         "https://chasedebt.co.uk/",
         "https://github.com/datenanfragen/data/pull/821"
     ],
-    "needs-id-document": true,
     "suggested-transport-medium": "email",
-    "comments": [
-        "Chase Debt will provide you all the services you need to recover what’s owed to you beginning with tracing a debtor who has absconded, to assisting you issue proceeding and enforcing a judgment in your favour, whether you are an individual or business, we can definitely help you."
-    ],
     "quality": "verified"
 }


### PR DESCRIPTION
This suggestion was submitted through the website.

**[Edit](https://company-json.netlify.com/#!doc=%7B%22slug%22%3A%22chasedebt-co%22%2C%22relevant-countries%22%3A%5B%22gb%22%5D%2C%22categories%22%3A%5B%22finance%22%5D%2C%22name%22%3A%22Chase%20Debt%20Ltd%22%2C%22address%22%3A%221st%20Floor%2C%2054%20Watling%20Street%20Radlett%2C%20Hertfordshire%22%2C%22phone%22%3A%220203%20780%207141%22%2C%22email%22%3A%22%20info%40chasedebt.co.uk%22%2C%22web%22%3A%22https%3A%2F%2Fchasedebt.co.uk%2F%22%2C%22sources%22%3A%5B%22https%3A%2F%2Fchasedebt.co.uk%2F%22%2C%22https%3A%2F%2Fgithub.com%2Fdatenanfragen%2Fdata%2Fpull%2F821%22%5D%2C%22needs-id-document%22%3Atrue%2C%22suggested-transport-medium%22%3A%22email%22%2C%22comments%22%3A%5B%22Chase%20Debt%20will%20provide%20you%20all%20the%20services%20you%20need%20to%20recover%20what%E2%80%99s%20owed%20to%20you%20beginning%20with%20tracing%20a%20debtor%20who%20has%20absconded%2C%20to%20assisting%20you%20issue%20proceeding%20and%20enforcing%20a%20judgment%20in%20your%20favour%2C%20whether%20you%20are%20an%20individual%20or%20business%2C%20we%20can%20definitely%20help%20you.%22%5D%2C%22quality%22%3A%22verified%22%7D)**