### PR TITLE
Add 'Südtiroler Sparkasse AG Niederlassung München' (community contribution)

### DIFF
--- a/companies/suedspa-de.json
+++ b/companies/suedspa-de.json
@@ -1,5 +1,5 @@
 {
-    "slug": "suedspa",
+    "slug": "suedspa-de",
     "relevant-countries": [
         "de"
     ],
@@ -7,14 +7,15 @@
         "finance"
     ],
     "name": "Südtiroler Sparkasse AG Niederlassung München",
-    "address": "Gaißacher Straße 18\n81371 München",
+    "address": "Gaißacher Straße 18\n81371 München\nDeutschland",
     "phone": "+49 89 59944350",
     "fax": "+49 89 599443599",
-    "email": "datenschutz@suedspa.de ",
+    "email": "Datenschutz@suedspa.de",
     "web": "https://www.suedspa.de/",
     "sources": [
         "https://www.suedspa.de/de/information/datenschutz/6-0.html",
         "https://github.com/datenanfragen/data/pull/830"
     ],
+    "suggested-transport-medium": "email",
     "quality": "verified"
 }

--- a/companies/suedspa.json
+++ b/companies/suedspa.json
@@ -1,0 +1,20 @@
+{
+    "slug": "suedspa",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "finance"
+    ],
+    "name": "Südtiroler Sparkasse AG Niederlassung München",
+    "address": "Gaißacher Straße 18\n81371 München",
+    "phone": "+49 89 59944350",
+    "fax": "+49 89 599443599",
+    "email": "datenschutz@suedspa.de ",
+    "web": "https://www.suedspa.de/",
+    "sources": [
+        "https://www.suedspa.de/de/information/datenschutz/6-0.html",
+        "https://github.com/datenanfragen/data/pull/830"
+    ],
+    "quality": "verified"
+}


### PR DESCRIPTION
This suggestion was submitted through the website.

**[Edit](https://company-json.netlify.com/#!doc=%7B%22slug%22%3A%22suedspa%22%2C%22relevant-countries%22%3A%5B%22de%22%5D%2C%22categories%22%3A%5B%22finance%22%5D%2C%22name%22%3A%22S%C3%BCdtiroler%20Sparkasse%20AG%20Niederlassung%20M%C3%BCnchen%22%2C%22address%22%3A%22Gai%C3%9Facher%20Stra%C3%9Fe%2018%5Cn81371%20M%C3%BCnchen%22%2C%22phone%22%3A%22%2B49%2089%2059944350%22%2C%22fax%22%3A%22%2B49%2089%20599443599%22%2C%22email%22%3A%22datenschutz%40suedspa.de%20%22%2C%22web%22%3A%22https%3A%2F%2Fwww.suedspa.de%2F%22%2C%22sources%22%3A%5B%22https%3A%2F%2Fwww.suedspa.de%2Fde%2Finformation%2Fdatenschutz%2F6-0.html%22%2C%22https%3A%2F%2Fgithub.com%2Fdatenanfragen%2Fdata%2Fpull%2F830%22%5D%2C%22quality%22%3A%22verified%22%7D)**