### PR TITLE
Update 'Sony Interactive Entertainment Europe Limited' (community contribution)

### DIFF
--- a/companies/playstation-com.json
+++ b/companies/playstation-com.json
@@ -13,11 +13,12 @@
         "Sony Interactive Entertainment Network Europe Limited"
     ],
     "address": "10 Great Marlborough Street\nLondon\nW1F 7LP\nUnited Kingdom",
-    "email": "dpo@scee.net",
+    "email": "siee.dpo@sony.com",
     "web": "https://www.playstation.com/",
     "sources": [
         "https://www.playstation.com/legal/privacy-policy/",
-        "https://github.com/datenanfragen/data/issues/649"
+        "https://github.com/datenanfragen/data/issues/649",
+        "https://github.com/datenanfragen/data/pull/849"
     ],
     "suggested-transport-medium": "email",
     "quality": "verified"


### PR DESCRIPTION
This suggestion was submitted through the website.

**[Edit](https://company-json.netlify.com/#!doc=%7B%22slug%22%3A%22playstation-com%22%2C%22relevant-countries%22%3A%5B%22all%22%5D%2C%22categories%22%3A%5B%22entertainment%22%5D%2C%22name%22%3A%22Sony%20Interactive%20Entertainment%20Europe%20Limited%22%2C%22runs%22%3A%5B%22My%20Playstation%22%2C%22PlayStation%20Network%22%2C%22Sony%20Interactive%20Entertainment%20Network%20Europe%20Limited%22%5D%2C%22address%22%3A%2210%20Great%20Marlborough%20Street%5CnLondon%5CnW1F%207LP%5CnUnited%20Kingdom%22%2C%22email%22%3A%22siee.dpo%40sony.com%22%2C%22web%22%3A%22https%3A%2F%2Fwww.playstation.com%2F%22%2C%22sources%22%3A%5B%22https%3A%2F%2Fwww.playstation.com%2Flegal%2Fprivacy-policy%2F%22%2C%22https%3A%2F%2Fgithub.com%2Fdatenanfragen%2Fdata%2Fissues%2F649%22%2C%22https%3A%2F%2Fgithub.com%2Fdatenanfragen%2Fdata%2Fpull%2F849%22%5D%2C%22suggested-transport-medium%22%3A%22email%22%2C%22quality%22%3A%22verified%22%7D)**