### PR TITLE
Update 'Valve GmbH' (community contribution)

### DIFF
--- a/companies/steam.json
+++ b/companies/steam.json
@@ -14,11 +14,12 @@
     ],
     "address": "Rödingsmarkt 9\n20354 Hamburg\nGermany",
     "email": "questions@valvesoftware.com",
-    "web": "https://store.steampowered.com/",
+    "web": "https://www.valvesoftware.com/",
     "sources": [
         "https://store.steampowered.com/privacy_agreement/",
-        "http://www.valvesoftware.com/contact/",
-        "https://www.privacyshield.gov/participant?id=a2zt0000000TO5UAAW&status=Active"
+        "https://www.valvesoftware.com/contact/",
+        "https://www.privacyshield.gov/participant?id=a2zt0000000TO5UAAW&status=Active",
+        "https://github.com/datenanfragen/data/pull/854"
     ],
     "request-language": "en",
     "comments": [


### PR DESCRIPTION
This suggestion was submitted through the website.

**[Edit](https://company-json.netlify.com/#!doc=%7B%22slug%22%3A%22steam%22%2C%22relevant-countries%22%3A%5B%22all%22%5D%2C%22categories%22%3A%5B%22entertainment%22%5D%2C%22name%22%3A%22Valve%20GmbH%22%2C%22runs%22%3A%5B%22Steam%20(store.steampowered.com)%22%2C%22Valve%20Corporation%22%2C%22Valve%20S.a.r.l.%22%5D%2C%22address%22%3A%22R%C3%B6dingsmarkt%209%5Cn20354%20Hamburg%5CnGermany%22%2C%22email%22%3A%22questions%40valvesoftware.com%22%2C%22web%22%3A%22https%3A%2F%2Fwww.valvesoftware.com%2F%22%2C%22sources%22%3A%5B%22https%3A%2F%2Fstore.steampowered.com%2Fprivacy_agreement%2F%22%2C%22https%3A%2F%2Fwww.valvesoftware.com%2Fcontact%2F%22%2C%22https%3A%2F%2Fwww.privacyshield.gov%2Fparticipant%3Fid%3Da2zt0000000TO5UAAW%26status%3DActive%22%2C%22https%3A%2F%2Fgithub.com%2Fdatenanfragen%2Fdata%2Fpull%2F854%22%5D%2C%22request-language%22%3A%22en%22%2C%22comments%22%3A%5B%22According%20to%20the%20privacy%20policy%2C%20Valve%20GmbH%20is%20the%20EU%20representative.%20Address%20of%20Valve%20Corp.%3A%20P.O.%20Box%201688%5CnBellevue%5CnWA%2098009%5CnUnited%20States%20of%20America%22%5D%2C%22quality%22%3A%22verified%22%7D)**