### PR TITLE
Add companies to cover Alexa Top 25 sites in germany

### DIFF
--- a/companies/bongacams-com.json
+++ b/companies/bongacams-com.json
@@ -3,11 +3,14 @@
     "relevant-countries": [
         "all"
     ],
-	"categories": [
-        "ads"
+    "categories": [
+        "entertainment"
     ],
-    "name": "PROWEB PROGRESSIVE DEVELOPMENT LTD",
-    "address": "5A Athinas\n2480 Tseri\nCyperus",
+    "name": "Proweb Progressive Development Ltd.",
+    "runs": [
+        "BongaCams.com"
+    ],
+    "address": "5A Athinas\n2480 Tseri\nCyprus",
     "email": "support@bongacams.com",
     "web": "https://www.bongacams.com",
     "sources": [

--- a/companies/bongacams-com.json
+++ b/companies/bongacams-com.json
@@ -1,0 +1,17 @@
+{
+    "slug": "bongacams-com",
+    "relevant-countries": [
+        "all"
+    ],
+	"categories": [
+        "ads"
+    ],
+    "name": "PROWEB PROGRESSIVE DEVELOPMENT LTD",
+    "address": "5A Athinas\n2480 Tseri\nCyperus",
+    "email": "support@bongacams.com",
+    "web": "https://www.bongacams.com",
+    "sources": [
+        "https://de.bongacams.com/privacy"
+    ],
+    "quality": "verified"
+}

--- a/companies/chaturbate-com.json
+++ b/companies/chaturbate-com.json
@@ -3,11 +3,15 @@
     "relevant-countries": [
         "all"
     ],
-	"categories": [
-        "ads"
+    "categories": [
+        "entertainment"
     ],
     "name": "Multi Media, LLC",
-    "address": "c/o Grizzly Empire Ltd\nUnit 4 Studios\n100 Bradford Road\nDewsbury WF13 2EF\nUnited Kingdom",
+    "runs": [
+        "Chaturbate.com"
+    ],
+    "address": "c/o Grizzly Empire Ltd.\nUnit 4 Studios\n100 Bradford Road\nDewsbury WF13 2EF\nUnited Kingdom",
+    "phone": "+1 877 338 7068",
     "email": "privacyquestions@chaturbate.com",
     "web": "https://chaturbate.com",
     "sources": [

--- a/companies/chaturbate-com.json
+++ b/companies/chaturbate-com.json
@@ -1,0 +1,18 @@
+{
+    "slug": "chaturbate-com",
+    "relevant-countries": [
+        "all"
+    ],
+	"categories": [
+        "ads"
+    ],
+    "name": "Multi Media, LLC",
+    "address": "c/o Grizzly Empire Ltd\nUnit 4 Studios\n100 Bradford Road\nDewsbury WF13 2EF\nUnited Kingdom",
+    "email": "privacyquestions@chaturbate.com",
+    "web": "https://chaturbate.com",
+    "sources": [
+        "https://chaturbate.com/privacy/"
+    ],
+    "suggested-transport-medium": "email",
+    "quality": "verified"
+}

--- a/companies/duodecad-it-services.json
+++ b/companies/duodecad-it-services.json
@@ -1,0 +1,24 @@
+{
+    "slug": "duodecad-it-services",
+    "relevant-countries": [
+        "all"
+    ],
+    "categories": [
+        "ads"
+    ],
+    "name": "Duodecad IT Services Luxembourg S.à.r.l.",
+    "runs": [
+        "Livejasmin.com"
+    ],
+    "address": "c/o Docler Holding S.à r.l.\n44 Avenue John F. Kennedy\nL-1855, Luxembourg\nLuxembourg",
+    "phone": "+352 26 11 18 1",
+    "email": "dpo@doclerholding.com",
+    "sources": [
+        "https://www.livejasmin.com",
+        "https://www.doclerholding.com/en/about/companies/39/",
+        "https://www.doclerholding.com/en/about/contact/",
+        "https://www.doclerholding.com/en/policy/"
+    ],
+    "suggested-transport-medium": "email",
+    "quality": "verified"
+}

--- a/companies/duodecad-it-services.json
+++ b/companies/duodecad-it-services.json
@@ -4,20 +4,22 @@
         "all"
     ],
     "categories": [
-        "ads"
+        "entertainment"
     ],
     "name": "Duodecad IT Services Luxembourg S.à.r.l.",
     "runs": [
-        "Livejasmin.com"
+        "Livejasmin.com",
+        "Jasmin IP S.à r.l.",
+        "Docler Services S.à r.l.",
+        "Docler IP S.à r.l.",
+        "Docler SSC Kft",
+        "Escalion S.à r.l."
     ],
-    "address": "c/o Docler Holding S.à r.l.\n44 Avenue John F. Kennedy\nL-1855, Luxembourg\nLuxembourg",
+    "address": "44 Avenue John F. Kennedy\nL-1855, Luxembourg\nLuxembourg",
     "phone": "+352 26 11 18 1",
-    "email": "dpo@doclerholding.com",
+    "email": "dpo@livejasmin.com",
     "sources": [
-        "https://www.livejasmin.com",
-        "https://www.doclerholding.com/en/about/companies/39/",
-        "https://www.doclerholding.com/en/about/contact/",
-        "https://www.doclerholding.com/en/policy/"
+        "https://www.livejasmin.com/en/privacy-policy"
     ],
     "suggested-transport-medium": "email",
     "quality": "verified"

--- a/companies/ebay-kleinanzeigen-gmbh.json
+++ b/companies/ebay-kleinanzeigen-gmbh.json
@@ -9,10 +9,12 @@
     ],
     "name": "eBay Kleinanzeigen GmbH",
     "address": "Albert-Einstein-Ring 2-6\n14532 Kleinmachnow Dreilinden\nDeutschland",
+    "fax": "+49 30 308324531",
     "email": "datenschutz@ebay-kleinanzeigen.de",
     "web": "https://www.ebay-kleinanzeigen.de",
     "sources": [
-        "https://themen.ebay-kleinanzeigen.de/datenschutzerklaerung/#3_datenschutzbeauftragte"
+        "https://themen.ebay-kleinanzeigen.de/datenschutzerklaerung/",
+        "https://www.ebay-kleinanzeigen.de/impressum.html"
     ],
     "suggested-transport-medium": "email",
     "quality": "verified"

--- a/companies/ebay-kleinanzeigen-gmbh.json
+++ b/companies/ebay-kleinanzeigen-gmbh.json
@@ -1,0 +1,19 @@
+{
+    "slug": "ebay-kleinanzeigen-gmbh",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "commerce",
+        "ads"
+    ],
+    "name": "eBay Kleinanzeigen GmbH",
+    "address": "Albert-Einstein-Ring 2-6\n14532 Kleinmachnow Dreilinden\nDeutschland",
+    "email": "datenschutz@ebay-kleinanzeigen.de",
+    "web": "https://www.ebay-kleinanzeigen.de",
+    "sources": [
+        "https://themen.ebay-kleinanzeigen.de/datenschutzerklaerung/#3_datenschutzbeauftragte"
+    ],
+    "suggested-transport-medium": "email",
+    "quality": "verified"
+}

--- a/companies/stroeer-digital-publishing.json
+++ b/companies/stroeer-digital-publishing.json
@@ -4,6 +4,7 @@
         "de"
     ],
     "categories": [
+        "ads",
         "entertainment"
     ],
     "name": "Ströer Digital Publishing GmbH",
@@ -12,7 +13,7 @@
     ],
     "address": "Platz der Einheit 1\n60327 Frankfurt\nDeutschland",
     "phone": "+49 69 921017610",
-    "email": "datenschutzbeauftragter@stroeer.de",
+    "email": "sdp-datenschutz@stroeer.de",
     "web": "https://www.t-online.de",
     "sources": [
         "https://www.t-online.de/datenschutz/",

--- a/companies/stroeer-digital-publishing.json
+++ b/companies/stroeer-digital-publishing.json
@@ -1,0 +1,23 @@
+{
+    "slug": "stroeer-digital-publishing",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "entertainment"
+    ],
+    "name": "Ströer Digital Publishing GmbH",
+    "runs": [
+        "t-online.de"
+    ],
+    "address": "Platz der Einheit 1\n60327 Frankfurt\nDeutschland",
+    "phone": "+49 69 921017610",
+    "email": "datenschutzbeauftragter@stroeer.de",
+    "web": "https://www.t-online.de",
+    "sources": [
+        "https://www.t-online.de/datenschutz/",
+        "https://www.t-online.de/impressum/id_12511434/index"
+    ],
+    "suggested-transport-medium": "email",
+    "quality": "verified"
+}


### PR DESCRIPTION
- Add bongacams, duodecad, stöer, ebay-kleinanzeigen, and chaturbate
