### PR TITLE
Add 'Stripe Inc.' (community contribution)

### DIFF
--- a/companies/stripe-inc.json
+++ b/companies/stripe-inc.json
@@ -1,0 +1,18 @@
+{
+    "slug": "stripe-inc",
+    "relevant-countries": [
+        "all"
+    ],
+    "categories": [
+        "finance"
+    ],
+    "name": "Stripe Inc.",
+    "address": "510 Townsend Street\nSan Francisco\nCA 94103\nUSA",
+    "email": "privacy@stripe.com",
+    "sources": [
+        "https://stripe.com/de/privacy",
+        "https://github.com/datenanfragen/data/pull/888"
+    ],
+    "suggested-transport-medium": "email",
+    "quality": "verified"
+}

--- a/companies/stripe.json
+++ b/companies/stripe.json
@@ -1,5 +1,5 @@
 {
-    "slug": "stripe-inc",
+    "slug": "stripe",
     "relevant-countries": [
         "all"
     ],


### PR DESCRIPTION
This suggestion was submitted through the website.

**[Edit](https://company-json.netlify.com/#!doc=%7B%22slug%22%3A%22stripe-inc%22%2C%22relevant-countries%22%3A%5B%22all%22%5D%2C%22categories%22%3A%5B%22finance%22%5D%2C%22name%22%3A%22Stripe%20Inc.%22%2C%22address%22%3A%22510%20Townsend%20Street%5CnSan%20Francisco%5CnCA%2094103%5CnUSA%22%2C%22email%22%3A%22privacy%40stripe.com%22%2C%22sources%22%3A%5B%22https%3A%2F%2Fstripe.com%2Fde%2Fprivacy%22%2C%22https%3A%2F%2Fgithub.com%2Fdatenanfragen%2Fdata%2Fpull%2F888%22%5D%2C%22suggested-transport-medium%22%3A%22email%22%2C%22quality%22%3A%22verified%22%7D)**