### PR TITLE
Update 'MEDION AG' (community contribution)

### DIFF
--- a/companies/medion.json
+++ b/companies/medion.json
@@ -1,5 +1,8 @@
 {
     "slug": "medion",
+    "relevant-countries": [
+        "de"
+    ],
     "categories": [
         "commerce"
     ],
@@ -10,22 +13,21 @@
         "MEDIONmobile"
     ],
     "address": "Am Zehnthof 77\n45307 Essen\nDeutschland",
-    "phone": "+49 201 83 83 0",
-    "fax": "+49 201 83 83 1112",
+    "phone": "+49 201 83830",
+    "fax": "+49 201 83831112",
     "email": "datenschutz@medion.com",
     "web": "https://www.medion.com/de/shop/",
     "sources": [
         "https://www.medion.com/de/shop/",
         "https://www.alditalk.de/datenschutz",
-        "https://www.alditalk.de/impressum"
-    ],
-    "comments": [
-        "Spezielle E-Mail-Adresse für den Webshop: datenschutz-webshop@medion.com",
-        "Spezielle E-Mail-Adresse für MEDIONmobile (ALDI Talk): datenschutz-alditalk@medion.com"
-    ],
-    "relevant-countries": [
-        "de"
+        "https://www.alditalk.de/impressum",
+        "https://github.com/datenanfragen/data/pull/889"
     ],
     "suggested-transport-medium": "email",
+    "comments": [
+        "Spezielle E-Mail-Adresse für den Webshop: datenschutz-webshop@medion.com",
+        "Spezielle E-Mail-Adresse für MEDIONmobile (ALDI Talk): datenschutz-alditalk@medion.com",
+        "eplus scheint für aldi talk zuständig zu seim"
+    ],
     "quality": "verified"
 }


### PR DESCRIPTION
This suggestion was submitted through the website.

**[Edit](https://company-json.netlify.com/#!doc=%7B%22slug%22%3A%22medion%22%2C%22relevant-countries%22%3A%5B%22de%22%5D%2C%22categories%22%3A%5B%22commerce%22%5D%2C%22name%22%3A%22MEDION%20AG%22%2C%22runs%22%3A%5B%22Medion%20Webshop%20(www.medion.com)%22%2C%22ALDI%20Talk%20(www.alditalk.de)%22%2C%22MEDIONmobile%22%5D%2C%22address%22%3A%22Am%20Zehnthof%2077%5Cn45307%20Essen%5CnDeutschland%22%2C%22phone%22%3A%22%2B49%20201%2083830%22%2C%22fax%22%3A%22%2B49%20201%2083831112%22%2C%22email%22%3A%22datenschutz%40medion.com%22%2C%22web%22%3A%22https%3A%2F%2Fwww.medion.com%2Fde%2Fshop%2F%22%2C%22sources%22%3A%5B%22https%3A%2F%2Fwww.medion.com%2Fde%2Fshop%2F%22%2C%22https%3A%2F%2Fwww.alditalk.de%2Fdatenschutz%22%2C%22https%3A%2F%2Fwww.alditalk.de%2Fimpressum%22%2C%22https%3A%2F%2Fgithub.com%2Fdatenanfragen%2Fdata%2Fpull%2F889%22%5D%2C%22suggested-transport-medium%22%3A%22email%22%2C%22comments%22%3A%5B%22Spezielle%20E-Mail-Adresse%20f%C3%BCr%20den%20Webshop%3A%20datenschutz-webshop%40medion.com%22%2C%22Spezielle%20E-Mail-Adresse%20f%C3%BCr%20MEDIONmobile%20(ALDI%20Talk)%3A%20datenschutz-alditalk%40medion.com%22%2C%22eplus%20scheint%20f%C3%BCr%20aldi%20talk%20zust%C3%A4ndig%20zu%20seim%22%5D%2C%22quality%22%3A%22verified%22%7D)**