### PR TITLE
Add 'Gameloft SE' (community contribution)

### DIFF
--- a/companies/gameloft.json
+++ b/companies/gameloft.json
@@ -7,7 +7,7 @@
         "entertainment"
     ],
     "name": "Gameloft SE",
-    "address": "14 rue Auber\n75009 Paris",
+    "address": "14 rue Auber\n75009 Paris\nFrance",
     "phone": "+33 1 53 16 20 40",
     "email": "DataProtectionSupport@gameloft.com",
     "web": "https://www.gameloft.com",
@@ -16,5 +16,6 @@
         "https://www.gameloft.com/de/information/legal-notices",
         "https://github.com/datenanfragen/data/pull/892"
     ],
+    "suggested-transport-medium": "email",
     "quality": "verified"
 }

--- a/companies/gameloft.json
+++ b/companies/gameloft.json
@@ -1,0 +1,20 @@
+{
+    "slug": "gameloft",
+    "relevant-countries": [
+        "all"
+    ],
+    "categories": [
+        "entertainment"
+    ],
+    "name": "Gameloft SE",
+    "address": "14 rue Auber\n75009 Paris",
+    "phone": "+33 1 53 16 20 40",
+    "email": "DataProtectionSupport@gameloft.com",
+    "web": "https://www.gameloft.com",
+    "sources": [
+        "https://www.gameloft.com/de/privacy-notice",
+        "https://www.gameloft.com/de/information/legal-notices",
+        "https://github.com/datenanfragen/data/pull/892"
+    ],
+    "quality": "verified"
+}


### PR DESCRIPTION
This suggestion was submitted through the website.

**[Edit](https://company-json.netlify.com/#!doc=%7B%22slug%22%3A%22gameloft%22%2C%22relevant-countries%22%3A%5B%22all%22%5D%2C%22categories%22%3A%5B%22entertainment%22%5D%2C%22name%22%3A%22Gameloft%20SE%22%2C%22address%22%3A%2214%20rue%20Auber%5Cn75009%20Paris%22%2C%22phone%22%3A%22%2B33%201%2053%2016%2020%2040%22%2C%22email%22%3A%22DataProtectionSupport%40gameloft.com%22%2C%22web%22%3A%22https%3A%2F%2Fwww.gameloft.com%22%2C%22sources%22%3A%5B%22https%3A%2F%2Fwww.gameloft.com%2Fde%2Fprivacy-notice%22%2C%22https%3A%2F%2Fwww.gameloft.com%2Fde%2Finformation%2Flegal-notices%22%2C%22https%3A%2F%2Fgithub.com%2Fdatenanfragen%2Fdata%2Fpull%2F892%22%5D%2C%22quality%22%3A%22verified%22%7D)**