### PR TITLE
Add 'Limburg.net' (community contribution)

### DIFF
--- a/companies/limburg-net.json
+++ b/companies/limburg-net.json
@@ -1,5 +1,5 @@
 {
-    "slug": "limburg",
+    "slug": "limburg-net",
     "relevant-countries": [
         "be"
     ],
@@ -7,13 +7,15 @@
         "utility"
     ],
     "name": "Limburg.net",
-    "address": "Gouverneur Verwilghensingel 32\n3500 Hasselt",
-    "phone": "011/28.89.89",
+    "address": "Gouverneur Verwilghensingel 32\n3500 Hasselt\nBelgium",
+    "phone": "+32 11 28 89 89",
     "email": "privacy@limburg.net",
     "web": "https://limburg.net",
     "sources": [
         "https://limburg.net/privacyverklaring",
         "https://github.com/datenanfragen/data/pull/908"
     ],
+    "request-language": "nl",
+    "suggested-transport-medium": "email",
     "quality": "verified"
 }

--- a/companies/limburg.json
+++ b/companies/limburg.json
@@ -1,0 +1,19 @@
+{
+    "slug": "limburg",
+    "relevant-countries": [
+        "be"
+    ],
+    "categories": [
+        "utility"
+    ],
+    "name": "Limburg.net",
+    "address": "Gouverneur Verwilghensingel 32\n3500 Hasselt",
+    "phone": "011/28.89.89",
+    "email": "privacy@limburg.net",
+    "web": "https://limburg.net",
+    "sources": [
+        "https://limburg.net/privacyverklaring",
+        "https://github.com/datenanfragen/data/pull/908"
+    ],
+    "quality": "verified"
+}


### PR DESCRIPTION
This suggestion was submitted through the website.

**[Edit](https://company-json.netlify.com/#!doc=%7B%22slug%22%3A%22limburg%22%2C%22relevant-countries%22%3A%5B%22be%22%5D%2C%22categories%22%3A%5B%22utility%22%5D%2C%22name%22%3A%22Limburg.net%22%2C%22address%22%3A%22Gouverneur%20Verwilghensingel%2032%5Cn3500%20Hasselt%22%2C%22phone%22%3A%22011%2F28.89.89%22%2C%22email%22%3A%22privacy%40limburg.net%22%2C%22web%22%3A%22https%3A%2F%2Flimburg.net%22%2C%22sources%22%3A%5B%22https%3A%2F%2Flimburg.net%2Fprivacyverklaring%22%2C%22https%3A%2F%2Fgithub.com%2Fdatenanfragen%2Fdata%2Fpull%2F908%22%5D%2C%22quality%22%3A%22verified%22%7D)**