### PR TITLE
Add 'Formula One Digital Media Limited' (community contribution)

### DIFF
--- a/companies/formula1.json
+++ b/companies/formula1.json
@@ -1,0 +1,23 @@
+{
+    "slug": "formula1",
+    "relevant-countries": [
+        "all"
+    ],
+    "categories": [
+        "entertainment"
+    ],
+    "name": "Formula One Digital Media Limited",
+    "runs": [
+        "Formula 1",
+        "F1 TV"
+    ],
+    "address": "No.2 St. James’s Market, London, SW1Y 4AH, England",
+    "email": "general@en.formula1.com",
+    "web": "https://www.formula1.com/",
+    "sources": [
+        "https://account.formula1.com/#/en/privacy-policy",
+        "https://github.com/datenanfragen/data/pull/913"
+    ],
+    "suggested-transport-medium": "email",
+    "quality": "verified"
+}

--- a/companies/formula1.json
+++ b/companies/formula1.json
@@ -11,13 +11,12 @@
         "Formula 1",
         "F1 TV"
     ],
-    "address": "No.2 St. James’s Market, London, SW1Y 4AH, England",
+    "address": "No.2 St. James’s Market\nLondon\nSW1Y 4AH\nUnited Kingdom",
     "email": "general@en.formula1.com",
     "web": "https://www.formula1.com/",
     "sources": [
         "https://account.formula1.com/#/en/privacy-policy",
         "https://github.com/datenanfragen/data/pull/913"
     ],
-    "suggested-transport-medium": "email",
     "quality": "verified"
 }


### PR DESCRIPTION
This suggestion was submitted through the website.

**[Edit](https://company-json.netlify.com/#!doc=%7B%22slug%22%3A%22formula1%22%2C%22relevant-countries%22%3A%5B%22all%22%5D%2C%22categories%22%3A%5B%22entertainment%22%5D%2C%22name%22%3A%22Formula%20One%20Digital%20Media%20Limited%22%2C%22runs%22%3A%5B%22Formula%201%22%2C%22F1%20TV%22%5D%2C%22address%22%3A%22No.2%20St.%20James%E2%80%99s%20Market%2C%20London%2C%20SW1Y%204AH%2C%20England%22%2C%22email%22%3A%22general%40en.formula1.com%22%2C%22web%22%3A%22https%3A%2F%2Fwww.formula1.com%2F%22%2C%22sources%22%3A%5B%22https%3A%2F%2Faccount.formula1.com%2F%23%2Fen%2Fprivacy-policy%22%2C%22https%3A%2F%2Fgithub.com%2Fdatenanfragen%2Fdata%2Fpull%2F913%22%5D%2C%22suggested-transport-medium%22%3A%22email%22%2C%22quality%22%3A%22verified%22%7D)**