### PR TITLE
Add 'Wolters Kluwer N.V.' (community contribution)

### DIFF
--- a/companies/wolterskluwer.json
+++ b/companies/wolterskluwer.json
@@ -1,24 +1,31 @@
 {
     "slug": "wolterskluwer",
     "relevant-countries": [
-        "de"
+        "all"
     ],
     "categories": [
-        "commerce"
+        "health",
+        "school",
+        "social media"
     ],
-    "name": "Wolterskluwer Deutschland GmbH",
+    "name": "Wolters Kluwer N.V.",
     "runs": [
-        "Akademische Arbeitsgemeinschaft Verlagsgesellschaft mbH"
+        "https://www.wolterskluwer.com/en/privacy-cookies/inquiry"
     ],
-    "address": "c/o TÜV IT, IT Security & Privacy\nLangemarckstr. 20\n45141 Essen\nDeutschland",
-    "phone": "+49 201 8999899",
-    "fax": "+49 201 8999666",
-    "email": "dsb@wolterskluwer.com",
-    "web": "https://www.wolterskluwer.de",
+    "address": "Data Privacy Officer\nWolters Kluwer N.V.,\nP.O. Box 1030, 2400 BA,\nAlphen aan den Rijn,\nThe Netherlands\n\nData Privacy Officer Contact Form\nhttps://www.wolterskluwer.com/en/privacy-cookies/inquiry",
+    "phone": "1-301-223-2300",
+    "email": "healthlrp_privacy@wolterskluwer.com",
+    "web": "https://www.wolterskluwer.com",
     "sources": [
-        "https://www.wolterskluwer.de/datenschutz/",
-        "https://www.steuertipps.de/datenschutz",
-        "https://github.com/datenanfragen/data/issues/445"
+        "https://www.wolterskluwer.com/en/privacy-cookies",
+        "https://journals.lww.com/_layouts/15/oaks.journals/privacy.aspx#section12",
+        "https://www.wolterskluwer.com/en/privacy-cookies/inquiry",
+        "https://github.com/datenanfragen/data/pull/922"
+    ],
+    "needs-id-document": false,
+    "suggested-transport-medium": "email",
+    "comments": [
+        "Wolters Kluwer N.V. operates medical journals and other journals. They will resell your information repeatedly. \n\nWant to see how many websites or services they operate where they suck in your data? Click on https://www.wolterskluwer.com/en/privacy-cookies/inquiry As of Jan 2021 its over 100."
     ],
     "quality": "verified"
 }


### PR DESCRIPTION
This suggestion was submitted through the website.

**[Edit](https://company-json.netlify.com/#!doc=%7B%22slug%22%3A%22wolterskluwer%22%2C%22relevant-countries%22%3A%5B%22all%22%5D%2C%22categories%22%3A%5B%22health%22%2C%22school%22%2C%22social%20media%22%5D%2C%22name%22%3A%22Wolters%20Kluwer%20N.V.%22%2C%22runs%22%3A%5B%22https%3A%2F%2Fwww.wolterskluwer.com%2Fen%2Fprivacy-cookies%2Finquiry%22%5D%2C%22address%22%3A%22Data%20Privacy%20Officer%5CnWolters%20Kluwer%20N.V.%2C%5CnP.O.%20Box%201030%2C%202400%20BA%2C%5CnAlphen%20aan%20den%20Rijn%2C%5CnThe%20Netherlands%5Cn%5CnData%20Privacy%20Officer%20Contact%20Form%5Cnhttps%3A%2F%2Fwww.wolterskluwer.com%2Fen%2Fprivacy-cookies%2Finquiry%22%2C%22phone%22%3A%221-301-223-2300%22%2C%22email%22%3A%22healthlrp_privacy%40wolterskluwer.com%22%2C%22web%22%3A%22https%3A%2F%2Fwww.wolterskluwer.com%22%2C%22sources%22%3A%5B%22https%3A%2F%2Fwww.wolterskluwer.com%2Fen%2Fprivacy-cookies%22%2C%22https%3A%2F%2Fjournals.lww.com%2F_layouts%2F15%2Foaks.journals%2Fprivacy.aspx%23section12%22%2C%22https%3A%2F%2Fwww.wolterskluwer.com%2Fen%2Fprivacy-cookies%2Finquiry%22%2C%22https%3A%2F%2Fgithub.com%2Fdatenanfragen%2Fdata%2Fpull%2F922%22%5D%2C%22needs-id-document%22%3Afalse%2C%22suggested-transport-medium%22%3A%22email%22%2C%22comments%22%3A%5B%22Wolters%20Kluwer%20N.V.%20operates%20medical%20journals%20and%20other%20journals.%20They%20will%20resell%20your%20information%20repeatedly.%20%5Cn%5CnWant%20to%20see%20how%20many%20websites%20or%20services%20they%20operate%20where%20they%20suck%20in%20your%20data%3F%20Click%20on%20https%3A%2F%2Fwww.wolterskluwer.com%2Fen%2Fprivacy-cookies%2Finquiry%20As%20of%20Jan%202021%20its%20over%20100.%22%5D%2C%22quality%22%3A%22verified%22%7D)**