### PR TITLE
Add 'Die Autobahn GmbH des Bundes' (community contribution)

### DIFF
--- a/companies/autobahn.json
+++ b/companies/autobahn.json
@@ -1,19 +1,24 @@
 {
     "slug": "autobahn",
     "relevant-countries": [
-        "de"
+        "all"
     ],
     "categories": [
-        "public body"
+        "public body",
+        "travel",
+        "utility"
     ],
     "name": "Die Autobahn GmbH des Bundes",
-    "address": "Die Autobahn GmbH des Bundes\nFriedrichstraße 71\n10117 Berlin",
+    "address": "Die Autobahn GmbH des Bundes\nFriedrichstraße 71\n10117 Berlin\nDeutschland",
+    "phone": "+49 30 403680800",
     "fax": "+49 30 403680810",
     "email": "datenschutz@autobahn.de",
     "web": "https://www.autobahn.de",
     "sources": [
-        "www.autobahn.de",
-        "https://github.com/datenanfragen/data/pull/927"
+        "https://www.autobahn.de/datenschutzerklaerung/",
+        "https://github.com/datenanfragen/data/pull/927",
+        "https://www.autobahn.de/impressum/"
     ],
+    "request-language": "de",
     "quality": "verified"
 }

--- a/companies/autobahn.json
+++ b/companies/autobahn.json
@@ -1,0 +1,19 @@
+{
+    "slug": "autobahn",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "public body"
+    ],
+    "name": "Die Autobahn GmbH des Bundes",
+    "address": "Die Autobahn GmbH des Bundes\nFriedrichstraße 71\n10117 Berlin",
+    "fax": "+49 30 403680810",
+    "email": "datenschutz@autobahn.de",
+    "web": "https://www.autobahn.de",
+    "sources": [
+        "www.autobahn.de",
+        "https://github.com/datenanfragen/data/pull/927"
+    ],
+    "quality": "verified"
+}


### PR DESCRIPTION
This suggestion was submitted through the website.

**[Edit](https://company-json.netlify.com/#!doc=%7B%22slug%22%3A%22autobahn%22%2C%22relevant-countries%22%3A%5B%22de%22%5D%2C%22categories%22%3A%5B%22public%20body%22%5D%2C%22name%22%3A%22Die%20Autobahn%20GmbH%20des%20Bundes%22%2C%22address%22%3A%22Die%20Autobahn%20GmbH%20des%20Bundes%5CnFriedrichstra%C3%9Fe%2071%5Cn10117%20Berlin%22%2C%22fax%22%3A%22%2B49%2030%20403680810%22%2C%22email%22%3A%22datenschutz%40autobahn.de%22%2C%22web%22%3A%22https%3A%2F%2Fwww.autobahn.de%22%2C%22sources%22%3A%5B%22www.autobahn.de%22%2C%22https%3A%2F%2Fgithub.com%2Fdatenanfragen%2Fdata%2Fpull%2F927%22%5D%2C%22quality%22%3A%22verified%22%7D)**