### PR TITLE
Add ' A Thinking Ape Entertainment Ltd.' (community contribution)

### DIFF
--- a/companies/a-thinking-ape-entertainment-ltd.json
+++ b/companies/a-thinking-ape-entertainment-ltd.json
@@ -1,0 +1,23 @@
+{
+    "slug": "a-thinking-ape-entertainment-ltd",
+    "relevant-countries": [
+        "all"
+    ],
+    "categories": [
+        "entertainment"
+    ],
+    "name": " A Thinking Ape Entertainment Ltd.",
+    "runs": [
+        "Party in my Dorm",
+        "Kingdoms of Heckfire",
+        "Kingdoms at War",
+        "Casino X"
+    ],
+    "address": "#200–1132 Alberni St.\nVancouver, BC, Canada\nV6E 1A5",
+    "email": "support@athinkingape.com",
+    "sources": [
+        "https://athinkingape.com/",
+        "https://github.com/datenanfragen/data/pull/938"
+    ],
+    "quality": "verified"
+}

--- a/companies/a-thinking-ape.json
+++ b/companies/a-thinking-ape.json
@@ -1,22 +1,23 @@
 {
-    "slug": "a-thinking-ape-entertainment-ltd",
+    "slug": "a-thinking-ape",
     "relevant-countries": [
         "all"
     ],
     "categories": [
         "entertainment"
     ],
-    "name": " A Thinking Ape Entertainment Ltd.",
+    "name": "A Thinking Ape Entertainment Ltd.",
     "runs": [
         "Party in my Dorm",
         "Kingdoms of Heckfire",
         "Kingdoms at War",
         "Casino X"
     ],
-    "address": "#200–1132 Alberni St.\nVancouver, BC, Canada\nV6E 1A5",
+    "address": "#200–1132 Alberni St.\nVancouver BC V6E 1A5\nCanada",
     "email": "support@athinkingape.com",
+    "web": "https://athinkingape.com",
     "sources": [
-        "https://athinkingape.com/",
+        "https://athinkingape.com/#footer",
         "https://github.com/datenanfragen/data/pull/938"
     ],
     "quality": "verified"


### PR DESCRIPTION
This suggestion was submitted through the website.

**[Edit](https://company-json.netlify.com/#!doc=%7B%22slug%22%3A%22a-thinking-ape-entertainment-ltd%22%2C%22relevant-countries%22%3A%5B%22all%22%5D%2C%22categories%22%3A%5B%22entertainment%22%5D%2C%22name%22%3A%22%20A%20Thinking%20Ape%20Entertainment%20Ltd.%22%2C%22runs%22%3A%5B%22Party%20in%20my%20Dorm%22%2C%22Kingdoms%20of%20Heckfire%22%2C%22Kingdoms%20at%20War%22%2C%22Casino%20X%22%5D%2C%22address%22%3A%22%23200%E2%80%931132%20Alberni%20St.%5CnVancouver%2C%20BC%2C%20Canada%5CnV6E%201A5%22%2C%22email%22%3A%22support%40athinkingape.com%22%2C%22sources%22%3A%5B%22https%3A%2F%2Fathinkingape.com%2F%22%2C%22https%3A%2F%2Fgithub.com%2Fdatenanfragen%2Fdata%2Fpull%2F938%22%5D%2C%22quality%22%3A%22verified%22%7D)**