### PR TITLE
Add 'TeamViewer Germany GmbH' (community contribution)

### DIFF
--- a/companies/teamviewer.json
+++ b/companies/teamviewer.json
@@ -1,0 +1,22 @@
+{
+    "slug": "teamviewer",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "telecommunication"
+    ],
+    "name": "TeamViewer Germany GmbH",
+    "address": "Bahnhofsplatz 2, 73033 Göppingen",
+    "email": "privacy@teamviewer.com",
+    "web": "https://www.teamviewer.com",
+    "sources": [
+        "https://www.teamviewer.com/de/datenschutzerklaerung/",
+        "https://github.com/datenanfragen/data/pull/976"
+    ],
+    "needs-id-document": false,
+    "comments": [
+        null
+    ],
+    "quality": "verified"
+}


### PR DESCRIPTION
This suggestion was submitted through the website.

**[Edit](https://company-json.netlify.com/#!doc=%7B%22slug%22%3A%22teamviewer%22%2C%22relevant-countries%22%3A%5B%22de%22%5D%2C%22categories%22%3A%5B%22telecommunication%22%5D%2C%22name%22%3A%22TeamViewer%20Germany%20GmbH%22%2C%22address%22%3A%22Bahnhofsplatz%202%2C%2073033%20G%C3%B6ppingen%22%2C%22email%22%3A%22privacy%40teamviewer.com%22%2C%22web%22%3A%22https%3A%2F%2Fwww.teamviewer.com%22%2C%22sources%22%3A%5B%22https%3A%2F%2Fwww.teamviewer.com%2Fde%2Fdatenschutzerklaerung%2F%22%2C%22https%3A%2F%2Fgithub.com%2Fdatenanfragen%2Fdata%2Fpull%2F976%22%5D%2C%22needs-id-document%22%3Afalse%2C%22comments%22%3A%5Bnull%5D%2C%22quality%22%3A%22verified%22%7D)**