### PR TITLE
Add 'Valimail Inc.' (community contribution)

### DIFF
--- a/companies/valimail.json
+++ b/companies/valimail.json
@@ -1,0 +1,19 @@
+{
+    "slug": "valimail",
+    "relevant-countries": [
+        "all"
+    ],
+    "categories": [
+        "utility"
+    ],
+    "name": "Valimail Inc.",
+    "address": "Valimail Inc.\n180 Montgomery Street, 20th Floor\nSan Francisco CA 94104\nUnited States of America",
+    "email": "privacy@valimail.com",
+    "web": "https://www.valimail.com",
+    "sources": [
+        "https://www.valimail.com/privacy/",
+        "https://github.com/datenanfragen/data/pull/993"
+    ],
+    "needs-id-document": false,
+    "quality": "verified"
+}

--- a/companies/valimail.json
+++ b/companies/valimail.json
@@ -4,16 +4,17 @@
         "all"
     ],
     "categories": [
-        "utility"
+        "telecommunication"
     ],
     "name": "Valimail Inc.",
-    "address": "Valimail Inc.\n180 Montgomery Street, 20th Floor\nSan Francisco CA 94104\nUnited States of America",
+    "address": "180 Montgomery Street, 20th Floor\nSan Francisco CA 94104\nUnited States of America",
     "email": "privacy@valimail.com",
     "web": "https://www.valimail.com",
     "sources": [
         "https://www.valimail.com/privacy/",
         "https://github.com/datenanfragen/data/pull/993"
     ],
+    "suggested-transport-medium": "email",
     "needs-id-document": false,
     "quality": "verified"
 }


### PR DESCRIPTION
This suggestion was submitted through the website.

**[Edit](https://company-json.netlify.com/#!doc=%7B%22slug%22%3A%22valimail%22%2C%22relevant-countries%22%3A%5B%22all%22%5D%2C%22categories%22%3A%5B%22utility%22%5D%2C%22name%22%3A%22Valimail%20Inc.%22%2C%22address%22%3A%22Valimail%20Inc.%5Cn180%20Montgomery%20Street%2C%2020th%20Floor%5CnSan%20Francisco%20CA%2094104%5CnUnited%20States%20of%20America%22%2C%22email%22%3A%22privacy%40valimail.com%22%2C%22web%22%3A%22https%3A%2F%2Fwww.valimail.com%22%2C%22sources%22%3A%5B%22https%3A%2F%2Fwww.valimail.com%2Fprivacy%2F%22%2C%22https%3A%2F%2Fgithub.com%2Fdatenanfragen%2Fdata%2Fpull%2F993%22%5D%2C%22needs-id-document%22%3Afalse%2C%22quality%22%3A%22verified%22%7D)**