### PR TITLE
Update 'British Broadcasting Corporation (BBC)' (community contribution)

### DIFF
--- a/companies/bbc.json
+++ b/companies/bbc.json
@@ -7,11 +7,18 @@
         "entertainment"
     ],
     "name": "British Broadcasting Corporation (BBC)",
+    "runs": [
+        "BBC Media Applications Technologies Limited",
+        "1943 Berlin Blitz (VR Experience)"
+    ],
     "address": "BC2 A4\n201 Wood Lane\nLondon W12 7TP\nUnited Kingdom",
     "email": "dataprotection@bbc.com",
     "web": "https://www.bbc.com",
     "sources": [
-        "https://www.bbc.co.uk/usingthebbc/privacy/privacy-policy/"
+        "https://www.bbc.co.uk/usingthebbc/privacy/privacy-policy/",
+        "https://store.steampowered.com/app/513490/1943_Berlin_Blitz/",
+        "https://store.steampowered.com//eula/513490_eula_0",
+        "https://github.com/datenanfragen/data/pull/996"
     ],
     "request-language": "en",
     "suggested-transport-medium": "email",


### PR DESCRIPTION
This suggestion was submitted through the website.

**[Edit](https://company-json.netlify.com/#!doc=%7B%22slug%22%3A%22bbc%22%2C%22relevant-countries%22%3A%5B%22all%22%5D%2C%22categories%22%3A%5B%22entertainment%22%5D%2C%22name%22%3A%22British%20Broadcasting%20Corporation%20(BBC)%22%2C%22runs%22%3A%5B%22BBC%20Media%20Applications%20Technologies%20Limited%22%2C%221943%20Berlin%20Blitz%20(VR%20Experience)%22%5D%2C%22address%22%3A%22BC2%20A4%5Cn201%20Wood%20Lane%5CnLondon%20W12%207TP%5CnUnited%20Kingdom%22%2C%22email%22%3A%22dataprotection%40bbc.com%22%2C%22web%22%3A%22https%3A%2F%2Fwww.bbc.com%22%2C%22sources%22%3A%5B%22https%3A%2F%2Fwww.bbc.co.uk%2Fusingthebbc%2Fprivacy%2Fprivacy-policy%2F%22%2C%22https%3A%2F%2Fstore.steampowered.com%2Fapp%2F513490%2F1943_Berlin_Blitz%2F%22%2C%22https%3A%2F%2Fstore.steampowered.com%2F%2Feula%2F513490_eula_0%22%2C%22https%3A%2F%2Fgithub.com%2Fdatenanfragen%2Fdata%2Fpull%2F996%22%5D%2C%22request-language%22%3A%22en%22%2C%22suggested-transport-medium%22%3A%22email%22%2C%22quality%22%3A%22verified%22%7D)**