### PR TITLE
Add 'Wallwisher, Inc.' (community contribution)

### DIFF
--- a/companies/wallwisher-inc.json
+++ b/companies/wallwisher-inc.json
@@ -1,0 +1,17 @@
+{
+    "slug": "wallwisher-inc",
+    "relevant-countries": [
+        "all"
+    ],
+    "name": "Wallwisher, Inc.",
+    "runs": [
+        "padlet.com"
+    ],
+    "address": "981 Mission St\nSan Francisco, CA 94103\nUSA",
+    "email": "hello@padlet.com",
+    "sources": [
+        "https://padlet.com/about/privacy",
+        "https://github.com/datenanfragen/data/pull/1030"
+    ],
+    "quality": "verified"
+}

--- a/companies/wallwisher-inc.json
+++ b/companies/wallwisher-inc.json
@@ -7,7 +7,7 @@
     "runs": [
         "padlet.com"
     ],
-    "address": "981 Mission St\nSan Francisco, CA 94103\nUSA",
+    "address": "981 Mission St\nSan Francisco, CA 94103\nUnited States of America",
     "email": "hello@padlet.com",
     "sources": [
         "https://padlet.com/about/privacy",


### PR DESCRIPTION
This suggestion was submitted through the website.

**[Edit](https://company-json.netlify.com/#!doc=%7B%22slug%22%3A%22wallwisher-inc%22%2C%22relevant-countries%22%3A%5B%22all%22%5D%2C%22name%22%3A%22Wallwisher%2C%20Inc.%22%2C%22runs%22%3A%5B%22padlet.com%22%5D%2C%22address%22%3A%22981%20Mission%20St%5CnSan%20Francisco%2C%20CA%2094103%5CnUSA%22%2C%22email%22%3A%22hello%40padlet.com%22%2C%22sources%22%3A%5B%22https%3A%2F%2Fpadlet.com%2Fabout%2Fprivacy%22%2C%22https%3A%2F%2Fgithub.com%2Fdatenanfragen%2Fdata%2Fpull%2F1030%22%5D%2C%22quality%22%3A%22verified%22%7D)**