### PR TITLE
Add 'Deutscher Fahrschulverlag GmbH' (community contribution)

### DIFF
--- a/companies/app-fahrschulcard.json
+++ b/companies/app-fahrschulcard.json
@@ -1,0 +1,17 @@
+{
+    "slug": "app-fahrschulcard",
+    "relevant-countries": [
+        "de"
+    ],
+    "name": "Deutscher Fahrschulverlag GmbH",
+    "address": "Luise-Ullrich-Straße 8\n82031 Grünwald\nDeutschland",
+    "email": "datenschutz@d-fv.de",
+    "web": "https://app.fahrschulcard.de/",
+    "sources": [
+        "https://app.fahrschulcard.de/imprint",
+        "https://app.fahrschulcard.de/privacy",
+        "https://github.com/datenanfragen/data/pull/1051"
+    ],
+    "suggested-transport-medium": "email",
+    "quality": "verified"
+}

--- a/companies/app-fahrschulcard.json
+++ b/companies/app-fahrschulcard.json
@@ -4,7 +4,12 @@
         "de"
     ],
     "name": "Deutscher Fahrschulverlag GmbH",
+    "runs": [
+        "Fahrschulcard (App)"
+    ],
     "address": "Luise-Ullrich-Straße 8\n82031 Grünwald\nDeutschland",
+    "phone": "+49 89 242399055",
+    "fax": "+49 89 242399080",
     "email": "datenschutz@d-fv.de",
     "web": "https://app.fahrschulcard.de/",
     "sources": [


### PR DESCRIPTION
This suggestion was submitted through the website.

**[Edit](https://company-json.netlify.com/#!doc=%7B%22slug%22%3A%22app-fahrschulcard%22%2C%22relevant-countries%22%3A%5B%22de%22%5D%2C%22name%22%3A%22Deutscher%20Fahrschulverlag%20GmbH%22%2C%22address%22%3A%22Luise-Ullrich-Stra%C3%9Fe%208%5Cn82031%20Gr%C3%BCnwald%5CnDeutschland%22%2C%22email%22%3A%22datenschutz%40d-fv.de%22%2C%22web%22%3A%22https%3A%2F%2Fapp.fahrschulcard.de%2F%22%2C%22sources%22%3A%5B%22https%3A%2F%2Fapp.fahrschulcard.de%2Fimprint%22%2C%22https%3A%2F%2Fapp.fahrschulcard.de%2Fprivacy%22%2C%22https%3A%2F%2Fgithub.com%2Fdatenanfragen%2Fdata%2Fpull%2F1051%22%5D%2C%22suggested-transport-medium%22%3A%22email%22%2C%22quality%22%3A%22verified%22%7D)**