### PR TITLE
Add 'Elsevier' (community contribution)

### DIFF
--- a/companies/elsevier.json
+++ b/companies/elsevier.json
@@ -4,16 +4,31 @@
         "all"
     ],
     "categories": [
-        "school"
+        "health"
     ],
-    "name": "Elsevier",
-    "address": "Data Protection Officer\nElsevier Limited\nThe Boulevard\nLangford Lane\nKidlington\nOxford OX5 1GB\nUnited Kingdom",
+    "name": "Elsevier B.V",
+    "address": "Radarweg 29\n1043 Amsterdam\nThe Netherlands",
     "email": "DPO@elsevier.com",
     "web": "https://www.elsevier.com/",
     "sources": [
-        "https://www.elsevier.com/legal/privacy-policy-de-de",
+        "https://www.elsevier.com/legal/privacy-policy",
         "https://github.com/datenanfragen/data/pull/1057"
     ],
+    "required-elements": [
+        {
+            "desc": "Name",
+            "type": "name",
+            "optional": false
+        },
+        {
+            "desc": "Email",
+            "type": "email",
+            "optional": false
+        }
+    ],
     "suggested-transport-medium": "email",
+    "comments": [
+        "You can also fill out the form at https://service.elsevier.com/app/contact/supporthub/privacysupport/"
+    ],
     "quality": "verified"
 }

--- a/companies/elsevier.json
+++ b/companies/elsevier.json
@@ -1,0 +1,19 @@
+{
+    "slug": "elsevier",
+    "relevant-countries": [
+        "all"
+    ],
+    "categories": [
+        "school"
+    ],
+    "name": "Elsevier",
+    "address": "Data Protection Officer\nElsevier Limited\nThe Boulevard\nLangford Lane\nKidlington\nOxford OX5 1GB\nUnited Kingdom",
+    "email": "DPO@elsevier.com",
+    "web": "https://www.elsevier.com/",
+    "sources": [
+        "https://www.elsevier.com/legal/privacy-policy-de-de",
+        "https://github.com/datenanfragen/data/pull/1057"
+    ],
+    "suggested-transport-medium": "email",
+    "quality": "verified"
+}


### PR DESCRIPTION
This suggestion was submitted through the website.

**[Edit](https://company-json.netlify.com/#!doc=%7B%22slug%22%3A%22elsevier%22%2C%22relevant-countries%22%3A%5B%22all%22%5D%2C%22categories%22%3A%5B%22school%22%5D%2C%22name%22%3A%22Elsevier%22%2C%22address%22%3A%22Data%20Protection%20Officer%5CnElsevier%20Limited%5CnThe%20Boulevard%5CnLangford%20Lane%5CnKidlington%5CnOxford%20OX5%201GB%5CnUnited%20Kingdom%22%2C%22email%22%3A%22DPO%40elsevier.com%22%2C%22web%22%3A%22https%3A%2F%2Fwww.elsevier.com%2F%22%2C%22sources%22%3A%5B%22https%3A%2F%2Fwww.elsevier.com%2Flegal%2Fprivacy-policy-de-de%22%2C%22https%3A%2F%2Fgithub.com%2Fdatenanfragen%2Fdata%2Fpull%2F1057%22%5D%2C%22suggested-transport-medium%22%3A%22email%22%2C%22quality%22%3A%22verified%22%7D)**