### PR TITLE
Add 'Staatliche Lotterie-Einnahme Glöckle KG' (community contribution)

### DIFF
--- a/companies/gloeckle.json
+++ b/companies/gloeckle.json
@@ -4,17 +4,35 @@
         "de"
     ],
     "categories": [
-        "ads"
+        "entertainment"
     ],
     "name": "Staatliche Lotterie-Einnahme Glöckle KG",
-    "address": "zu Hd. Datenschutzbeauftragter\nDaimlerstraße 86\n70372 Stuttgart",
-    "phone": "07119541620",
-    "fax": "07319541309",
+    "address": "Daimlerstraße 86\n70372 Stuttgart\nDeutschland",
+    "phone": "+49 711 9541620",
+    "fax": "+49 731 9541309",
     "email": "datenschutz@gloeckle.de",
     "web": "https://www.gloeckle.de",
     "sources": [
         "https://www.gloeckle.de/datenschutz/",
         "https://github.com/datenanfragen/data/pull/1063"
     ],
+    "required-elements": [
+        {
+            "desc": "Name",
+            "type": "name",
+            "optional": false
+        },
+        {
+            "desc": "Email",
+            "type": "email",
+            "optional": false
+        },
+        {
+            "desc": "Kundennummer",
+            "type": "input",
+            "optional": true
+        }
+    ],
+    "suggested-transport-medium": "email",
     "quality": "verified"
 }

--- a/companies/gloeckle.json
+++ b/companies/gloeckle.json
@@ -1,0 +1,20 @@
+{
+    "slug": "gloeckle",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "ads"
+    ],
+    "name": "Staatliche Lotterie-Einnahme Glöckle KG",
+    "address": "zu Hd. Datenschutzbeauftragter\nDaimlerstraße 86\n70372 Stuttgart",
+    "phone": "07119541620",
+    "fax": "07319541309",
+    "email": "datenschutz@gloeckle.de",
+    "web": "https://www.gloeckle.de",
+    "sources": [
+        "https://www.gloeckle.de/datenschutz/",
+        "https://github.com/datenanfragen/data/pull/1063"
+    ],
+    "quality": "verified"
+}


### PR DESCRIPTION
This suggestion was submitted through the website.

**[Edit](https://company-json.netlify.com/#!doc=%7B%22slug%22%3A%22gloeckle%22%2C%22relevant-countries%22%3A%5B%22de%22%5D%2C%22categories%22%3A%5B%22ads%22%5D%2C%22name%22%3A%22Staatliche%20Lotterie-Einnahme%20Gl%C3%B6ckle%20KG%22%2C%22address%22%3A%22zu%20Hd.%20Datenschutzbeauftragter%5CnDaimlerstra%C3%9Fe%2086%5Cn70372%20Stuttgart%22%2C%22phone%22%3A%2207119541620%22%2C%22fax%22%3A%2207319541309%22%2C%22email%22%3A%22datenschutz%40gloeckle.de%22%2C%22web%22%3A%22https%3A%2F%2Fwww.gloeckle.de%22%2C%22sources%22%3A%5B%22https%3A%2F%2Fwww.gloeckle.de%2Fdatenschutz%2F%22%2C%22https%3A%2F%2Fgithub.com%2Fdatenanfragen%2Fdata%2Fpull%2F1063%22%5D%2C%22quality%22%3A%22verified%22%7D)**