### PR TITLE
Add 'GB Intelligence Ltd' (community contribution)

### DIFF
--- a/companies/cio-institute.json
+++ b/companies/cio-institute.json
@@ -1,0 +1,22 @@
+{
+    "slug": "cio-institute",
+    "relevant-countries": [
+        "all"
+    ],
+    "categories": [
+        "ads",
+        "school"
+    ],
+    "name": "GB Intelligence Ltd",
+    "runs": [
+        "Global CIO Institute"
+    ],
+    "address": "8-10 Griffin Street\nNewport NP20 1GL",
+    "email": "marketing@cio-institute.com",
+    "web": "https://www.cio-institute.com",
+    "sources": [
+        "website",
+        "https://github.com/datenanfragen/data/pull/1078"
+    ],
+    "quality": "verified"
+}

--- a/companies/gb-intelligence.json
+++ b/companies/gb-intelligence.json
@@ -1,5 +1,5 @@
 {
-    "slug": "cio-institute",
+    "slug": "gb-intelligence",
     "relevant-countries": [
         "all"
     ],
@@ -7,16 +7,16 @@
         "ads",
         "school"
     ],
-    "name": "GB Intelligence Ltd",
+    "name": "GB Intelligence Ltd.",
     "runs": [
         "Global CIO Institute"
     ],
-    "address": "8-10 Griffin Street\nNewport NP20 1GL",
+    "address": "8-10 Griffin Street\nNewport\nNP20 1GL\nUnited Kingdom",
     "email": "marketing@cio-institute.com",
     "web": "https://www.cio-institute.com",
     "sources": [
-        "website",
-        "https://github.com/datenanfragen/data/pull/1078"
+        "https://github.com/datenanfragen/data/pull/1078",
+        "https://www.cio-institute.com/privacy-policy"
     ],
     "quality": "verified"
 }


### PR DESCRIPTION
This suggestion was submitted through the website.

**[Edit](https://company-json.netlify.com/#!doc=%7B%22slug%22%3A%22cio-institute%22%2C%22relevant-countries%22%3A%5B%22all%22%5D%2C%22categories%22%3A%5B%22ads%22%2C%22school%22%5D%2C%22name%22%3A%22GB%20Intelligence%20Ltd%22%2C%22runs%22%3A%5B%22Global%20CIO%20Institute%22%5D%2C%22address%22%3A%228-10%20Griffin%20Street%5CnNewport%20NP20%201GL%22%2C%22email%22%3A%22marketing%40cio-institute.com%22%2C%22web%22%3A%22https%3A%2F%2Fwww.cio-institute.com%22%2C%22sources%22%3A%5B%22website%22%2C%22https%3A%2F%2Fgithub.com%2Fdatenanfragen%2Fdata%2Fpull%2F1078%22%5D%2C%22quality%22%3A%22verified%22%7D)**