### PR TITLE
Add 'Deutscher Zentralverein homöopathischer Ärzte e.V.' (community contribution)

### DIFF
--- a/companies/dzvhae.json
+++ b/companies/dzvhae.json
@@ -1,0 +1,20 @@
+{
+    "slug": "dzvhae",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "health"
+    ],
+    "name": "Deutscher Zentralverein homöopathischer Ärzte e.V.",
+    "address": "Deutscher Zentralverein homöopathischer Ärzte e.V.\nDatenschutzbeauftragter\nAxel-Springer-Str. 54 B\n10117 Berlin",
+    "email": "datenschutz@dzvhae.de",
+    "web": "https://www.dzvhae.de",
+    "sources": [
+        "https://www.dzvhae.de/datenschutz/",
+        "https://github.com/datenanfragen/data/pull/1103"
+    ],
+    "needs-id-document": false,
+    "suggested-transport-medium": "email",
+    "quality": "verified"
+}

--- a/companies/dzvhae.json
+++ b/companies/dzvhae.json
@@ -7,14 +7,15 @@
         "health"
     ],
     "name": "Deutscher Zentralverein homöopathischer Ärzte e.V.",
-    "address": "Deutscher Zentralverein homöopathischer Ärzte e.V.\nDatenschutzbeauftragter\nAxel-Springer-Str. 54 B\n10117 Berlin",
+    "address": "Axel-Springer-Str. 54 B\n10117 Berlin\nDeutschland",
+    "phone": "+49 30 32597340",
+    "fax": "+49 30 325973419",
     "email": "datenschutz@dzvhae.de",
     "web": "https://www.dzvhae.de",
     "sources": [
         "https://www.dzvhae.de/datenschutz/",
         "https://github.com/datenanfragen/data/pull/1103"
     ],
-    "needs-id-document": false,
     "suggested-transport-medium": "email",
     "quality": "verified"
 }


### PR DESCRIPTION
This suggestion was submitted through the website.

**[Edit](https://company-json.netlify.com/#!doc=%7B%22slug%22%3A%22dzvhae%22%2C%22relevant-countries%22%3A%5B%22de%22%5D%2C%22categories%22%3A%5B%22health%22%5D%2C%22name%22%3A%22Deutscher%20Zentralverein%20hom%C3%B6opathischer%20%C3%84rzte%20e.V.%22%2C%22address%22%3A%22Deutscher%20Zentralverein%20hom%C3%B6opathischer%20%C3%84rzte%20e.V.%5CnDatenschutzbeauftragter%5CnAxel-Springer-Str.%2054%20B%5Cn10117%20Berlin%22%2C%22email%22%3A%22datenschutz%40dzvhae.de%22%2C%22web%22%3A%22https%3A%2F%2Fwww.dzvhae.de%22%2C%22sources%22%3A%5B%22https%3A%2F%2Fwww.dzvhae.de%2Fdatenschutz%2F%22%2C%22https%3A%2F%2Fgithub.com%2Fdatenanfragen%2Fdata%2Fpull%2F1103%22%5D%2C%22needs-id-document%22%3Afalse%2C%22suggested-transport-medium%22%3A%22email%22%2C%22quality%22%3A%22verified%22%7D)**