### PR TITLE
Add 'ContentScope GmbH' (community contribution)

### DIFF
--- a/companies/sooner.json
+++ b/companies/sooner.json
@@ -1,0 +1,25 @@
+{
+    "slug": "sooner",
+    "relevant-countries": [
+        "all"
+    ],
+    "categories": [
+        "entertainment"
+    ],
+    "name": "ContentScope GmbH",
+    "runs": [
+        "Sooner (sooner.de)"
+    ],
+    "address": "Alte Jakobstraße 76\n10179 Berlin\nDeutschland",
+    "phone": "+49 30 97004330",
+    "fax": "+49 30 97004331",
+    "email": "privacy@sooner.de",
+    "web": "https://sooner.de",
+    "sources": [
+        "https://sooner.de/rechtliches/",
+        "https://sooner.de/impressum/",
+        "https://github.com/datenanfragen/data/pull/1117"
+    ],
+    "suggested-transport-medium": "email",
+    "quality": "verified"
+}


### PR DESCRIPTION
This suggestion was submitted through the website.

**[Edit](https://company-json.netlify.com/#!doc=%7B%22slug%22%3A%22sooner%22%2C%22relevant-countries%22%3A%5B%22all%22%5D%2C%22categories%22%3A%5B%22entertainment%22%5D%2C%22name%22%3A%22ContentScope%20GmbH%22%2C%22runs%22%3A%5B%22Sooner%20(sooner.de)%22%5D%2C%22address%22%3A%22Alte%20Jakobstra%C3%9Fe%2076%5Cn10179%20Berlin%5CnDeutschland%22%2C%22phone%22%3A%22%2B49%2030%2097004330%22%2C%22fax%22%3A%22%2B49%2030%2097004331%22%2C%22email%22%3A%22privacy%40sooner.de%22%2C%22web%22%3A%22https%3A%2F%2Fsooner.de%22%2C%22sources%22%3A%5B%22https%3A%2F%2Fsooner.de%2Frechtliches%2F%22%2C%22https%3A%2F%2Fsooner.de%2Fimpressum%2F%22%2C%22https%3A%2F%2Fgithub.com%2Fdatenanfragen%2Fdata%2Fpull%2F1117%22%5D%2C%22suggested-transport-medium%22%3A%22email%22%2C%22quality%22%3A%22verified%22%7D)**