### PR TITLE
Schema: Remove overseas territories that aren't actually countries

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -18,7 +18,7 @@
             "minItems": 1,
             "items": {
                 "type": "string",
-                "enum": ["all", "at", "be", "bg", "hr", "cy", "cz", "dk", "ee", "fi", "fr", "de", "gr", "hu", "ie", "it", "lv", "lt", "lu", "mt", "nl", "pl", "pt", "ro", "sk", "si", "es", "se", "gb", "no", "is", "li", "ic", "gp", "gf", "mq", "yt", "re", "mf", "ch"]
+                "enum": ["all", "at", "be", "bg", "hr", "cy", "cz", "dk", "ee", "fi", "fr", "de", "gr", "hu", "ie", "it", "lv", "lt", "lu", "mt", "nl", "pl", "pt", "ro", "sk", "si", "es", "se", "gb", "no", "is", "li", "ch"]
             }
         },
         "categories": {


### PR DESCRIPTION
This will also "fix" the missing translations in the suggest form:

![image](https://user-images.githubusercontent.com/4048809/119271274-679fc080-bbf0-11eb-9c71-14fd6a1847a6.png)
