### PR TITLE
Update 'Facebook Ireland Ltd.' (community contribution)

### DIFF
--- a/companies/facebook.json
+++ b/companies/facebook.json
@@ -23,7 +23,8 @@
         "https://github.com/datenanfragen/data/issues/92",
         "https://github.com/datenanfragen/data/issues/93",
         "https://www.facebook.com/help/contact/2032834846972583",
-        "https://github.com/datenanfragen/data/pull/974"
+        "https://github.com/datenanfragen/data/pull/974",
+        "https://github.com/datenanfragen/data/pull/1128"
     ],
     "comments": [
         "Various privacy controls (including the ability to download your data as HTML or JSON) are available via the Facebook website: https://www.facebook.com/settings?tab=your_facebook_information",


### PR DESCRIPTION
This suggestion was submitted through the website.

**[Edit](https://company-json.netlify.com/#!doc=%7B%22slug%22%3A%22facebook%22%2C%22relevant-countries%22%3A%5B%22all%22%5D%2C%22categories%22%3A%5B%22entertainment%22%2C%22social%20media%22%5D%2C%22name%22%3A%22Facebook%20Ireland%20Ltd.%22%2C%22runs%22%3A%5B%22Facebook%2C%20Inc.%22%5D%2C%22address%22%3A%224%20Grand%20Canal%20Square%5CnGrand%20Canal%20Harbour%5CnDublin%202%5CnIreland%22%2C%22phone%22%3A%22%2B1%20650%20543%204800%22%2C%22fax%22%3A%22%2B1%20650%20543%205349%22%2C%22web%22%3A%22https%3A%2F%2Fwww.facebook.com%2F%22%2C%22sources%22%3A%5B%22https%3A%2F%2Fwww.facebook.com%2Fprivacy%2Fexplanation%22%2C%22https%3A%2F%2Fwww.facebook.com%2Flegal%2Fterms%22%2C%22https%3A%2F%2Fwww.privacyshield.gov%2Fparticipant%3Fid%3Da2zt0000000GnywAAC%22%2C%22https%3A%2F%2Fwww.facebook.com%2Fcareers%2Fprivacy%22%2C%22https%3A%2F%2Fgithub.com%2Fdatenanfragen%2Fdata%2Fissues%2F92%22%2C%22https%3A%2F%2Fgithub.com%2Fdatenanfragen%2Fdata%2Fissues%2F93%22%2C%22https%3A%2F%2Fwww.facebook.com%2Fhelp%2Fcontact%2F2032834846972583%22%2C%22https%3A%2F%2Fgithub.com%2Fdatenanfragen%2Fdata%2Fpull%2F974%22%2C%22https%3A%2F%2Fgithub.com%2Fdatenanfragen%2Fdata%2Fpull%2F1128%22%5D%2C%22comments%22%3A%5B%22Various%20privacy%20controls%20(including%20the%20ability%20to%20download%20your%20data%20as%20HTML%20or%20JSON)%20are%20available%20via%20the%20Facebook%20website%3A%20https%3A%2F%2Fwww.facebook.com%2Fsettings%3Ftab%3Dyour_facebook_information%22%2C%22Facebook's%20Data%20Protection%20Officer%20can%20be%20contacted%20via%20this%20form%3A%20https%3A%2F%2Fwww.facebook.com%2Fhelp%2Fcontact%2F540977946302970%22%2C%22We%20have%20previously%20listed%20Instagram%20under%20this%20record.%20We%20have%20since%20discovered%20better%20direct%20contact%20details%20and%20thus%20split%20the%20records.%22%5D%2C%22quality%22%3A%22verified%22%7D)**