### PR TITLE
Add 'sendinblue.com' (community contribution)

### DIFF
--- a/companies/sendinblue.json
+++ b/companies/sendinblue.json
@@ -2,17 +2,31 @@
     "slug": "sendinblue",
     "relevant-countries": [
         "fr",
-        "de"
+        "de",
+        "it",
+        "es",
+        "pt",
+        "gb"
     ],
-    "name": "sendinblue.com",
-    "address": "Address: Köpenicker Str. 126, 10179 Berlin, Germany",
-    "web": "https://www.sendinblue.com/about/",
+    "categories": [
+        "ads"
+    ],
+    "name": "Sendinblue SAS",
+    "runs": [
+        "Sendinblue GmbH",
+        "Sendinblue Inc."
+    ],
+    "address": "7 rue de Madrid\n75008 Paris\nFrance",
+    "email": "privacy@sendinblue.com",
+    "web": "https://www.sendinblue.com",
     "sources": [
-        "https://www.sendinblue.com/about/",
-        "https://github.com/datenanfragen/data/pull/1135"
+        "https://www.sendinblue.com/legal/privacypolicy/",
+        "https://github.com/datenanfragen/data/pull/1135",
+        "https://de.sendinblue.com/legal/privacypolicy/"
     ],
+    "suggested-transport-medium": "email",
     "comments": [
-        "Competitor to Mailchimp, handles massive marketing campaign databases"
+        "German address: Köpenicker Str. 126, 10179 Berlin, Germany"
     ],
     "quality": "verified"
 }

--- a/companies/sendinblue.json
+++ b/companies/sendinblue.json
@@ -1,0 +1,18 @@
+{
+    "slug": "sendinblue",
+    "relevant-countries": [
+        "fr",
+        "de"
+    ],
+    "name": "sendinblue.com",
+    "address": "Address: Köpenicker Str. 126, 10179 Berlin, Germany",
+    "web": "https://www.sendinblue.com/about/",
+    "sources": [
+        "https://www.sendinblue.com/about/",
+        "https://github.com/datenanfragen/data/pull/1135"
+    ],
+    "comments": [
+        "Competitor to Mailchimp, handles massive marketing campaign databases"
+    ],
+    "quality": "verified"
+}


### PR DESCRIPTION
This suggestion was submitted through the website.

**[Edit](https://company-json.netlify.com/#!doc=%7B%22slug%22%3A%22sendinblue%22%2C%22relevant-countries%22%3A%5B%22fr%22%2C%22de%22%5D%2C%22name%22%3A%22sendinblue.com%22%2C%22address%22%3A%22Address%3A%20K%C3%B6penicker%20Str.%20126%2C%2010179%20Berlin%2C%20Germany%22%2C%22web%22%3A%22https%3A%2F%2Fwww.sendinblue.com%2Fabout%2F%22%2C%22sources%22%3A%5B%22https%3A%2F%2Fwww.sendinblue.com%2Fabout%2F%22%2C%22https%3A%2F%2Fgithub.com%2Fdatenanfragen%2Fdata%2Fpull%2F1135%22%5D%2C%22comments%22%3A%5B%22Competitor%20to%20Mailchimp%2C%20handles%20massive%20marketing%20campaign%20databases%22%5D%2C%22quality%22%3A%22verified%22%7D)**