### PR TITLE
Update 'Discord, Inc.' (community contribution)

### DIFF
--- a/companies/discord.json
+++ b/companies/discord.json
@@ -12,8 +12,8 @@
     "web": "https://discord.com",
     "sources": [
         "https://discord.com/privacy",
-        "https://www.bloomberg.com/research/stocks/private/snapshot.asp?privcapId=243221325",
         "https://discord.com/terms",
+        "https://businesssearch.sos.ca.gov/Document/RetrievePDF?Id=03472899-23565581",
         "https://github.com/datenanfragen/data/pull/1159"
     ],
     "request-language": "en",

--- a/companies/discord.json
+++ b/companies/discord.json
@@ -7,12 +7,14 @@
         "social media"
     ],
     "name": "Discord, Inc.",
-    "address": "1901 South Bascom Avenue\nSuite 1180\nCampbell\nCA 95008\nUnited States of America",
-    "email": "privacy@discordapp.com",
-    "web": "https://discordapp.com",
+    "address": "444 De Haro Street\nSuite #200\nSan Francisco\nCA 94107\nUnited States of America",
+    "email": "privacy@discord.com",
+    "web": "https://discord.com",
     "sources": [
-        "https://discordapp.com/privacy",
-        "https://www.bloomberg.com/research/stocks/private/snapshot.asp?privcapId=243221325"
+        "https://discord.com/privacy",
+        "https://www.bloomberg.com/research/stocks/private/snapshot.asp?privcapId=243221325",
+        "https://discord.com/terms",
+        "https://github.com/datenanfragen/data/pull/1159"
     ],
     "request-language": "en",
     "suggested-transport-medium": "email",


### PR DESCRIPTION
This suggestion was submitted through the website.

**[Edit](https://company-json.datenanfragen.de/#!doc=%7B%22slug%22%3A%22discord%22%2C%22relevant-countries%22%3A%5B%22all%22%5D%2C%22categories%22%3A%5B%22social%20media%22%5D%2C%22name%22%3A%22Discord%2C%20Inc.%22%2C%22address%22%3A%22444%20De%20Haro%20Street%5CnSuite%20%23200%5CnSan%20Francisco%5CnCA%2094107%5CnUnited%20States%20of%20America%22%2C%22email%22%3A%22privacy%40discord.com%22%2C%22web%22%3A%22https%3A%2F%2Fdiscord.com%22%2C%22sources%22%3A%5B%22https%3A%2F%2Fdiscord.com%2Fprivacy%22%2C%22https%3A%2F%2Fwww.bloomberg.com%2Fresearch%2Fstocks%2Fprivate%2Fsnapshot.asp%3FprivcapId%3D243221325%22%2C%22https%3A%2F%2Fdiscord.com%2Fterms%22%2C%22https%3A%2F%2Fgithub.com%2Fdatenanfragen%2Fdata%2Fpull%2F1159%22%5D%2C%22request-language%22%3A%22en%22%2C%22suggested-transport-medium%22%3A%22email%22%2C%22quality%22%3A%22verified%22%7D)**