### PR TITLE
Add 'Taxfix GmbH' (community contribution)

### DIFF
--- a/companies/taxfix.json
+++ b/companies/taxfix.json
@@ -1,19 +1,31 @@
 {
     "slug": "taxfix",
     "relevant-countries": [
-        "de"
+        "de",
+        "it",
+        "fr"
     ],
     "categories": [
         "finance"
     ],
     "name": "Taxfix GmbH",
-    "address": "Karl-Liebknecht-Str. 34\n10178 Berlin",
+    "address": "Karl-Liebknecht-Str. 34\n10178 Berlin\nDeutschland",
     "phone": "+49 30 92106949",
     "email": "privacy@taxfix.de",
     "web": "https://taxfix.de",
     "sources": [
-        "privacy@taxfix.de",
+        "https://taxfix.de/datenschutz/",
         "https://github.com/datenanfragen/data/pull/1163"
+    ],
+    "required-elements": [
+        {
+            "desc": "Name",
+            "type": "name"
+        },
+        {
+            "desc": "Email",
+            "type": "email"
+        }
     ],
     "suggested-transport-medium": "email",
     "quality": "verified"

--- a/companies/taxfix.json
+++ b/companies/taxfix.json
@@ -1,0 +1,20 @@
+{
+    "slug": "taxfix",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "finance"
+    ],
+    "name": "Taxfix GmbH",
+    "address": "Karl-Liebknecht-Str. 34\n10178 Berlin",
+    "phone": "+49 30 92106949",
+    "email": "privacy@taxfix.de",
+    "web": "https://taxfix.de",
+    "sources": [
+        "privacy@taxfix.de",
+        "https://github.com/datenanfragen/data/pull/1163"
+    ],
+    "suggested-transport-medium": "email",
+    "quality": "verified"
+}


### PR DESCRIPTION
This suggestion was submitted through the website.

**[Edit](https://company-json.datenanfragen.de/#!doc=%7B%22slug%22%3A%22taxfix%22%2C%22relevant-countries%22%3A%5B%22de%22%5D%2C%22categories%22%3A%5B%22finance%22%5D%2C%22name%22%3A%22Taxfix%20GmbH%22%2C%22address%22%3A%22Karl-Liebknecht-Str.%2034%5Cn10178%20Berlin%22%2C%22phone%22%3A%22%2B49%2030%2092106949%22%2C%22email%22%3A%22privacy%40taxfix.de%22%2C%22web%22%3A%22https%3A%2F%2Ftaxfix.de%22%2C%22sources%22%3A%5B%22privacy%40taxfix.de%22%2C%22https%3A%2F%2Fgithub.com%2Fdatenanfragen%2Fdata%2Fpull%2F1163%22%5D%2C%22suggested-transport-medium%22%3A%22email%22%2C%22quality%22%3A%22verified%22%7D)**