### PR TITLE
Add 'FABER Lotto GmbH & Co. KG' (community contribution)

### DIFF
--- a/companies/faber-lotto.json
+++ b/companies/faber-lotto.json
@@ -1,20 +1,17 @@
 {
-    "slug": "faber",
+    "slug": "faber-lotto",
     "relevant-countries": [
         "de"
     ],
-    "categories": [
-        "ads"
-    ],
     "name": "FABER Lotto GmbH & Co. KG",
-    "address": "Markstraße 79\n44801 Bochum\nDeutschland ",
-    "email": "datenschutz@faber.de.",
+    "address": "Markstraße 79\n44801 Bochum\nDeutschland",
+    "phone": "+49 234 9383333",
+    "email": "datenschutz@faber.de",
     "web": "https://www.faber.de",
     "sources": [
-        "https://www.faber.de",
+        "https://www.faber.de/service/datenschutz/",
         "https://github.com/datenanfragen/data/pull/1181"
     ],
-    "needs-id-document": false,
     "suggested-transport-medium": "email",
     "quality": "verified"
 }

--- a/companies/faber.json
+++ b/companies/faber.json
@@ -1,0 +1,20 @@
+{
+    "slug": "faber",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "ads"
+    ],
+    "name": "FABER Lotto GmbH & Co. KG",
+    "address": "Markstraße 79\n44801 Bochum\nDeutschland ",
+    "email": "datenschutz@faber.de.",
+    "web": "https://www.faber.de",
+    "sources": [
+        "https://www.faber.de",
+        "https://github.com/datenanfragen/data/pull/1181"
+    ],
+    "needs-id-document": false,
+    "suggested-transport-medium": "email",
+    "quality": "verified"
+}


### PR DESCRIPTION
This suggestion was submitted through the website.

**[Edit](https://company-json.datenanfragen.de/#!doc=%7B%22slug%22%3A%22faber%22%2C%22relevant-countries%22%3A%5B%22de%22%5D%2C%22categories%22%3A%5B%22ads%22%5D%2C%22name%22%3A%22FABER%20Lotto%20GmbH%20%26%20Co.%20KG%22%2C%22address%22%3A%22Markstra%C3%9Fe%2079%5Cn44801%20Bochum%5CnDeutschland%20%22%2C%22email%22%3A%22datenschutz%40faber.de.%22%2C%22web%22%3A%22https%3A%2F%2Fwww.faber.de%22%2C%22sources%22%3A%5B%22https%3A%2F%2Fwww.faber.de%22%2C%22https%3A%2F%2Fgithub.com%2Fdatenanfragen%2Fdata%2Fpull%2F1181%22%5D%2C%22needs-id-document%22%3Afalse%2C%22suggested-transport-medium%22%3A%22email%22%2C%22quality%22%3A%22verified%22%7D)**