### PR TITLE
Set 'suggest-transport-medium' to 'email' for privacy-related emails

### DIFF
--- a/companies/a1-austria.json
+++ b/companies/a1-austria.json
@@ -11,7 +11,8 @@
     "phone": "+43 050 664 0",
     "web": "https://www.a1.net",
     "sources": [
-        "http://cdn12.a1.net/m/resources/media/pdf/a1-datenschutzerklaerung-250518-pdf.pdf"
+        "https://cdn12.a1.net/m/resources/media/pdf/Informationspflichten-und-Zustimmungserklaerung-A1.pdf",
+        "https://www.a1.net/impressum
     ],
     "request-language": "de",
     "needs-id-document": true,

--- a/companies/a1-austria.json
+++ b/companies/a1-austria.json
@@ -9,7 +9,6 @@
     "name": "A1 Telekom Austria AG",
     "address": "Lassallestraße 9\n1020 Wien\nÖsterreich",
     "phone": "+43 050 664 0",
-    "email": "datenschutz@a1telekom.at",
     "web": "https://www.a1.net",
     "sources": [
         "http://cdn12.a1.net/m/resources/media/pdf/a1-datenschutzerklaerung-250518-pdf.pdf"

--- a/companies/a1-austria.json
+++ b/companies/a1-austria.json
@@ -12,7 +12,7 @@
     "web": "https://www.a1.net",
     "sources": [
         "https://cdn12.a1.net/m/resources/media/pdf/Informationspflichten-und-Zustimmungserklaerung-A1.pdf",
-        "https://www.a1.net/impressum
+        "https://www.a1.net/impressum"
     ],
     "request-language": "de",
     "needs-id-document": true,

--- a/companies/abis.json
+++ b/companies/abis.json
@@ -26,5 +26,6 @@
             "type": "address"
         }
     ],
+    "suggested-transport-medium": "email",
     "quality": "tested"
 }

--- a/companies/adjust-com.json
+++ b/companies/adjust-com.json
@@ -15,5 +15,6 @@
         "https://www.adjust.com/terms/privacy-policy/"
     ],
     "custom-access-template": "access-tracking",
+    "suggested-transport-medium": "email",
     "quality": "verified"
 }

--- a/companies/alphonso-tv.json
+++ b/companies/alphonso-tv.json
@@ -15,5 +15,6 @@
         "https://alphonso.tv/privacy/"
     ],
     "custom-access-template": "access-tracking",
+    "suggested-transport-medium": "email",
     "quality": "verified"
 }

--- a/companies/arag-de.json
+++ b/companies/arag-de.json
@@ -34,5 +34,6 @@
             "type": "birthdate"
         }
     ],
+    "suggested-transport-medium": "email",
     "quality": "verified"
 }

--- a/companies/astrid-lindgren-schule-bs.json
+++ b/companies/astrid-lindgren-schule-bs.json
@@ -17,6 +17,7 @@
         "https://wordpress.nibis.de/alsbs/impressum/"
     ],
     "request-language": "de",
+    "suggested-transport-medium": "email",
     "quality": "verified",
     "facet-group": "school"
 }

--- a/companies/autobahn.json
+++ b/companies/autobahn.json
@@ -20,5 +20,6 @@
         "https://www.autobahn.de/impressum/"
     ],
     "request-language": "de",
+    "suggested-transport-medium": "email",
     "quality": "verified"
 }

--- a/companies/bonifyde.json
+++ b/companies/bonifyde.json
@@ -18,5 +18,6 @@
         "https://wwwbonifyde-prod.cdn.prismic.io/wwwbonifyde-prod/7547e427-5414-4825-99a6-40f5b7d79ecc_2020-06-05+-+DSE+Forteil_v_6_03.pdf",
         "https://github.com/datenanfragen/data/issues/614"
     ],
+    "suggested-transport-medium": "email",
     "quality": "verified"
 }

--- a/companies/creditreform-verband.json
+++ b/companies/creditreform-verband.json
@@ -16,5 +16,6 @@
         "https://github.com/datenanfragen/data/pull/695",
         "https://www.creditreform.de/datenschutz"
     ],
+    "suggested-transport-medium": "email",
     "quality": "verified"
 }

--- a/companies/dainst-bund.json
+++ b/companies/dainst-bund.json
@@ -16,5 +16,6 @@
         "https://www.dainst.org/datenschutz"
     ],
     "request-language": "de",
+    "suggested-transport-medium": "email",
     "quality": "verified"
 }

--- a/companies/destatis.json
+++ b/companies/destatis.json
@@ -16,5 +16,6 @@
         "https://www.destatis.de/DE/Meta/Datenschutz/Datenschutz.html"
     ],
     "request-language": "de",
+    "suggested-transport-medium": "email",
     "quality": "verified"
 }

--- a/companies/dm-drogerie.json
+++ b/companies/dm-drogerie.json
@@ -23,5 +23,6 @@
         "https://www.dm.de/datenschutz-c469442.html",
         "https://www.dm.de/unternehmen/ueber-uns/zahlen-und-fakten"
     ],
+    "suggested-transport-medium": "email",
     "quality": "verified"
 }

--- a/companies/dpma-bund.json
+++ b/companies/dpma-bund.json
@@ -17,5 +17,6 @@
         "https://www.dpma.de/dpma/recht_und_gesetz/datenschutzerklaerung/verantwortlichestelle/index.html"
     ],
     "request-language": "de",
+    "suggested-transport-medium": "email",
     "quality": "verified"
 }

--- a/companies/dsg-retail.json
+++ b/companies/dsg-retail.json
@@ -19,5 +19,6 @@
         "https://www.currys.co.uk/gbuk/privacy-on-currys-321-commercial.html",
         "https://github.com/datenanfragen/data/issues/488"
     ],
+    "suggested-transport-medium": "email",
     "quality": "verified"
 }

--- a/companies/e-fellows.json
+++ b/companies/e-fellows.json
@@ -22,5 +22,6 @@
             "type": "email"
         }
     ],
+    "suggested-transport-medium": "email",
     "quality": "verified"
 }

--- a/companies/ert-gr.json
+++ b/companies/ert-gr.json
@@ -29,5 +29,6 @@
         "https://github.com/datenanfragen/data/pull/1077"
     ],
     "request-language": "el",
+    "suggested-transport-medium": "email",
     "quality": "verified"
 }

--- a/companies/gaussschule-bs.json
+++ b/companies/gaussschule-bs.json
@@ -18,6 +18,7 @@
         "https://gaussschule-braunschweig.de/?page_id=658"
     ],
     "request-language": "de",
+    "suggested-transport-medium": "email",
     "quality": "verified",
     "facet-group": "school"
 }

--- a/companies/gsaltmhl-bs.json
+++ b/companies/gsaltmhl-bs.json
@@ -17,6 +17,7 @@
         "http://gsaltmhl.alfahosting.org/kontakt/impressum/"
     ],
     "request-language": "de",
+    "suggested-transport-medium": "email",
     "quality": "verified",
     "facet-group": "school"
 }

--- a/companies/gsasberg-bs.json
+++ b/companies/gsasberg-bs.json
@@ -18,6 +18,7 @@
         "https://wordpress.nibis.de/gsasberg/impressum/"
     ],
     "request-language": "de",
+    "suggested-transport-medium": "email",
     "quality": "verified",
     "facet-group": "school"
 }

--- a/companies/gsbue-bs.json
+++ b/companies/gsbue-bs.json
@@ -18,6 +18,7 @@
         "http://wordpress.nibis.de/gsbue/files/Informationsblatt_DGSVO__GS_B%C3%BCltenweg.pdf"
     ],
     "request-language": "de",
+    "suggested-transport-medium": "email",
     "quality": "verified",
     "facet-group": "school"
 }

--- a/companies/heinekingmedia.json
+++ b/companies/heinekingmedia.json
@@ -33,5 +33,6 @@
     "sources": [
         "https://heinekingmedia.de/datenschutz/"
     ],
+    "suggested-transport-medium": "email",
     "quality": "verified"
 }

--- a/companies/hvf-bs.json
+++ b/companies/hvf-bs.json
@@ -17,6 +17,7 @@
         "https://www.hvf-bs.net/index.php?id=38"
     ],
     "request-language": "de",
+    "suggested-transport-medium": "email",
     "quality": "verified",
     "facet-group": "school"
 }

--- a/companies/igsquerum-bs.json
+++ b/companies/igsquerum-bs.json
@@ -17,5 +17,6 @@
         "https://igsquerum.net/service/impressum/"
     ],
     "request-language": "de",
+    "suggested-transport-medium": "email",
     "quality": "verified"
 }

--- a/companies/imgur.json
+++ b/companies/imgur.json
@@ -28,5 +28,6 @@
             "type": "email"
         }
     ],
+    "suggested-transport-medium": "email",
     "quality": "verified"
 }

--- a/companies/iserv.json
+++ b/companies/iserv.json
@@ -17,5 +17,6 @@
         "https://iserv.eu/legal/privacy",
         "https://iserv.eu/legal"
     ],
+    "suggested-transport-medium": "email",
     "quality": "verified"
 }

--- a/companies/julius-kuehn-bund.json
+++ b/companies/julius-kuehn-bund.json
@@ -17,5 +17,6 @@
         "https://www.julius-kuehn.de/impressum/"
     ],
     "request-language": "de",
+    "suggested-transport-medium": "email",
     "quality": "verified"
 }

--- a/companies/ludwigvonkapff.json
+++ b/companies/ludwigvonkapff.json
@@ -16,5 +16,6 @@
         "https://www.ludwig-von-kapff.de/impressum",
         "https://www.ludwig-von-kapff.de/datenschutz"
     ],
+    "suggested-transport-medium": "email",
     "quality": "verified"
 }

--- a/companies/meetup-com.json
+++ b/companies/meetup-com.json
@@ -26,5 +26,6 @@
             "type": "email"
         }
     ],
+    "suggested-transport-medium": "email",
     "quality": "verified"
 }

--- a/companies/mri-bund.json
+++ b/companies/mri-bund.json
@@ -16,5 +16,6 @@
         "https://www.mri.bund.de/de/datenschutz/"
     ],
     "request-language": "de",
+    "suggested-transport-medium": "email",
     "quality": "verified"
 }

--- a/companies/neue-oberschule-bs.json
+++ b/companies/neue-oberschule-bs.json
@@ -16,6 +16,7 @@
         "https://www.neue-oberschule.de/index.php/impressum/"
     ],
     "request-language": "de",
+    "suggested-transport-medium": "email",
     "quality": "verified",
     "facet-group": "school"
 }

--- a/companies/otto-bennemann-schule-bs.json
+++ b/companies/otto-bennemann-schule-bs.json
@@ -18,6 +18,7 @@
         "https://otto-bennemann-schule.de/kontakt/impressum/"
     ],
     "request-language": "de",
+    "suggested-transport-medium": "email",
     "quality": "verified",
     "facet-group": "school"
 }

--- a/companies/raabeschule-bs.json
+++ b/companies/raabeschule-bs.json
@@ -17,6 +17,7 @@
         "https://raabeschule.de/impressum/"
     ],
     "request-language": "de",
+    "suggested-transport-medium": "email",
     "quality": "verified",
     "facet-group": "school"
 }

--- a/companies/rhs-bs.json
+++ b/companies/rhs-bs.json
@@ -18,6 +18,7 @@
         "https://www.rhs-bs.de/impressum/"
     ],
     "request-language": "de",
+    "suggested-transport-medium": "email",
     "quality": "verified",
     "facet-group": "school"
 }

--- a/companies/rockerbox.json
+++ b/companies/rockerbox.json
@@ -14,5 +14,6 @@
         "https://www.rockerbox.com/privacy"
     ],
     "custom-access-template": "access-tracking",
+    "suggested-transport-medium": "email",
     "quality": "verified"
 }

--- a/companies/ruyterast.json
+++ b/companies/ruyterast.json
@@ -19,5 +19,6 @@
         "https://www.club-of-wine.de/impressum/",
         "https://www.club-of-wine.de/datenschutz/"
     ],
+    "suggested-transport-medium": "email",
     "quality": "verified"
 }

--- a/companies/schober-direct-media.json
+++ b/companies/schober-direct-media.json
@@ -29,6 +29,5 @@
             "type": "address"
         }
     ],
-    "suggested-transport-medium": "email",
     "quality": "verified"
 }

--- a/companies/semasio.json
+++ b/companies/semasio.json
@@ -14,6 +14,8 @@
         "https://www.semasio.com/privacy"
     ],
     "custom-access-template": "access-tracking",
-    "suggested-transport-medium": "letter",
+    "comments": [
+        "There is a webform available at https://me.semasio.net/right-for-information/"
+    ],
     "quality": "verified"
 }

--- a/companies/sgd.json
+++ b/companies/sgd.json
@@ -32,5 +32,6 @@
         }
     ],
     "needs-id-document": false,
+    "suggested-transport-medium": "email",
     "quality": "verified"
 }

--- a/companies/shoop.json
+++ b/companies/shoop.json
@@ -14,5 +14,6 @@
     "sources": [
         "https://www.shoop.de/datenschutz/"
     ],
+    "suggested-transport-medium": "email",
     "quality": "verified"
 }

--- a/companies/shutterstock.json
+++ b/companies/shutterstock.json
@@ -17,5 +17,6 @@
         "https://github.com/datenanfragen/data/pull/694",
         "https://www.shutterstock.com/privacy"
     ],
+    "suggested-transport-medium": "email",
     "quality": "verified"
 }

--- a/companies/stadtausstellung.json
+++ b/companies/stadtausstellung.json
@@ -17,5 +17,6 @@
         "https://github.com/datenanfragen/data/issues/576",
         "https://dsgvo.stadtausstellung.at/datenschutzerklaerung/"
     ],
+    "suggested-transport-medium": "email",
     "quality": "verified"
 }

--- a/companies/teads.json
+++ b/companies/teads.json
@@ -16,5 +16,6 @@
         "https://www.teads.com/teads-offices/"
     ],
     "custom-access-template": "access-tracking",
+    "suggested-transport-medium": "email",
     "quality": "verified"
 }

--- a/companies/teambank-de.json
+++ b/companies/teambank-de.json
@@ -35,5 +35,6 @@
             "type": "email"
         }
     ],
+    "suggested-transport-medium": "email",
     "quality": "verified"
 }

--- a/companies/teamviewer.json
+++ b/companies/teamviewer.json
@@ -21,5 +21,6 @@
         "https://www.teamviewer.com/de/impressum/"
     ],
     "needs-id-document": false,
+    "suggested-transport-medium": "email",
     "quality": "verified"
 }

--- a/companies/technikakademie-bs.json
+++ b/companies/technikakademie-bs.json
@@ -16,5 +16,6 @@
         "https://www.technikakademie-bs.de/service/datenschutz/"
     ],
     "request-language": "de",
+    "suggested-transport-medium": "email",
     "quality": "verified"
 }

--- a/companies/threema.json
+++ b/companies/threema.json
@@ -14,5 +14,6 @@
     "sources": [
         "https://threema.ch/de/privacy"
     ],
+    "suggested-transport-medium": "email",
     "quality": "verified"
 }

--- a/companies/thuenen-bund.json
+++ b/companies/thuenen-bund.json
@@ -17,5 +17,6 @@
         "https://www.thuenen.de/de/impressum/"
     ],
     "request-language": "de",
+    "suggested-transport-medium": "email",
     "quality": "verified"
 }

--- a/companies/trusted-traffic.json
+++ b/companies/trusted-traffic.json
@@ -20,5 +20,6 @@
         "https://trusted-traffic.de/impressum",
         "https://github.com/datenanfragen/data/issues/516"
     ],
+    "suggested-transport-medium": "email",
     "quality": "verified"
 }

--- a/companies/vodafone-de.json
+++ b/companies/vodafone-de.json
@@ -31,5 +31,6 @@
         "https://github.com/datenanfragen/data/pull/1131",
         "https://www.handelsregisterbekanntmachungen.de/skripte/hrb.php?rb_id=1456353&land_abk=by"
     ],
+    "suggested-transport-medium": "email",
     "quality": "verified"
 }

--- a/companies/webtrekk.json
+++ b/companies/webtrekk.json
@@ -14,5 +14,6 @@
         "https://github.com/datenanfragen/data/issues/64",
         "https://www.webtrekk.com/en/legal/legal/"
     ],
+    "suggested-transport-medium": "email",
     "quality": "verified"
 }

--- a/companies/wilhelm-gym-bs.json
+++ b/companies/wilhelm-gym-bs.json
@@ -17,5 +17,6 @@
         "https://www.wilhelm-gym.de/home/datenschutzerklaerung.pdf"
     ],
     "request-language": "de",
+    "suggested-transport-medium": "email",
     "quality": "verified"
 }

--- a/companies/wolterskluwer-global.json
+++ b/companies/wolterskluwer-global.json
@@ -19,7 +19,6 @@
         "https://www.wolterskluwer.com/en/site-owner",
         "https://www.wolterskluwer.com/en/privacy-cookies/california-consumer-privacy-act"
     ],
-    "suggested-transport-medium": "email",
     "comments": [
         "Web form for inquiries: https://www.wolterskluwer.com/en/privacy-cookies/inquiry"
     ],

--- a/companies/wolterskluwer.json
+++ b/companies/wolterskluwer.json
@@ -20,6 +20,7 @@
         "https://www.steuertipps.de/datenschutz",
         "https://github.com/datenanfragen/data/issues/445"
     ],
+    "suggested-transport-medium": "email",
     "comments": [
         "Webformular für Anfragen: https://www.wolterskluwer.com/de-de/privacy-cookies/inquiry"
     ],

--- a/companies/xaxis-com.json
+++ b/companies/xaxis-com.json
@@ -16,5 +16,6 @@
         "https://www.xaxis.com/contact-us/"
     ],
     "custom-access-template": "access-tracking",
+    "suggested-transport-medium": "email",
     "quality": "verified"
 }

--- a/companies/yesasia.json
+++ b/companies/yesasia.json
@@ -25,5 +25,6 @@
         }
     ],
     "request-language": "en",
+    "suggested-transport-medium": "email",
     "quality": "verified"
 }

--- a/companies/zomato.json
+++ b/companies/zomato.json
@@ -15,5 +15,6 @@
         "https://www.zomato.com/privacy",
         "https://github.com/datenanfragen/data/issues/429"
     ],
+    "suggested-transport-medium": "email",
     "quality": "verified"
 }

--- a/companies/zucchetti.json
+++ b/companies/zucchetti.json
@@ -20,5 +20,6 @@
         "https://www.zucchetti.it/website/cms/contatti.html"
     ],
     "request-language": "it",
+    "suggested-transport-medium": "email",
     "quality": "verified"
 }


### PR DESCRIPTION
Not sure about these:

https://github.com/datenanfragen/data/blob/e8eb3ddc1740340031884bf15d013ed8e421de5d/companies/a1-austria.json#L19

https://github.com/datenanfragen/data/blob/e8eb3ddc1740340031884bf15d013ed8e421de5d/companies/semasio.json#L17

Did we have additional knowledge about these records, explaining the `letter`-choice?

