### PR TITLE
more precise fax and phone regex

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -55,13 +55,13 @@
             "type": "string",
             "title": "Phone",
             "description": "A phone number where the company can be reached for privacy-related inquires and requests. Has to be in the standard international format and include the country code.",
-            "pattern": "^\\+\\d+ \\d+ [\\d ]+(?: ext. )?\\d*$"
+            "pattern": "^\\+\\d+ \\d+ [\\d ]+?\\d(?: ext\\. )?\\d*$"
         },
         "fax": {
             "type": "string",
             "title": "Fax",
             "description": "A fax number where the company can be reached for privacy-related inquires and requests. Has to be in the standard international format and include the country code.",
-            "pattern": "^\\+\\d+ \\d+ [\\d ]+(?: ext. )?\\d*$"
+            "pattern": "^\\+\\d+ \\d+ [\\d ]+?\\d(?: ext\\. )?\\d*$"
         },
         "email": {
             "type": "string",

--- a/schema.json
+++ b/schema.json
@@ -55,13 +55,13 @@
             "type": "string",
             "title": "Phone",
             "description": "A phone number where the company can be reached for privacy-related inquires and requests. Has to be in the standard international format and include the country code.",
-            "pattern": "^\\+\\d+ \\d+ [\\d ]+?\\d(?: ext\\. )?\\d*$"
+            "pattern": "^\\+\\d+ \\d+ (?:\\d+ )*\\d+(?: ext\\. \\d+)?$"
         },
         "fax": {
             "type": "string",
             "title": "Fax",
             "description": "A fax number where the company can be reached for privacy-related inquires and requests. Has to be in the standard international format and include the country code.",
-            "pattern": "^\\+\\d+ \\d+ [\\d ]+?\\d(?: ext\\. )?\\d*$"
+            "pattern": "^\\+\\d+ \\d+ (?:\\d+ )*\\d+(?: ext\\. \\d+)?$"
         },
         "email": {
             "type": "string",


### PR DESCRIPTION
The regex allowed trailing spaces before. I've also escaped the point in the 'ext.'-clause.