### PR TITLE
Add 'INFOVERGLEICH99 UG' (community contribution)

### DIFF
--- a/companies/infovergleich99.json
+++ b/companies/infovergleich99.json
@@ -3,18 +3,18 @@
     "relevant-countries": [
         "de"
     ],
+    "categories": [
+        "ads"
+    ],
     "name": "INFOVERGLEICH99 UG",
-    "address": "Zimmerstraße 78\n10117 Berlin",
+    "address": "Zimmerstraße 78\n10117 Berlin\nDeutschland",
     "phone": "+49 30 255583655",
     "email": "datenschutz@infovergleich99.de",
     "web": "https://www.infovergleich99.de",
     "sources": [
-        "https://www.infovergleich99.de/",
+        "https://www.infovergleich99.de/datenschutzerklarung",
         "https://github.com/datenanfragen/data/pull/1206"
     ],
     "suggested-transport-medium": "email",
-    "comments": [
-        "Rufen pauschal bei Leuten an, erzählen was von Spartarifen, verlangen nach der Zählernummer und wollen einen damit zu nem anderen Anbieter ziehen."
-    ],
     "quality": "verified"
 }

--- a/companies/infovergleich99.json
+++ b/companies/infovergleich99.json
@@ -1,0 +1,20 @@
+{
+    "slug": "infovergleich99",
+    "relevant-countries": [
+        "de"
+    ],
+    "name": "INFOVERGLEICH99 UG",
+    "address": "Zimmerstraße 78\n10117 Berlin",
+    "phone": "+49 30 255583655",
+    "email": "datenschutz@infovergleich99.de",
+    "web": "https://www.infovergleich99.de",
+    "sources": [
+        "https://www.infovergleich99.de/",
+        "https://github.com/datenanfragen/data/pull/1206"
+    ],
+    "suggested-transport-medium": "email",
+    "comments": [
+        "Rufen pauschal bei Leuten an, erzählen was von Spartarifen, verlangen nach der Zählernummer und wollen einen damit zu nem anderen Anbieter ziehen."
+    ],
+    "quality": "verified"
+}


### PR DESCRIPTION
This suggestion was submitted through the website.

**[Edit](https://company-json.datenanfragen.de/#!doc=%7B%22slug%22%3A%22infovergleich99%22%2C%22relevant-countries%22%3A%5B%22de%22%5D%2C%22name%22%3A%22INFOVERGLEICH99%20UG%22%2C%22address%22%3A%22Zimmerstra%C3%9Fe%2078%5Cn10117%20Berlin%22%2C%22phone%22%3A%22%2B49%2030%20255583655%22%2C%22email%22%3A%22datenschutz%40infovergleich99.de%22%2C%22web%22%3A%22https%3A%2F%2Fwww.infovergleich99.de%22%2C%22sources%22%3A%5B%22https%3A%2F%2Fwww.infovergleich99.de%2F%22%2C%22https%3A%2F%2Fgithub.com%2Fdatenanfragen%2Fdata%2Fpull%2F1206%22%5D%2C%22suggested-transport-medium%22%3A%22email%22%2C%22comments%22%3A%5B%22Rufen%20pauschal%20bei%20Leuten%20an%2C%20erz%C3%A4hlen%20was%20von%20Spartarifen%2C%20verlangen%20nach%20der%20Z%C3%A4hlernummer%20und%20wollen%20einen%20damit%20zu%20nem%20anderen%20Anbieter%20ziehen.%22%5D%2C%22quality%22%3A%22verified%22%7D)**