### PR TITLE
Add 'Hannoversche Le­bens­ver­siche­rung AG' (community contribution)

### DIFF
--- a/companies/hannoversche.json
+++ b/companies/hannoversche.json
@@ -1,0 +1,20 @@
+{
+    "slug": "hannoversche",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "insurance"
+    ],
+    "name": "Hannoversche Le­bens­ver­siche­rung AG",
+    "address": "Hannoversche Lebens­versicherung AG\nVHV-Platz 1\nD-30177 Hannover",
+    "phone": "0511/9565-0",
+    "fax": "0511/9565-666",
+    "email": "service@hannoversche.de",
+    "web": "https://www.hannoversche.de/",
+    "sources": [
+        "https://www.hannoversche.de/datenschutz/allgemeine-informationen",
+        "https://github.com/datenanfragen/data/pull/1213"
+    ],
+    "quality": "verified"
+}

--- a/companies/hannoversche.json
+++ b/companies/hannoversche.json
@@ -6,15 +6,33 @@
     "categories": [
         "insurance"
     ],
-    "name": "Hannoversche Le­bens­ver­siche­rung AG",
-    "address": "Hannoversche Lebens­versicherung AG\nVHV-Platz 1\nD-30177 Hannover",
-    "phone": "0511/9565-0",
-    "fax": "0511/9565-666",
-    "email": "service@hannoversche.de",
+    "name": "Hannoversche Lebensversicherung AG",
+    "runs": [
+        "VHV Vereinigte Hannoversche Versicherung a. G.",
+        "VHV Holding AG",
+        "VHV Allgemeine Versicherung AG",
+        "Hannoversche Direktversicherung AG",
+        "VHV solutions GmbH",
+        "VHV Dienstleistungen GmbH",
+        "VHV Vermögensanlage AG",
+        "Pensionskasse der VHV Versicherungen",
+        "Hannoversche Direktvertriebs-GmbH",
+        "HANNOVERSCHE CONSULT GmbH",
+        "HANNO-PENSION-Versorgungs-Management e.V.",
+        "Rhein-Ruhr-Vermögensverwaltungsgesellschaft mbH",
+        "VAV Versicherungen-AG, Wien",
+        "VVH Versicherungsvermittlung Hannover GmbH",
+        "WAVE Management AG"
+    ],
+    "address": "VHV-Platz 1\n30177 Hannover\nDeutschland",
+    "phone": "+49 511 67058300",
+    "fax": "+49 511 9565666",
+    "email": "datenschutz@hannoversche-leben.de",
     "web": "https://www.hannoversche.de/",
     "sources": [
         "https://www.hannoversche.de/datenschutz/allgemeine-informationen",
-        "https://github.com/datenanfragen/data/pull/1213"
+        "https://github.com/datenanfragen/data/pull/1213",
+        "https://www.hannoversche.de/datenschutz"
     ],
     "quality": "verified"
 }


### PR DESCRIPTION
This suggestion was submitted through the website.

**[Edit](https://company-json.datenanfragen.de/#!doc=%7B%22slug%22%3A%22hannoversche%22%2C%22relevant-countries%22%3A%5B%22de%22%5D%2C%22categories%22%3A%5B%22insurance%22%5D%2C%22name%22%3A%22Hannoversche%20Le%C2%ADbens%C2%ADver%C2%ADsiche%C2%ADrung%20AG%22%2C%22address%22%3A%22Hannoversche%20Lebens%C2%ADversicherung%20AG%5CnVHV-Platz%201%5CnD-30177%20Hannover%22%2C%22phone%22%3A%220511%2F9565-0%22%2C%22fax%22%3A%220511%2F9565-666%22%2C%22email%22%3A%22service%40hannoversche.de%22%2C%22web%22%3A%22https%3A%2F%2Fwww.hannoversche.de%2F%22%2C%22sources%22%3A%5B%22https%3A%2F%2Fwww.hannoversche.de%2Fdatenschutz%2Fallgemeine-informationen%22%2C%22https%3A%2F%2Fgithub.com%2Fdatenanfragen%2Fdata%2Fpull%2F1213%22%5D%2C%22quality%22%3A%22verified%22%7D)**