### PR TITLE
Add 'Basler Sachversicherungs-AG und Basler Lebensversicherungs-AG' (community contribution)

### DIFF
--- a/companies/basler-versicherungen.json
+++ b/companies/basler-versicherungen.json
@@ -1,13 +1,17 @@
 {
-    "slug": "basler",
+    "slug": "basler-versicherungen",
     "relevant-countries": [
         "de"
     ],
     "categories": [
         "insurance"
     ],
-    "name": "Basler Sachversicherungs-AG und Basler Lebensversicherungs-AG",
-    "address": "Basler Straße 4\n61352 Bad Homburg",
+    "name": "Basler Versicherungen",
+    "runs": [
+        "Basler Sachversicherungs-AG",
+        "Basler Lebensversicherungs-AG"
+    ],
+    "address": "Basler Straße 4\n61352 Bad Homburg\nDeutschland",
     "phone": "+49 6172 1254600",
     "fax": "+49 6172 1254056",
     "email": "datenschutz@basler.de",
@@ -16,5 +20,6 @@
         "https://www.basler.de/de/ueber-uns/datenschutz.html",
         "https://github.com/datenanfragen/data/pull/1239"
     ],
+    "suggested-transport-medium": "email",
     "quality": "verified"
 }

--- a/companies/basler.json
+++ b/companies/basler.json
@@ -1,0 +1,20 @@
+{
+    "slug": "basler",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "insurance"
+    ],
+    "name": "Basler Sachversicherungs-AG und Basler Lebensversicherungs-AG",
+    "address": "Basler Straße 4\n61352 Bad Homburg",
+    "phone": "+49 6172 1254600",
+    "fax": "+49 6172 1254056",
+    "email": "datenschutz@basler.de",
+    "web": "https://www.basler.de",
+    "sources": [
+        "https://www.basler.de/de/ueber-uns/datenschutz.html",
+        "https://github.com/datenanfragen/data/pull/1239"
+    ],
+    "quality": "verified"
+}


### PR DESCRIPTION
This suggestion was submitted through the website.

**[Edit](https://company-json.datenanfragen.de/#!doc=%7B%22slug%22%3A%22basler%22%2C%22relevant-countries%22%3A%5B%22de%22%5D%2C%22categories%22%3A%5B%22insurance%22%5D%2C%22name%22%3A%22Basler%20Sachversicherungs-AG%20und%20Basler%20Lebensversicherungs-AG%22%2C%22address%22%3A%22Basler%20Stra%C3%9Fe%204%5Cn61352%20Bad%20Homburg%22%2C%22phone%22%3A%22%2B49%206172%201254600%22%2C%22fax%22%3A%22%2B49%206172%201254056%22%2C%22email%22%3A%22datenschutz%40basler.de%22%2C%22web%22%3A%22https%3A%2F%2Fwww.basler.de%22%2C%22sources%22%3A%5B%22https%3A%2F%2Fwww.basler.de%2Fde%2Fueber-uns%2Fdatenschutz.html%22%2C%22https%3A%2F%2Fgithub.com%2Fdatenanfragen%2Fdata%2Fpull%2F1239%22%5D%2C%22quality%22%3A%22verified%22%7D)**