### PR TITLE
Add 'ProSiebenSat.1 Digital GmbH' (community contribution)

### DIFF
--- a/companies/sat1.json
+++ b/companies/sat1.json
@@ -1,16 +1,13 @@
 {
-    "slug": "sat1",
+    "slug": "prosiebensat1",
     "relevant-countries": [
         "de"
     ],
     "categories": [
         "entertainment"
     ],
-    "name": "ProSiebenSat.1 Digital GmbH",
-    "runs": [
-        "https://www.7pass.de"
-    ],
-    "address": "ProSiebenSat.1 Digital GmbH\nDatenschutzbeauftragter\nMedienallee 4\nD-85774 Unterföhring",
+    "name": "SAT1.de",
+    "address": "c/o ProSiebenSat.1 Digital GmbH\nMedienallee 4\n85774 Unterföhring\nDeutschland",
     "phone": "+49 89 950710",
     "email": "datenschutz@sat1.de",
     "web": "https://www.sat1.de",
@@ -18,8 +15,6 @@
         "https://www.sat1.de/service/agb/datenschutz",
         "https://github.com/datenanfragen/data/pull/1241"
     ],
-    "comments": [
-        "Vermutlich  ist die ProSiebenSat.1 Digital GmbH noch für weitere Webauftritte der TV-Sendergruppe verantwortlich. Emailadressen und URLs  dürften dann abweichen. Vielleicht gibt es noch eine übergeordnete Unternehmensseite."
-    ],
+    "suggested-transport-medium": "email",
     "quality": "verified"
 }

--- a/companies/sat1.json
+++ b/companies/sat1.json
@@ -1,0 +1,25 @@
+{
+    "slug": "sat1",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "entertainment"
+    ],
+    "name": "ProSiebenSat.1 Digital GmbH",
+    "runs": [
+        "https://www.7pass.de"
+    ],
+    "address": "ProSiebenSat.1 Digital GmbH\nDatenschutzbeauftragter\nMedienallee 4\nD-85774 Unterföhring",
+    "phone": "+49 89 950710",
+    "email": "datenschutz@sat1.de",
+    "web": "https://www.sat1.de",
+    "sources": [
+        "https://www.sat1.de/service/agb/datenschutz",
+        "https://github.com/datenanfragen/data/pull/1241"
+    ],
+    "comments": [
+        "Vermutlich  ist die ProSiebenSat.1 Digital GmbH noch für weitere Webauftritte der TV-Sendergruppe verantwortlich. Emailadressen und URLs  dürften dann abweichen. Vielleicht gibt es noch eine übergeordnete Unternehmensseite."
+    ],
+    "quality": "verified"
+}

--- a/companies/sat1de.json
+++ b/companies/sat1de.json
@@ -1,5 +1,5 @@
 {
-    "slug": "prosiebensat1",
+    "slug": "sat1de",
     "relevant-countries": [
         "de"
     ],


### PR DESCRIPTION
This suggestion was submitted through the website.

**[Edit](https://company-json.datenanfragen.de/#!doc=%7B%22slug%22%3A%22sat1%22%2C%22relevant-countries%22%3A%5B%22de%22%5D%2C%22categories%22%3A%5B%22entertainment%22%5D%2C%22name%22%3A%22ProSiebenSat.1%20Digital%20GmbH%22%2C%22runs%22%3A%5B%22https%3A%2F%2Fwww.7pass.de%22%5D%2C%22address%22%3A%22ProSiebenSat.1%20Digital%20GmbH%5CnDatenschutzbeauftragter%5CnMedienallee%204%5CnD-85774%20Unterf%C3%B6hring%22%2C%22phone%22%3A%22%2B49%2089%20950710%22%2C%22email%22%3A%22datenschutz%40sat1.de%22%2C%22web%22%3A%22https%3A%2F%2Fwww.sat1.de%22%2C%22sources%22%3A%5B%22https%3A%2F%2Fwww.sat1.de%2Fservice%2Fagb%2Fdatenschutz%22%2C%22https%3A%2F%2Fgithub.com%2Fdatenanfragen%2Fdata%2Fpull%2F1241%22%5D%2C%22comments%22%3A%5B%22Vermutlich%20%20ist%20die%20ProSiebenSat.1%20Digital%20GmbH%20noch%20f%C3%BCr%20weitere%20Webauftritte%20der%20TV-Sendergruppe%20verantwortlich.%20Emailadressen%20und%20URLs%20%20d%C3%BCrften%20dann%20abweichen.%20Vielleicht%20gibt%20es%20noch%20eine%20%C3%BCbergeordnete%20Unternehmensseite.%22%5D%2C%22quality%22%3A%22verified%22%7D)**