### PR TITLE
Add 'Gartentraum.de' (community contribution)

### DIFF
--- a/companies/gartentraum.json
+++ b/companies/gartentraum.json
@@ -1,0 +1,19 @@
+{
+    "slug": "gartentraum",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "commerce",
+        "ads"
+    ],
+    "name": "Gartentraum.de",
+    "address": "Rudolstädter Str. 39\n07745\nJena\nGermany",
+    "web": "https://www.gartentraum.de/",
+    "sources": [
+        "https://www.gartentraum.de/Impressum",
+        "https://www.gartentraum.de/datenschutzbestimmungen",
+        "https://github.com/datenanfragen/data/pull/1249"
+    ],
+    "quality": "verified"
+}

--- a/companies/gartentraum.json
+++ b/companies/gartentraum.json
@@ -1,14 +1,17 @@
 {
     "slug": "gartentraum",
     "relevant-countries": [
-        "de"
+        "all"
     ],
     "categories": [
         "commerce",
         "ads"
     ],
     "name": "Gartentraum.de",
-    "address": "Rudolstädter Str. 39\n07745\nJena\nGermany",
+    "address": "Rudolstädter Str. 39\n07745 Jena\nGermany",
+    "phone": "+49 3641 4787510",
+    "fax": "+49 3641 4787529",
+    "email": "service@gartentraum.de",
     "web": "https://www.gartentraum.de/",
     "sources": [
         "https://www.gartentraum.de/Impressum",


### PR DESCRIPTION
This suggestion was submitted through the website.

**[Edit](https://company-json.datenanfragen.de/#!doc=%7B%22slug%22%3A%22gartentraum%22%2C%22relevant-countries%22%3A%5B%22de%22%5D%2C%22categories%22%3A%5B%22commerce%22%2C%22ads%22%5D%2C%22name%22%3A%22Gartentraum.de%22%2C%22address%22%3A%22Rudolst%C3%A4dter%20Str.%2039%5Cn07745%5CnJena%5CnGermany%22%2C%22web%22%3A%22https%3A%2F%2Fwww.gartentraum.de%2F%22%2C%22sources%22%3A%5B%22https%3A%2F%2Fwww.gartentraum.de%2FImpressum%22%2C%22https%3A%2F%2Fwww.gartentraum.de%2Fdatenschutzbestimmungen%22%2C%22https%3A%2F%2Fgithub.com%2Fdatenanfragen%2Fdata%2Fpull%2F1249%22%5D%2C%22quality%22%3A%22verified%22%7D)**