### PR TITLE
Add 'hamburg.de GmbH & Co. KG' (community contribution)

### DIFF
--- a/companies/hamburg.json
+++ b/companies/hamburg.json
@@ -4,15 +4,16 @@
         "de"
     ],
     "name": "hamburg.de GmbH & Co. KG",
-    "address": "Rothenbaumchaussee 80b\n20148 Hamburg",
+    "address": "Rothenbaumchaussee 80b\n20148 Hamburg\nDeutschland",
+    "phone": "+49 40 688757600",
+    "fax": "+49 40 688757800",
     "email": "datenschutz@hamburg.de",
     "web": "https://www.hamburg.de",
     "sources": [
         "https://www.hamburg.de/datenschutz",
-        "https://github.com/datenanfragen/data/pull/1253"
+        "https://github.com/datenanfragen/data/pull/1253",
+        "https://www.hamburg.de/impressum/"
     ],
-    "comments": [
-        "Bei der Bearbeitung kann es möglich sein, dass der Betreiber um einen Identitätsnachweis bittet. Dieses ergibt sich im Einzelfall."
-    ],
+    "suggested-transport-medium": "email",
     "quality": "verified"
 }

--- a/companies/hamburg.json
+++ b/companies/hamburg.json
@@ -1,0 +1,18 @@
+{
+    "slug": "hamburg",
+    "relevant-countries": [
+        "de"
+    ],
+    "name": "hamburg.de GmbH & Co. KG",
+    "address": "Rothenbaumchaussee 80b\n20148 Hamburg",
+    "email": "datenschutz@hamburg.de",
+    "web": "https://www.hamburg.de",
+    "sources": [
+        "https://www.hamburg.de/datenschutz",
+        "https://github.com/datenanfragen/data/pull/1253"
+    ],
+    "comments": [
+        "Bei der Bearbeitung kann es möglich sein, dass der Betreiber um einen Identitätsnachweis bittet. Dieses ergibt sich im Einzelfall."
+    ],
+    "quality": "verified"
+}


### PR DESCRIPTION
This suggestion was submitted through the website.

**[Edit](https://company-json.datenanfragen.de/#!doc=%7B%22slug%22%3A%22hamburg%22%2C%22relevant-countries%22%3A%5B%22de%22%5D%2C%22name%22%3A%22hamburg.de%20GmbH%20%26%20Co.%20KG%22%2C%22address%22%3A%22Rothenbaumchaussee%2080b%5Cn20148%20Hamburg%22%2C%22email%22%3A%22datenschutz%40hamburg.de%22%2C%22web%22%3A%22https%3A%2F%2Fwww.hamburg.de%22%2C%22sources%22%3A%5B%22https%3A%2F%2Fwww.hamburg.de%2Fdatenschutz%22%2C%22https%3A%2F%2Fgithub.com%2Fdatenanfragen%2Fdata%2Fpull%2F1253%22%5D%2C%22comments%22%3A%5B%22Bei%20der%20Bearbeitung%20kann%20es%20m%C3%B6glich%20sein%2C%20dass%20der%20Betreiber%20um%20einen%20Identit%C3%A4tsnachweis%20bittet.%20Dieses%20ergibt%20sich%20im%20Einzelfall.%22%5D%2C%22quality%22%3A%22verified%22%7D)**