### PR TITLE
Add 'Netleih GmbH & Co. KG' (community contribution)

### DIFF
--- a/companies/videobuster.json
+++ b/companies/videobuster.json
@@ -1,0 +1,22 @@
+{
+    "slug": "videobuster",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "entertainment"
+    ],
+    "name": "Netleih GmbH & Co. KG",
+    "address": "Johann-Zincken-Straße 6\n38723 Seesen\nDeutschland",
+    "phone": "+49 5381 74929898",
+    "email": "datenschutz@videobuster.de",
+    "web": "https://www.videobuster.de",
+    "sources": [
+        "https://www.videobuster.de/datenschutz",
+        "https://github.com/datenanfragen/data/pull/1254"
+    ],
+    "comments": [
+        "Externer Datenschutzbeauftragter:\nHerr Markus Strauss\ntacticx Consulting GmbH\nWalbecker Straße 53\n47608 Geldern\n\nDer Anbieter weißt darauf hin , dass in bestimmten Fällen möglicherweise zusätzliche Informatione angefordert werden, um die Identität festzustellen. So kann z. B. bei der Wahrnehmung des Auskunftsanspruchs sichergestellt werden, dass Informationen nicht an unbefugte Personen herausgegeben werden."
+    ],
+    "quality": "verified"
+}

--- a/companies/videobuster.json
+++ b/companies/videobuster.json
@@ -7,16 +7,18 @@
         "entertainment"
     ],
     "name": "Netleih GmbH & Co. KG",
-    "address": "Johann-Zincken-Straße 6\n38723 Seesen\nDeutschland",
+    "runs": [
+        "VIDEOBUSTER.de"
+    ],
+    "address": "c/o tacticx Consulting GmbH\nWalbecker Straße 53\n47608 Geldern\nDeutschland",
     "phone": "+49 5381 74929898",
+    "fax": "+49 5381 74929899",
     "email": "datenschutz@videobuster.de",
     "web": "https://www.videobuster.de",
     "sources": [
         "https://www.videobuster.de/datenschutz",
-        "https://github.com/datenanfragen/data/pull/1254"
-    ],
-    "comments": [
-        "Externer Datenschutzbeauftragter:\nHerr Markus Strauss\ntacticx Consulting GmbH\nWalbecker Straße 53\n47608 Geldern\n\nDer Anbieter weißt darauf hin , dass in bestimmten Fällen möglicherweise zusätzliche Informatione angefordert werden, um die Identität festzustellen. So kann z. B. bei der Wahrnehmung des Auskunftsanspruchs sichergestellt werden, dass Informationen nicht an unbefugte Personen herausgegeben werden."
+        "https://github.com/datenanfragen/data/pull/1254",
+        "https://www.videobuster.de/impressum"
     ],
     "quality": "verified"
 }


### PR DESCRIPTION
This suggestion was submitted through the website.

**[Edit](https://company-json.datenanfragen.de/#!doc=%7B%22slug%22%3A%22videobuster%22%2C%22relevant-countries%22%3A%5B%22de%22%5D%2C%22categories%22%3A%5B%22entertainment%22%5D%2C%22name%22%3A%22Netleih%20GmbH%20%26%20Co.%20KG%22%2C%22address%22%3A%22Johann-Zincken-Stra%C3%9Fe%206%5Cn38723%20Seesen%5CnDeutschland%22%2C%22phone%22%3A%22%2B49%205381%2074929898%22%2C%22email%22%3A%22datenschutz%40videobuster.de%22%2C%22web%22%3A%22https%3A%2F%2Fwww.videobuster.de%22%2C%22sources%22%3A%5B%22https%3A%2F%2Fwww.videobuster.de%2Fdatenschutz%22%2C%22https%3A%2F%2Fgithub.com%2Fdatenanfragen%2Fdata%2Fpull%2F1254%22%5D%2C%22comments%22%3A%5B%22Externer%20Datenschutzbeauftragter%3A%5CnHerr%20Markus%20Strauss%5Cntacticx%20Consulting%20GmbH%5CnWalbecker%20Stra%C3%9Fe%2053%5Cn47608%20Geldern%5Cn%5CnDer%20Anbieter%20wei%C3%9Ft%20darauf%20hin%20%2C%20dass%20in%20bestimmten%20F%C3%A4llen%20m%C3%B6glicherweise%20zus%C3%A4tzliche%20Informatione%20angefordert%20werden%2C%20um%20die%20Identit%C3%A4t%20festzustellen.%20So%20kann%20z.%20B.%20bei%20der%20Wahrnehmung%20des%20Auskunftsanspruchs%20sichergestellt%20werden%2C%20dass%20Informationen%20nicht%20an%20unbefugte%20Personen%20herausgegeben%20werden.%22%5D%2C%22quality%22%3A%22verified%22%7D)**