### PR TITLE
Add 'Buhl Data Service GmbH' (community contribution)

### DIFF
--- a/companies/buhl-de.json
+++ b/companies/buhl-de.json
@@ -1,19 +1,19 @@
 {
-    "slug": "buhl",
+    "slug": "buhl-de",
     "relevant-countries": [
         "de"
     ],
     "name": "Buhl Data Service GmbH",
-    "address": "Am Siebertsweiher 3/5\n57290 Neunkirchen",
+    "address": "Am Siebertsweiher 3/5\n57290 Neunkirchen\nDeutschland",
+    "phone": "+49 2735 909699",
     "fax": "+49 2735 77619",
     "email": "datenschutz@buhl-data.com",
     "web": "https://www.buhl.de",
     "sources": [
         "https://www.buhl.de/datenschutz",
+        "https://www.buhl.de/impressum/",
         "https://github.com/datenanfragen/data/pull/1260"
     ],
-    "comments": [
-        "Eine Anfrage per Email eröffnet ein Ticket beim Kundenservice. Die Zustellung der Askunft erfolgt auf dem Postweg."
-    ],
+    "suggested-transport-medium": "email",
     "quality": "verified"
 }

--- a/companies/buhl.json
+++ b/companies/buhl.json
@@ -1,0 +1,19 @@
+{
+    "slug": "buhl",
+    "relevant-countries": [
+        "de"
+    ],
+    "name": "Buhl Data Service GmbH",
+    "address": "Am Siebertsweiher 3/5\n57290 Neunkirchen",
+    "fax": "+49 2735 77619",
+    "email": "datenschutz@buhl-data.com",
+    "web": "https://www.buhl.de",
+    "sources": [
+        "https://www.buhl.de/datenschutz",
+        "https://github.com/datenanfragen/data/pull/1260"
+    ],
+    "comments": [
+        "Eine Anfrage per Email eröffnet ein Ticket beim Kundenservice. Die Zustellung der Askunft erfolgt auf dem Postweg."
+    ],
+    "quality": "verified"
+}


### PR DESCRIPTION
This suggestion was submitted through the website.

**[Edit](https://company-json.datenanfragen.de/#!doc=%7B%22slug%22%3A%22buhl%22%2C%22relevant-countries%22%3A%5B%22de%22%5D%2C%22name%22%3A%22Buhl%20Data%20Service%20GmbH%22%2C%22address%22%3A%22Am%20Siebertsweiher%203%2F5%5Cn57290%20Neunkirchen%22%2C%22fax%22%3A%22%2B49%202735%2077619%22%2C%22email%22%3A%22datenschutz%40buhl-data.com%22%2C%22web%22%3A%22https%3A%2F%2Fwww.buhl.de%22%2C%22sources%22%3A%5B%22https%3A%2F%2Fwww.buhl.de%2Fdatenschutz%22%2C%22https%3A%2F%2Fgithub.com%2Fdatenanfragen%2Fdata%2Fpull%2F1260%22%5D%2C%22comments%22%3A%5B%22Eine%20Anfrage%20per%20Email%20er%C3%B6ffnet%20ein%20Ticket%20beim%20Kundenservice.%20Die%20Zustellung%20der%20Askunft%20erfolgt%20auf%20dem%20Postweg.%22%5D%2C%22quality%22%3A%22verified%22%7D)**