### PR TITLE
Add 'Pearson Deutschland GmbH' (community contribution)

### DIFF
--- a/companies/pearson.json
+++ b/companies/pearson.json
@@ -1,0 +1,19 @@
+{
+    "slug": "pearson",
+    "relevant-countries": [
+        "de"
+    ],
+    "name": "Pearson Deutschland GmbH",
+    "address": "St.-Martin-Straße 82\n81541 München\nDeutschland",
+    "phone": "+49 89 954597420",
+    "fax": "+49 89 954597429",
+    "web": "https://www.pearson.de",
+    "sources": [
+        "https://www.pearson.de/datenschutz",
+        "https://github.com/datenanfragen/data/pull/1263"
+    ],
+    "comments": [
+        "Externer Datenschutzbeauftragter:\n\nDr. Felix Wittern, Fieldfisher (Germany) LLP\nAm Sandtorkai 68\n20457 Hamburg\n\nE-Mail: Datenschutz.Pearson@fieldfisher.com\n\n"
+    ],
+    "quality": "verified"
+}

--- a/companies/pearson.json
+++ b/companies/pearson.json
@@ -7,13 +7,15 @@
     "address": "St.-Martin-Straße 82\n81541 München\nDeutschland",
     "phone": "+49 89 954597420",
     "fax": "+49 89 954597429",
+    "email": "datenschutz.Pearson@fieldfisher.com",
     "web": "https://www.pearson.de",
     "sources": [
         "https://www.pearson.de/datenschutz",
         "https://github.com/datenanfragen/data/pull/1263"
     ],
+    "suggested-transport-medium": "email",
     "comments": [
-        "Externer Datenschutzbeauftragter:\n\nDr. Felix Wittern, Fieldfisher (Germany) LLP\nAm Sandtorkai 68\n20457 Hamburg\n\nE-Mail: Datenschutz.Pearson@fieldfisher.com\n\n"
+        "Externer Datenschutzbeauftragter:\n\nFieldfisher (Germany) LLP\nAm Sandtorkai 68\n20457 Hamburg"
     ],
     "quality": "verified"
 }


### PR DESCRIPTION
This suggestion was submitted through the website.

**[Edit](https://company-json.datenanfragen.de/#!doc=%7B%22slug%22%3A%22pearson%22%2C%22relevant-countries%22%3A%5B%22de%22%5D%2C%22name%22%3A%22Pearson%20Deutschland%20GmbH%22%2C%22address%22%3A%22St.-Martin-Stra%C3%9Fe%2082%5Cn81541%20M%C3%BCnchen%5CnDeutschland%22%2C%22phone%22%3A%22%2B49%2089%20954597420%22%2C%22fax%22%3A%22%2B49%2089%20954597429%22%2C%22web%22%3A%22https%3A%2F%2Fwww.pearson.de%22%2C%22sources%22%3A%5B%22https%3A%2F%2Fwww.pearson.de%2Fdatenschutz%22%2C%22https%3A%2F%2Fgithub.com%2Fdatenanfragen%2Fdata%2Fpull%2F1263%22%5D%2C%22comments%22%3A%5B%22Externer%20Datenschutzbeauftragter%3A%5Cn%5CnDr.%20Felix%20Wittern%2C%20Fieldfisher%20(Germany)%20LLP%5CnAm%20Sandtorkai%2068%5Cn20457%20Hamburg%5Cn%5CnE-Mail%3A%20Datenschutz.Pearson%40fieldfisher.com%5Cn%5Cn%22%5D%2C%22quality%22%3A%22verified%22%7D)**