### PR TITLE
Add 'Hannover 96 Sales & Service GmbH & Co.KG' (community contribution)

### DIFF
--- a/companies/shop-hannover96.json
+++ b/companies/shop-hannover96.json
@@ -7,7 +7,7 @@
         "commerce"
     ],
     "name": "Hannover 96 Sales & Service GmbH & Co.KG",
-    "address": "Robert-Enke-Str. 1\n30169 Hannover",
+    "address": "Robert-Enke-Str. 1\n30169 Hannover\nDeutschland",
     "phone": "+49 511 9690096",
     "fax": "+49 511 96900796",
     "email": "datenschutz@hannover96.de",
@@ -16,5 +16,6 @@
         "https://shop.hannover96.de/datenschutzerklaerung",
         "https://github.com/datenanfragen/data/pull/1311"
     ],
+    "suggested-transport-medium": "email",
     "quality": "verified"
 }

--- a/companies/shop-hannover96.json
+++ b/companies/shop-hannover96.json
@@ -1,0 +1,20 @@
+{
+    "slug": "shop-hannover96",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "commerce"
+    ],
+    "name": "Hannover 96 Sales & Service GmbH & Co.KG",
+    "address": "Robert-Enke-Str. 1\n30169 Hannover",
+    "phone": "+49 511 9690096",
+    "fax": "+49 511 96900796",
+    "email": "datenschutz@hannover96.de",
+    "web": "https://shop.hannover96.de",
+    "sources": [
+        "https://shop.hannover96.de/datenschutzerklaerung",
+        "https://github.com/datenanfragen/data/pull/1311"
+    ],
+    "quality": "verified"
+}


### PR DESCRIPTION
This suggestion was submitted through the website.

**[Edit](https://company-json.datenanfragen.de/#!doc=%7B%22slug%22%3A%22shop-hannover96%22%2C%22relevant-countries%22%3A%5B%22de%22%5D%2C%22categories%22%3A%5B%22commerce%22%5D%2C%22name%22%3A%22Hannover%2096%20Sales%20%26%20Service%20GmbH%20%26%20Co.KG%22%2C%22address%22%3A%22Robert-Enke-Str.%201%5Cn30169%20Hannover%22%2C%22phone%22%3A%22%2B49%20511%209690096%22%2C%22fax%22%3A%22%2B49%20511%2096900796%22%2C%22email%22%3A%22datenschutz%40hannover96.de%22%2C%22web%22%3A%22https%3A%2F%2Fshop.hannover96.de%22%2C%22sources%22%3A%5B%22https%3A%2F%2Fshop.hannover96.de%2Fdatenschutzerklaerung%22%2C%22https%3A%2F%2Fgithub.com%2Fdatenanfragen%2Fdata%2Fpull%2F1311%22%5D%2C%22quality%22%3A%22verified%22%7D)**