### PR TITLE
Add 'GIGA.de' (community contribution)

### DIFF
--- a/companies/giga-de.json
+++ b/companies/giga-de.json
@@ -1,10 +1,15 @@
 {
-    "slug": "giga",
+    "slug": "giga-de",
     "relevant-countries": [
         "de"
     ],
+    "categories": [
+        "entertainment"
+    ],
     "name": "GIGA.de",
-    "address": "℅ Ströer Media Brands GmbH\nTorstraße 49\n10119 Berlin-Mitte",
+    "address": "c/o Ströer Media Brands GmbH\nTorstraße 49\n10119 Berlin-Mitte\nDeutschland",
+    "phone": "+49 30 59001130",
+    "fax": "+49 30 590011399",
     "email": "datenschutz-giga@stroeermediabrands.de",
     "web": "https://www.giga.de",
     "sources": [
@@ -13,8 +18,5 @@
         "https://github.com/datenanfragen/data/pull/1337"
     ],
     "suggested-transport-medium": "email",
-    "comments": [
-        "Alternative E-Mail-Adresse: smb-datenschutzbeauftragter@stroeer.de"
-    ],
     "quality": "verified"
 }

--- a/companies/giga.json
+++ b/companies/giga.json
@@ -1,0 +1,20 @@
+{
+    "slug": "giga",
+    "relevant-countries": [
+        "de"
+    ],
+    "name": "GIGA.de",
+    "address": "℅ Ströer Media Brands GmbH\nTorstraße 49\n10119 Berlin-Mitte",
+    "email": "datenschutz-giga@stroeermediabrands.de",
+    "web": "https://www.giga.de",
+    "sources": [
+        "https://www.giga.de/info/impressum",
+        "https://www.giga.de/datenschutz",
+        "https://github.com/datenanfragen/data/pull/1337"
+    ],
+    "suggested-transport-medium": "email",
+    "comments": [
+        "Alternative E-Mail-Adresse: smb-datenschutzbeauftragter@stroeer.de"
+    ],
+    "quality": "verified"
+}


### PR DESCRIPTION
This suggestion was submitted through the website.

**[Edit](https://company-json.datenanfragen.de/#!doc=%7B%22slug%22%3A%22giga%22%2C%22relevant-countries%22%3A%5B%22de%22%5D%2C%22name%22%3A%22GIGA.de%22%2C%22address%22%3A%22%E2%84%85%20Str%C3%B6er%20Media%20Brands%20GmbH%5CnTorstra%C3%9Fe%2049%5Cn10119%20Berlin-Mitte%22%2C%22email%22%3A%22datenschutz-giga%40stroeermediabrands.de%22%2C%22web%22%3A%22https%3A%2F%2Fwww.giga.de%22%2C%22sources%22%3A%5B%22https%3A%2F%2Fwww.giga.de%2Finfo%2Fimpressum%22%2C%22https%3A%2F%2Fwww.giga.de%2Fdatenschutz%22%2C%22https%3A%2F%2Fgithub.com%2Fdatenanfragen%2Fdata%2Fpull%2F1337%22%5D%2C%22suggested-transport-medium%22%3A%22email%22%2C%22comments%22%3A%5B%22Alternative%20E-Mail-Adresse%3A%20smb-datenschutzbeauftragter%40stroeer.de%22%5D%2C%22quality%22%3A%22verified%22%7D)**