### PR TITLE
Add Rundfunkdatenschutzbeauftragte (public broadcasting SVAs)

### DIFF
--- a/supervisory-authorities/derf.json
+++ b/supervisory-authorities/derf.json
@@ -6,11 +6,11 @@
     "name": "Der Rundfunkdatenschutzbeauftragte von BR, SR, WDR, Deutschlandradio und ZDF",
     "address": "Marlene-Dietrich-Allee 20\n14482 Potsdam\nDeutschland",
     "phone": "+49 331 9799385500",
+    "fax": "+49 331 7098985509",
     "email": "kontakt@rundfunkdatenschutz.de",
     "web": "https://www.rundfunkdatenschutz.de/",
     "sources": [
-        "https://www.rundfunkdatenschutz.de/kontakt/",
-        "https://www.deutschlandradio.de/datenschutzerklaerung.1828.de.html"
+        "https://www.rundfunkdatenschutz.de/impressum/"
     ],
     "suggested-transport-medium": "email"
 }

--- a/supervisory-authorities/derf.json
+++ b/supervisory-authorities/derf.json
@@ -1,0 +1,16 @@
+{
+    "slug": "derf",
+    "relevant-countries": [
+        "de"
+    ],
+    "name": "Der Rundfunkdatenschutzbeauftragte von BR, SR, WDR, Deutschlandradio und ZDF",
+    "address": "Marlene-Dietrich-Allee 20\n14482 Potsdam\nDeutschland",
+    "phone": "+49 331 9799385500",
+    "email": "kontakt@rundfunkdatenschutz.de",
+    "web": "https://www.rundfunkdatenschutz.de/",
+    "sources": [
+        "https://www.rundfunkdatenschutz.de/kontakt/",
+        "https://www.deutschlandradio.de/datenschutzerklaerung.1828.de.html"
+    ],
+    "suggested-transport-medium": "email"
+}

--- a/supervisory-authorities/derfdw.json
+++ b/supervisory-authorities/derfdw.json
@@ -7,7 +7,7 @@
     "address": "Kurt-Schumacher-Straße 3\n53113 Bonn\nDeutschland",
     "phone": "+49 228 4290",
     "email": "datenschutz@dw.com",
-    "web": "https://www.dw.com/",
+    "web": "https://www.dw.com/de/datenschutzbericht/a-16130989",
     "sources": [
         "https://www.dw.com/de/definition-und-nutzung-von-daten-durch-die-deutsche-welle-gemäß-eu-dsgvo/a-18265186",
         "https://www.bfdi.bund.de/SharedDocs/Adressen/DE/Rundfunkdatenschutzbeauftragte/DatenschutzbeauftragterDeutscheWelle.html"

--- a/supervisory-authorities/derfdw.json
+++ b/supervisory-authorities/derfdw.json
@@ -5,10 +5,12 @@
     ],
     "name": "Rundfunkdatenschutzbeauftragter Deutsche Welle",
     "address": "Kurt-Schumacher-Straße 3\n53113 Bonn\nDeutschland",
-    "phone": "+49 228 4290",
+    "phone": "+49 228 4292123",
+    "fax": "+49 228 4292120",
     "email": "datenschutz@dw.com",
     "web": "https://www.dw.com/de/datenschutzbericht/a-16130989",
     "sources": [
+        "https://www.rundfunkdatenschutzkonferenz.de/kontakt",
         "https://www.dw.com/de/definition-und-nutzung-von-daten-durch-die-deutsche-welle-gemäß-eu-dsgvo/a-18265186",
         "https://www.bfdi.bund.de/SharedDocs/Adressen/DE/Rundfunkdatenschutzbeauftragte/DatenschutzbeauftragterDeutscheWelle.html"
     ],

--- a/supervisory-authorities/derfdw.json
+++ b/supervisory-authorities/derfdw.json
@@ -11,7 +11,6 @@
     "web": "https://www.dw.com/de/datenschutzbericht/a-16130989",
     "sources": [
         "https://www.rundfunkdatenschutzkonferenz.de/kontakt",
-        "https://www.dw.com/de/definition-und-nutzung-von-daten-durch-die-deutsche-welle-gemäß-eu-dsgvo/a-18265186",
         "https://www.bfdi.bund.de/SharedDocs/Adressen/DE/Rundfunkdatenschutzbeauftragte/DatenschutzbeauftragterDeutscheWelle.html"
     ],
     "suggested-transport-medium": "email"

--- a/supervisory-authorities/derfdw.json
+++ b/supervisory-authorities/derfdw.json
@@ -1,0 +1,16 @@
+{
+    "slug": "derfdw",
+    "relevant-countries": [
+        "de"
+    ],
+    "name": "Rundfunkdatenschutzbeauftragter Deutsche Welle",
+    "address": "Kurt-Schumacher-Straße 3\n53113 Bonn\nDeutschland",
+    "phone": "+49 228 4290",
+    "email": "datenschutz@dw.com",
+    "web": "https://www.dw.com/",
+    "sources": [
+        "https://www.dw.com/de/definition-und-nutzung-von-daten-durch-die-deutsche-welle-gemäß-eu-dsgvo/a-18265186",
+        "https://www.bfdi.bund.de/SharedDocs/Adressen/DE/Rundfunkdatenschutzbeauftragte/DatenschutzbeauftragterDeutscheWelle.html"
+    ],
+    "suggested-transport-medium": "email"
+}

--- a/supervisory-authorities/derfhr.json
+++ b/supervisory-authorities/derfhr.json
@@ -1,0 +1,16 @@
+{
+    "slug": "derfhr",
+    "relevant-countries": [
+        "de"
+    ],
+    "name": "Datenschutzbeauftragter Hessischer Rundfunk",
+    "address": "Bertramstraße 8\n60320 Frankfurt\nDeutschland",
+    "phone": "+49 69 1552541",
+    "email": "datenschutz@hr.de",
+    "web": "https://www.hr.de/",
+    "sources": [
+        "https://www.hr.de/datenschutz/index.html",
+        "https://www.bfdi.bund.de/SharedDocs/Adressen/DE/Rundfunkdatenschutzbeauftragte/DatenschutzbeauftragterHessischerRundfunk.html"
+    ],
+    "suggested-transport-medium": "email"
+}

--- a/supervisory-authorities/derfhr.json
+++ b/supervisory-authorities/derfhr.json
@@ -7,7 +7,7 @@
     "address": "Bertramstraße 8\n60320 Frankfurt\nDeutschland",
     "phone": "+49 69 1552541",
     "email": "datenschutz@hr.de",
-    "web": "https://www.hr.de/",
+    "web": "https://www.hr.de/unternehmen/struktur/datenschutz,ulrich_goehler-datenschutzbeauftragter-100.html",
     "sources": [
         "https://www.hr.de/datenschutz/index.html",
         "https://www.bfdi.bund.de/SharedDocs/Adressen/DE/Rundfunkdatenschutzbeauftragte/DatenschutzbeauftragterHessischerRundfunk.html"

--- a/supervisory-authorities/derfmdr.json
+++ b/supervisory-authorities/derfmdr.json
@@ -7,10 +7,10 @@
     "address": "Kantstraße 71-73\n04275 Leipzig\nDeutschland",
     "phone": "+49 341 3000",
     "email": "rundfunkdatenschutz@mdr.de",
-    "web": "https://www.mdr.de/",
+    "web": "https://www.mdr.de/unternehmen/datenschutz-im-mdr100.html",
     "sources": [
         "https://www.mdr.de/service/datenschutz/index.html",
-        "https://www.bfdi.bund.de/SharedDocs/Adrhttps://www.bfdi.bund.de/SharedDocs/Adressen/DE/Rundfunkdatenschutzbeauftragte/DatenschutzbeauftragterMitteldeutscherRundfunk.html"
+        "https://www.bfdi.bund.de/SharedDocs/Adressen/DE/Rundfunkdatenschutzbeauftragte/DatenschutzbeauftragterMitteldeutscherRundfunk.html"
     ],
     "suggested-transport-medium": "email"
 }

--- a/supervisory-authorities/derfmdr.json
+++ b/supervisory-authorities/derfmdr.json
@@ -11,7 +11,6 @@
     "web": "https://www.mdr.de/unternehmen/datenschutz-im-mdr100.html",
     "sources": [
         "https://www.rundfunkdatenschutzkonferenz.de/kontakt",
-        "https://www.mdr.de/service/datenschutz/index.html",
         "https://www.bfdi.bund.de/SharedDocs/Adressen/DE/Rundfunkdatenschutzbeauftragte/DatenschutzbeauftragterMitteldeutscherRundfunk.html"
     ],
     "suggested-transport-medium": "email"

--- a/supervisory-authorities/derfmdr.json
+++ b/supervisory-authorities/derfmdr.json
@@ -5,10 +5,12 @@
     ],
     "name": "Rundfunkbeauftragter für den Datenschutz beim MDR",
     "address": "Kantstraße 71-73\n04275 Leipzig\nDeutschland",
-    "phone": "+49 341 3000",
+    "phone": "+49 341 3007732",
+    "fax": "+49 341 300297732",
     "email": "rundfunkdatenschutz@mdr.de",
     "web": "https://www.mdr.de/unternehmen/datenschutz-im-mdr100.html",
     "sources": [
+        "https://www.rundfunkdatenschutzkonferenz.de/kontakt",
         "https://www.mdr.de/service/datenschutz/index.html",
         "https://www.bfdi.bund.de/SharedDocs/Adressen/DE/Rundfunkdatenschutzbeauftragte/DatenschutzbeauftragterMitteldeutscherRundfunk.html"
     ],

--- a/supervisory-authorities/derfmdr.json
+++ b/supervisory-authorities/derfmdr.json
@@ -1,0 +1,16 @@
+{
+    "slug": "derfmdr",
+    "relevant-countries": [
+        "de"
+    ],
+    "name": "Rundfunkbeauftragter für den Datenschutz beim MDR",
+    "address": "Kantstraße 71-73\n04275 Leipzig\nDeutschland",
+    "phone": "+49 341 3000",
+    "email": "rundfunkdatenschutz@mdr.de",
+    "web": "https://www.mdr.de/",
+    "sources": [
+        "https://www.mdr.de/service/datenschutz/index.html",
+        "https://www.bfdi.bund.de/SharedDocs/Adrhttps://www.bfdi.bund.de/SharedDocs/Adressen/DE/Rundfunkdatenschutzbeauftragte/DatenschutzbeauftragterMitteldeutscherRundfunk.html"
+    ],
+    "suggested-transport-medium": "email"
+}

--- a/supervisory-authorities/derfndr.json
+++ b/supervisory-authorities/derfndr.json
@@ -6,10 +6,11 @@
     "name": "Rundfunkdatenschutzbeauftragter Norddeutscher Rundfunk",
     "address": "Rothenbaumchaussee 132\n20149 Hamburg\nDeutschland",
     "phone": "+49 40 41562236",
+    "fax": "+49 40 41563452",
     "email": "datenschutz@ndr.de",
     "web": "https://www.ndr.de/der_ndr/unternehmen/organisation/Datenschutz-beimNDR,datenschutz6.html",
     "sources": [
-        "https://www.ndr.de/service/datenschutz/index.html",
+        "https://www.rundfunkdatenschutzkonferenz.de/kontakt",
         "https://www.bfdi.bund.de/SharedDocs/Adressen/DE/Rundfunkdatenschutzbeauftragte/DatenschutzbeauftragterNorddeutscherRundfunk.html"
     ],
     "suggested-transport-medium": "email"

--- a/supervisory-authorities/derfndr.json
+++ b/supervisory-authorities/derfndr.json
@@ -1,0 +1,16 @@
+{
+    "slug": "derfndr",
+    "relevant-countries": [
+        "de"
+    ],
+    "name": "Rundfunkdatenschutzbeauftragter Norddeutscher Rundfunk",
+    "address": "Rothenbaumchaussee 132\n20149 Hamburg\nDeutschland",
+    "phone": "+49 40 41562236",
+    "email": "datenschutz@ndr.de",
+    "web": "https://www.ndr.de/",
+    "sources": [
+        "https://www.ndr.de/service/datenschutz/index.html",
+        "https://www.bfdi.bund.de/SharedDocs/Adressen/DE/Rundfunkdatenschutzbeauftragte/DatenschutzbeauftragterNorddeutscherRundfunk.html"
+    ],
+    "suggested-transport-medium": "email"
+}

--- a/supervisory-authorities/derfndr.json
+++ b/supervisory-authorities/derfndr.json
@@ -7,7 +7,7 @@
     "address": "Rothenbaumchaussee 132\n20149 Hamburg\nDeutschland",
     "phone": "+49 40 41562236",
     "email": "datenschutz@ndr.de",
-    "web": "https://www.ndr.de/",
+    "web": "https://www.ndr.de/der_ndr/unternehmen/organisation/Datenschutz-beimNDR,datenschutz6.html",
     "sources": [
         "https://www.ndr.de/service/datenschutz/index.html",
         "https://www.bfdi.bund.de/SharedDocs/Adressen/DE/Rundfunkdatenschutzbeauftragte/DatenschutzbeauftragterNorddeutscherRundfunk.html"

--- a/supervisory-authorities/derfrb.json
+++ b/supervisory-authorities/derfrb.json
@@ -6,10 +6,11 @@
     "name": "Datenschutzbeauftragte Radio Bremen",
     "address": "Diepenau 10\n28195 Bremen\nDeutschland",
     "phone": "+49 421 24641029",
+    "fax": "+49 421 24641097",
     "email": "datenschutz@radiobremen.de",
-    "web": "https://www.radiobremen.de/",
+    "web": "https://www.radiobremen.de/info/datenschutz/datenschutz-beauftragte-106.html",
     "sources": [
-        "https://www.radiobremen.de/info/datenschutz/index.html",
+        "https://www.radiobremen.de/info/datenschutz/datenschutz-beauftragte-106.html",
         "https://www.bfdi.bund.de/SharedDocs/Adressen/DE/Rundfunkdatenschutzbeauftragte/DatenschutzbeauftragterRadioBremen.html"
     ],
     "suggested-transport-medium": "email"

--- a/supervisory-authorities/derfrb.json
+++ b/supervisory-authorities/derfrb.json
@@ -1,0 +1,16 @@
+{
+    "slug": "derfrb",
+    "relevant-countries": [
+        "de"
+    ],
+    "name": "Datenschutzbeauftragte Radio Bremen",
+    "address": "Diepenau 10\n28195 Bremen\nDeutschland",
+    "phone": "+49 421 24641029",
+    "email": "datenschutz@radiobremen.de",
+    "web": "https://www.radiobremen.de/",
+    "sources": [
+        "https://www.radiobremen.de/info/datenschutz/index.html",
+        "https://www.bfdi.bund.de/SharedDocs/Adressen/DE/Rundfunkdatenschutzbeauftragte/DatenschutzbeauftragterRadioBremen.html"
+    ],
+    "suggested-transport-medium": "email"
+}

--- a/supervisory-authorities/derfrbb.json
+++ b/supervisory-authorities/derfrbb.json
@@ -5,11 +5,12 @@
     ],
     "name": "Datenschutzbeauftragte Rundfunk Berlin-Brandenburg",
     "address": "Masurenallee 8-14\n14057 Berlin\nDeutschland",
-    "phone": "+49 30 979930",
+    "phone": "+49 30 9799310400",
+    "fax": "+49 30 9799360109",
     "email": "datenschutz@rbb-online.de",
     "web": "https://www.rbb-online.de/unternehmen/der_rbb/struktur/datenschutz/datenschutz_im_rbb.html",
     "sources": [
-        "https://www.rbb-online.de/datenschutz/datenschutzerklaerung.html",
+        "https://www.rbb-online.de/unternehmen/der_rbb/struktur/datenschutz/kontakt.html",
         "https://www.bfdi.bund.de/SharedDocs/Adressen/DE/Rundfunkdatenschutzbeauftragte/DatenschutzbeauftragteRundfunkBerlin-Brandenburg.html"
     ],
     "suggested-transport-medium": "email"

--- a/supervisory-authorities/derfrbb.json
+++ b/supervisory-authorities/derfrbb.json
@@ -1,0 +1,16 @@
+{
+    "slug": "derfrbb",
+    "relevant-countries": [
+        "de"
+    ],
+    "name": "Datenschutzbeauftragte Rundfunk Berlin-Brandenburg",
+    "address": "Masurenallee 8-14\n14057 Berlin\nDeutschland",
+    "phone": "+49 30 979930",
+    "email": "datenschutz@rbb-online.de",
+    "web": "https://www.rbb-online.de/",
+    "sources": [
+        "https://www.rbb-online.de/datenschutz/datenschutzerklaerung.html",
+        "https://www.bfdi.bund.de/SharedDocs/Adressen/DE/Rundfunkdatenschutzbeauftragte/DatenschutzbeauftragteRundfunkBerlin-Brandenburg.html"
+    ],
+    "suggested-transport-medium": "email"
+}

--- a/supervisory-authorities/derfrbb.json
+++ b/supervisory-authorities/derfrbb.json
@@ -7,7 +7,7 @@
     "address": "Masurenallee 8-14\n14057 Berlin\nDeutschland",
     "phone": "+49 30 979930",
     "email": "datenschutz@rbb-online.de",
-    "web": "https://www.rbb-online.de/",
+    "web": "https://www.rbb-online.de/unternehmen/der_rbb/struktur/datenschutz/datenschutz_im_rbb.html",
     "sources": [
         "https://www.rbb-online.de/datenschutz/datenschutzerklaerung.html",
         "https://www.bfdi.bund.de/SharedDocs/Adressen/DE/Rundfunkdatenschutzbeauftragte/DatenschutzbeauftragteRundfunkBerlin-Brandenburg.html"

--- a/supervisory-authorities/derfswr.json
+++ b/supervisory-authorities/derfswr.json
@@ -1,0 +1,17 @@
+{
+    "slug": "derfswr",
+    "relevant-countries": [
+        "de"
+    ],
+    "name": "Rundfunkbeauftragter für den Datenschutz beim Südwestrundfunk",
+    "address": "Neckarstraße 230\n70190 Stuttgart\nDeutschland",
+    "phone": "+49 711 92913014",
+    "fax": "+49 711 92913019",
+    "email": "datenschutz@SWR.de",
+    "web": "https://www.swr.de/",
+    "sources": [
+        "https://www.swr.de/unternehmen/organisation/datenschutz-128.html",
+        "https://www.bfdi.bund.de/SharedDocs/Adressen/DE/Rundfunkdatenschutzbeauftragte/DatenschutzbeauftragterSuedwestrundfunk.html"
+    ],
+    "suggested-transport-medium": "email"
+}

--- a/supervisory-authorities/derfswr.json
+++ b/supervisory-authorities/derfswr.json
@@ -7,7 +7,7 @@
     "address": "Neckarstraße 230\n70190 Stuttgart\nDeutschland",
     "phone": "+49 711 92913014",
     "fax": "+49 711 92913019",
-    "email": "datenschutz@SWR.de",
+    "email": "datenschutz@swr.de",
     "web": "https://www.swr.de/",
     "sources": [
         "https://www.swr.de/unternehmen/organisation/datenschutz-128.html",

--- a/supervisory-authorities/derfswr.json
+++ b/supervisory-authorities/derfswr.json
@@ -8,7 +8,7 @@
     "phone": "+49 711 92913014",
     "fax": "+49 711 92913019",
     "email": "datenschutz@swr.de",
-    "web": "https://www.swr.de/",
+    "web": "https://www.swr.de/unternehmen/organisation/datenschutz-128.html",
     "sources": [
         "https://www.swr.de/unternehmen/organisation/datenschutz-128.html",
         "https://www.bfdi.bund.de/SharedDocs/Adressen/DE/Rundfunkdatenschutzbeauftragte/DatenschutzbeauftragterSuedwestrundfunk.html"


### PR DESCRIPTION
Fixes #1126 

- `supervisory-authorities/derf.json`
responsible for BR (Bayerischer Rundfunk), SR (Saarländischer Rundfunk), WDR (Westdeutscher Rundfunk), Deutschlandradio, ZDF (Zweites Deutsches Fernsehen)
- `supervisory-authorities/derfdw.json`
responsible for Deutsche Welle
- `supervisory-authorities/derfhr.json`
responsible for HR (Hessischer Rundfunk)
- `supervisory-authorities/derfmdr.json`
responsible for MDR (Mitteldeutscher Rundfunk)
- `supervisory-authorities/derfndr.json`
responsible for NDR (Norddeutscher Rundfunk)
- `supervisory-authorities/derfrbb.json`
responsible for RBB (Rundfunk Berlin-Brandenburg)
- `supervisory-authorities/derfswr.json`
responsible for SWR (Südwestrundfunk)