### PR TITLE
Translate objection and rectification template to Dutch

### DIFF
--- a/templates/nl/objection-default.txt
+++ b/templates/nl/objection-default.txt
@@ -1,0 +1,19 @@
+Aan wie het aanbelangt:
+
+Ik maak hierbij bezwaar tegen de verwerking van persoonlijke gegevens die mij betreffen voor direct marketingdoeleinden in overeenstemming met artikel 21(2) AVG. Dit bezwaar omvat het gebruik voor profilering voor zover het verband houdt met direct marketing.
+
+Als ik toestemming heb gegeven voor de verwerking van mijn persoonsgegevens voor direct marketingdoeleinden (bijv. volgens artikel 6(1) of artikel 9(2) AVG), trek ik deze toestemming hierbij in.
+
+Ik hoor graag of het bezwaar zal leiden tot de verwijdering van een account die ik mogelijk bij u heb, de annulering van een contract dat ik mogelijk met u heb, of iets dergelijks. Ik zal dan beslissen of dit moet gebeuren.
+
+Mijn verzoek omvat uitdrukkelijk [runs>het volgende, evenals ]alle andere diensten en bedrijven waarvoor u de verwerkingsverantwoordelijke bent zoals gedefinieerd in artikel 4(7) AVG[runs>: {runs_list}].
+
+Zoals beschreven in artikel 12, lid 3 AVG, dient u mij zonder onnodige vertraging en in ieder geval binnen een maand na ontvangst van het verzoek het bezwaar te bevestigen.
+
+Ik neem de volgende informatie op die nodig is om mij te identificeren:
+{id_data}
+Als u mijn verzoek niet binnen de vermelde periode beantwoord, behoud ik het recht om juridische stappen te ondernemen tegen u en een klacht in te dienen bij de daarvoor verantwoordelijke autoriteit.
+
+Bij voorbaat dank.
+
+Hoogachtend,

--- a/templates/nl/rectification-default.txt
+++ b/templates/nl/rectification-default.txt
@@ -1,0 +1,19 @@
+Aan wie het aanbelangt:
+
+Ik verzoek hierbij om rectificatie of aanvulling van onjuiste persoonlijke gegevens over mij in overeenstemming met artikel 16 AVG.
+
+Ik zou graag willen dat de volgende wijzigingen aangebracht worden:
+{rectification_data}
+In het geval dat u de betrokken persoonlijke gegevens aan een of meer ontvangers hebt bekendgemaakt zoals gedefinieerd in artikel 4(9) AVG, moet u mijn verzoek tot rectificatie van de betrokken persoonlijke gegevens aan elke ontvanger meedelen zoals bepaald in artikel 19 AVG. Gelieve mij ook te informeren over die ontvangers.
+
+Mijn verzoek omvat expliciet [runs>het volgende, evenals ]alle andere diensten en bedrijven waarvoor u de verwerkingsverantwoordelijke bent zoals gedefinieerd in artikel 4(7) AVG[runs>: {runs_list}].
+
+Zoals beschreven in artikel 12, lid 3 AVG, dient u mij zonder onnodige vertraging en in ieder geval binnen een maand na ontvangst van het verzoek de rectificatie of aanvulling te bevestigen.
+[has_fields>
+Ik neem de volgende informatie op die nodig is om mij te identificeren:
+{id_data}]
+Als u mijn verzoek niet binnen de vermelde periode beantwoord, behoud ik het recht om juridische stappen te ondernemen tegen u en een klacht in te dienen bij de daarvoor verantwoordelijke autoriteit.
+
+Bij voorbaat dank.
+
+Hoogachtend,


### PR DESCRIPTION
I've translated the objection and rectification template to the Dutch language.

I've kept the wording consistent between the other Dutch translations. Although I believe that the email greeting "Aan wie het aanbelangt:" isn't correct, I kept it for consistency. If this is something that can be changed I'm willing to do so in a seperate pull request.

[This Quora question](https://nl.quora.com/Hoe-zeg-ik-to-whom-it-may-concern-in-het-Nederlands) goes a bit more in depth. It states that in Flanders (a part of Belgium), it would be considered normal, but in the Netherlands it "absolutely wouldn't be". We don't have a perfect translation for this phrase, although something like "Aan wie het aangaat" might be better. Perhaps it's better to raise a seperate issue for this.