### PR TITLE
Improve Dutch translations to match the default English translations

### DIFF
--- a/templates/nl/access-default.txt
+++ b/templates/nl/access-default.txt
@@ -24,4 +24,6 @@ Ik neem de volgende informatie op die nodig is om mij te identificeren:
 {id_data}]
 Als u mijn verzoek niet binnen de vermelde periode beantwoordt, behoud ik het recht om juridische stappen te ondernemen en een klacht tegen u in te dienen bij de daarvoor verantwoordelijke toezichthoudende autoriteit.
 
+Bij voorbaat dank,
+
 Hoogachtend,

--- a/templates/nl/access-default.txt
+++ b/templates/nl/access-default.txt
@@ -1,4 +1,4 @@
-Aan wie het aanbelangt:
+Geachte heer, mevrouw,
 
 Ik verzoek hierbij om toegang overeenkomstig met artikel 15 AVG. Bevestig alstublieft of u al dan niet persoonlijke gegevens (zoals gedefinieerd in artikel 4, leden 1 en 2, AVG) over mij verwerkt.
 

--- a/templates/nl/access-default.txt
+++ b/templates/nl/access-default.txt
@@ -22,6 +22,6 @@ Zoals bepaald in artikel 12, lid 3, AVG, moet u mij de gevraagde informatie vers
 [has_fields>
 Ik neem de volgende informatie op die nodig is om mij te identificeren:
 {id_data}]
-Als u mijn verzoek niet binnen de gestelde termijn beantwoordt, behoud ik het recht voor om gerechtelijke stappen tegen u te ondernemen en een klacht in te dienen bij de verantwoordelijke toezichthoudende autoriteit.
+Als u mijn verzoek niet binnen de vermelde periode beantwoordt, behoud ik het recht om juridische stappen te ondernemen en een klacht tegen u in te dienen bij de daarvoor verantwoordelijke toezichthoudende autoriteit.
 
 Hoogachtend,

--- a/templates/nl/access-default.txt
+++ b/templates/nl/access-default.txt
@@ -6,7 +6,7 @@ In het geval dat u dat doet, vraag ik hierbij, in overeenstemming met art. 15, l
 1. het doel van de gegevensverwerking;
 2. de categorieën van de betrokken persoonlijke gegevens;
 3. de ontvangers of categorieën van ontvangers aan wie de persoonlijke gegevens zijn of zullen worden verstrekt;
-4. waar mogelijk, de beoogde periode waarin de persoonlijke gegevens worden opgeslagen, of, indien niet mogelijk, de criteria die worden gebruikt om die periode te bepalen;
+4. waar mogelijk, de beoogde periode waarvoor de persoonlijke gegevens worden opgeslagen, of, indien niet mogelijk, de criteria die worden gebruikt om die periode te bepalen;
 5. in de gevallen waar de persoonsgegevens niet bij de betrokkene worden verzameld, alle beschikbare informatie over hun bron;
 6. het bestaan van geautomatiseerde besluitvorming, inclusief profilering, zoals vermeld in artikel 22, leden 1 en 4, AVG en, tenminste in die gevallen, zinvolle informatie over de betrokken logica, evenals het belang en de beoogde gevolgen van dergelijke verwerking voor mij.
 

--- a/templates/nl/access-default.txt
+++ b/templates/nl/access-default.txt
@@ -2,20 +2,21 @@ Aan wie het aanbelangt:
 
 Ik verzoek hierbij om toegang overeenkomstig met artikel 15 AVG. Bevestig alstublieft of u al dan niet persoonlijke gegevens (zoals gedefinieerd in artikel 4, leden 1 en 2, AVG) over mij verwerkt.
 
-In het geval dat u dat doet, vraag ik hierbij toegang tot de volgende informatie overeenkomstig met artikel 15 AVG:
-1. <italic>alle</italic> mij betreffende persoonlijke gegevens die u over mij heeft opgeslagen;
-2. het doel van de verwerking;
-3. de categorieën van de betrokken persoonlijke gegevens;
-4. de ontvangers of categorieën van ontvangers aan wie de persoonlijke gegevens zijn of zullen worden bekendgemaakt;
-5. waar mogelijk, de beoogde periode waarvoor de persoonlijke gegevens worden opgeslagen, of, indien niet mogelijk, de criteria die worden gebruikt om die periode te bepalen;
-6. wanneer de persoonlijke gegevens niet van de betrokkene worden verzameld, alle beschikbare informatie over hun bron;
-7. het bestaan van geautomatiseerde besluitvorming, inclusief profilering, als bedoeld in artikel 22, leden 1 en 4, AVG en, althans in die gevallen, zinvolle informatie over de betrokken logica, evenals het belang en de beoogde gevolgen van dergelijke verwerking voor mij.
+In het geval dat u dat doet, vraag ik hierbij, in overeenstemming met art. 15, lid 3, AVG, een kopie van <italic>alle</italic> persoonlijke data over mij die jullie verwerken, inclusief eventuele gepseudonimiseerde gegevens over mij op grond van artikel 4, lid 5, AVG. Ik verzoek verder toegang tot de volgende data op grond van artikel 15, lid 1, AVG:
+1. het doel van de verwerking;
+2. de categorieën van de betrokken persoonlijke gegevens;
+3. de ontvangers of categorieën van ontvangers aan wie de persoonlijke gegevens zijn of zullen worden bekendgemaakt;
+4. waar mogelijk, de beoogde periode waarvoor de persoonlijke gegevens worden opgeslagen, of, indien niet mogelijk, de criteria die worden gebruikt om die periode te bepalen;
+5. wanneer de persoonlijke gegevens niet van de betrokkene worden verzameld, alle beschikbare informatie over hun bron;
+6. het bestaan van geautomatiseerde besluitvorming, inclusief profilering, als bedoeld in artikel 22, leden 1 en 4, AVG en, tenminste in die gevallen, zinvolle informatie over de betrokken logica, evenals het belang en de beoogde gevolgen van dergelijke verwerking voor mij.
+
+Indien u geanonimiseerde gegevens over mij verwerkt, verzoek ik om hierover geïnformeerd te worden en wil ik dat de gebruikte procedure op een gemakkelijk te begrijpen manier uitgelegd wordt.
 
 Als u mijn persoonlijke gegevens overdraagt naar een derde land of een internationale organisatie, verzoek ik om te worden geïnformeerd over de passende waarborgen overeenkomstig met artikel 46 AVG betreffende de overdracht.
 [data_portability>
 Stel alstublieft de persoonlijke gegevens over mij, die ik u heb verstrekt, voor mij beschikbaar in een gestructureerd, algemeen gebruikt en machine leesbaar formaat zoals vastgesteld in artikel 20, lid 1, AVG.
 ]
-Mijn verzoek omvat expliciet [runs>het volgende, evenals ]alle andere services en bedrijven waarvoor u de controleur bent zoals gedefinieerd in artikel 4, lid 7, AVG[runs>: {runs_list}].
+Mijn verzoek omvat expliciet [runs>het volgende, evenals ]alle andere diensten en bedrijven waarvoor u de controleur bent zoals gedefinieerd in artikel 4, lid 7, AVG[runs>: {runs_list}].
 
 Zoals bepaald in artikel 12, lid 3, AVG, moet u mij de gevraagde informatie verstrekken zonder onnodige vertraging en in elk geval binnen een maand na ontvangst van het verzoek. Volgens artikel 15, lid 3, AVG moet u dit verzoek zonder kosten voor mij beantwoorden.
 [has_fields>

--- a/templates/nl/access-default.txt
+++ b/templates/nl/access-default.txt
@@ -3,14 +3,14 @@ Aan wie het aanbelangt:
 Ik verzoek hierbij om toegang overeenkomstig met artikel 15 AVG. Bevestig alstublieft of u al dan niet persoonlijke gegevens (zoals gedefinieerd in artikel 4, leden 1 en 2, AVG) over mij verwerkt.
 
 In het geval dat u dat doet, vraag ik hierbij, in overeenstemming met art. 15, lid 3, AVG, een kopie van <italic>alle</italic> persoonlijke data over mij die jullie verwerken, inclusief eventuele gepseudonimiseerde gegevens over mij op grond van artikel 4, lid 5, AVG. Ik verzoek verder toegang tot de volgende data op grond van artikel 15, lid 1, AVG:
-1. het doel van de verwerking;
+1. het doel van de gegevensverwerking;
 2. de categorieën van de betrokken persoonlijke gegevens;
-3. de ontvangers of categorieën van ontvangers aan wie de persoonlijke gegevens zijn of zullen worden bekendgemaakt;
-4. waar mogelijk, de beoogde periode waarvoor de persoonlijke gegevens worden opgeslagen, of, indien niet mogelijk, de criteria die worden gebruikt om die periode te bepalen;
-5. wanneer de persoonlijke gegevens niet van de betrokkene worden verzameld, alle beschikbare informatie over hun bron;
-6. het bestaan van geautomatiseerde besluitvorming, inclusief profilering, als bedoeld in artikel 22, leden 1 en 4, AVG en, tenminste in die gevallen, zinvolle informatie over de betrokken logica, evenals het belang en de beoogde gevolgen van dergelijke verwerking voor mij.
+3. de ontvangers of categorieën van ontvangers aan wie de persoonlijke gegevens zijn of zullen worden verstrekt;
+4. waar mogelijk, de beoogde periode waarin de persoonlijke gegevens worden opgeslagen, of, indien niet mogelijk, de criteria die worden gebruikt om die periode te bepalen;
+5. in de gevallen waar de persoonsgegevens niet bij de betrokkene worden verzameld, alle beschikbare informatie over hun bron;
+6. het bestaan van geautomatiseerde besluitvorming, inclusief profilering, zoals vermeld in artikel 22, leden 1 en 4, AVG en, tenminste in die gevallen, zinvolle informatie over de betrokken logica, evenals het belang en de beoogde gevolgen van dergelijke verwerking voor mij.
 
-Indien u geanonimiseerde gegevens over mij verwerkt, verzoek ik om hierover geïnformeerd te worden en wil ik dat de gebruikte procedure op een gemakkelijk te begrijpen manier uitgelegd wordt.
+Indien u geanonimiseerde gegevens over mij verwerkt, verzoek ik om hierover geïnformeerd te worden en verzoek ik dat de gebruikte procedure op een gemakkelijk te begrijpen manier uitgelegd wordt.
 
 Als u mijn persoonlijke gegevens overdraagt naar een derde land of een internationale organisatie, verzoek ik om te worden geïnformeerd over de passende waarborgen overeenkomstig met artikel 46 AVG betreffende de overdracht.
 [data_portability>

--- a/templates/nl/access-tracking.txt
+++ b/templates/nl/access-tracking.txt
@@ -1,4 +1,4 @@
-Aan wie het aanbelangt:
+Geachte heer, mevrouw,
 
 Ik verzoek hierbij om toegang overeenkomstig met artikel 15 AVG. Bevestig alstublieft of u al dan niet persoonlijke gegevens (zoals gedefinieerd in artikel 4, leden 1 en 2, AVG) over mij verwerkt.
 

--- a/templates/nl/access-tracking.txt
+++ b/templates/nl/access-tracking.txt
@@ -6,7 +6,7 @@ In het geval dat u dat doet, vraag ik hierbij, in overeenstemming met art. 15, l
 1. het doel van de gegevensverwerking;
 2. de categorieën van de betrokken persoonlijke gegevens;
 3. de ontvangers of categorieën van ontvangers aan wie de persoonlijke gegevens zijn of zullen worden verstrekt;
-4. waar mogelijk, de beoogde periode waarin de persoonlijke gegevens worden opgeslagen, of, indien niet mogelijk, de criteria die worden gebruikt om die periode te bepalen;
+4. waar mogelijk, de beoogde periode waarvoor de persoonlijke gegevens worden opgeslagen, of, indien niet mogelijk, de criteria die worden gebruikt om die periode te bepalen;
 5. in de gevallen waar de persoonsgegevens niet bij de betrokkene worden verzameld, alle beschikbare informatie over hun bron;
 6. het bestaan van geautomatiseerde besluitvorming, inclusief profilering, zoals vermeld in artikel 22, leden 1 en 4, AVG en, tenminste in die gevallen, zinvolle informatie over de betrokken logica, evenals het belang en de beoogde gevolgen van dergelijke verwerking voor mij.
 

--- a/templates/nl/access-tracking.txt
+++ b/templates/nl/access-tracking.txt
@@ -2,14 +2,15 @@ Aan wie het aanbelangt:
 
 Ik verzoek hierbij om toegang overeenkomstig met artikel 15 AVG. Bevestig alstublieft of u al dan niet persoonlijke gegevens (zoals gedefinieerd in artikel 4, leden 1 en 2, AVG) over mij verwerkt.
 
-In het geval dat u dat doet, vraag ik hierbij toegang tot de volgende informatie overeenkomstig met artikel 15 AVG:
-1. <italic>alle</italic> aan mij toebehorende persoonlijke gegeven die u over mij heeft opgeslagen;
-2. het doel van de gegevensverwerking;
-3. de categorieën van de betrokken persoonlijke gegevens;
-4. de ontvangers of categorieën van ontvangers aan wie de persoonlijke gegevens zijn of zullen worden bekendgemaakt;
-5. waar mogelijk, de beoogde periode waarvoor de persoonlijke gegevens worden opgeslagen, of, indien niet mogelijk, de criteria die worden gebruikt om die periode te bepalen;
-6. waar de data niet direct van de betrokkene verzameld is, alle beschikbare informatie over de bron;
-7. het bestaan van geautomatiseerde besluitvorming, inclusief profilering, als bedoeld in artikel 22, leden 1 en 4, AVG en, althans in die gevallen, zinvolle informatie over de betrokken logica, evenals het belang en de beoogde gevolgen van dergelijke verwerking voor mij.
+In het geval dat u dat doet, vraag ik hierbij, in overeenstemming met art. 15, lid 3 AVG, een kopie van <italic>alle</italic> persoonlijke gegevens over mij die u verwerkt, inclusief eventuele gepseudonimiseerde gegevens over mij volgens artikel 4, lid 5, AVG. Ik verzoek verder om toegang tot de volgende informatie op grond van artikel 15, lid 1, AVG:
+1. het doel van de gegevensverwerking;
+2. de categorieën van de betrokken persoonlijke gegevens;
+3. de ontvangers of categorieën van ontvangers aan wie de persoonlijke gegevens zijn of zullen worden verstrekt;
+4. waar mogelijk, de beoogde periode waarin de persoonlijke gegevens worden opgeslagen, of, indien niet mogelijk, de criteria die worden gebruikt om die periode te bepalen;
+5. in de gevallen waar de persoonsgegevens niet bij de betrokkene worden verzameld, alle beschikbare informatie over hun bron;
+6. het bestaan van geautomatiseerde besluitvorming, inclusief profilering, zoals vermeld in artikel 22, leden 1 en 4, AVG en, tenminste in die gevallen, zinvolle informatie over de betrokken logica, evenals het belang en de beoogde gevolgen van dergelijke verwerking voor mij.
+
+Indien u geanonimiseerde gegevens over mij verwerkt, verzoek ik om hierover geïnformeerd te worden en verzoek ik dat de gebruikte procedure op een gemakkelijk te begrijpen manier uitgelegd wordt.
 
 Als u mijn persoonlijke gegevens overdraagt naar een derde land of een internationale organisatie, verzoek ik om te worden geïnformeerd over de passende waarborgen overeenkomstig met artikel 46 AVG betreffende de overdracht.
 [data_portability>
@@ -17,12 +18,14 @@ Stel alstublieft de persoonlijke gegevens over mij, die ik u heb verstrekt, voor
 ]
 Mijn verzoek omvat expliciet [runs>het volgende, evenals ]alle andere services en bedrijven waarvoor u de controleur bent zoals gedefinieerd in artikel 4, lid 7, AVG[runs>: {runs_list}].
 
-Zoals bepaald in Artikel 12, lid 3 AVG, you have to provide the requested information to me without undue delay and in any event within one month of receipt of the request. According to Article 15(3) GDPR, moet u mij de gevraagde informatie verstrekken zonder onnodige vertraging en in elk geval binnen een maand na ontvangst van het verzoek. Volgens artikel 15, lid 3, AVG moet u dit verzoek zonder kosten voor mij beantwoorden.
+Zoals bepaald in artikel 12, lid 3, AVG, moet u mij de gevraagde informatie verstrekken zonder onnodige vertraging en in elk geval binnen een maand na ontvangst van het verzoek. Volgens artikel 15, lid 3, AVG moet u dit verzoek zonder kosten voor mij beantwoorden.
 
-Vriendlijk verzoek ik u om mij te vertellen welke informatie (cookie nummer, apparaatkenmerk, etc.) nodig is voor u om mijn identiteit vast te stellen en hoe ik die informatie kan verkrijgen.
+Vriendlijk verzoek ik u om mij te vertellen welke informatie (cookie ID, apparaatkenmerk, etc.) nodig is voor u om mijn identiteit vast te stellen en hoe ik die informatie kan verkrijgen.
 [has_fields>
 Mijn contactgegevens zijn:
 {id_data}]
 Als u mijn verzoek niet binnen de vermelde periode beantwoordt, behoud ik het recht om juridische stappen te ondernemen en een klacht tegen u in te dienen bij de daarvoor verantwoordelijke toezichthoudende autoriteit.
+
+Bij voorbaat dank,
 
 Hoogachtend,

--- a/templates/nl/access-tracking.txt
+++ b/templates/nl/access-tracking.txt
@@ -23,6 +23,6 @@ Vriendlijk verzoek ik u om mij te vertellen welke informatie (cookie nummer, app
 [has_fields>
 Mijn contactgegevens zijn:
 {id_data}]
-Als u mijn verzoek niet binnen de gestelde termijn beantwoordt, behoud ik het recht voor om gerechtelijke stappen tegen u te ondernemen en een klacht in te dienen bij de verantwoordelijke toezichthoudende autoriteit.
+Als u mijn verzoek niet binnen de vermelde periode beantwoordt, behoud ik het recht om juridische stappen te ondernemen en een klacht tegen u in te dienen bij de daarvoor verantwoordelijke toezichthoudende autoriteit.
 
 Hoogachtend,

--- a/templates/nl/admonition.txt
+++ b/templates/nl/admonition.txt
@@ -1,8 +1,7 @@
 Aan wie het aanbelangt:
 
-op {request_date} heb ik u een verzoek verstuurd navenant artikel {request_article} GDPR.
+op {request_date} heb ik u een verzoek verstuurd overeenkomstig met artikel {request_article} AVG.
 {Beschrijving van het probleem, bijv.: Helaas heb ik dusver nog geen antwoord ontvangen. De periode van een maand zoals beschreven in artikel 12(3) zin 1 GDPR is daarmee overschreden.}
-
 
 Daarom neem ik nu opnieuw contact met u op. Na de aankomst van deze vermaning, gelieve mijn verzoek binnen twee weken adequaat te beantwoorden. Anders behoud ik het recht om juridische stappen te ondernemen en een klacht tegen u in te dienen bij de daarvoor verantwoordelijke toezichthoudende autoriteit.
 

--- a/templates/nl/admonition.txt
+++ b/templates/nl/admonition.txt
@@ -1,7 +1,7 @@
 Aan wie het aanbelangt:
 
 op {request_date} heb ik u een verzoek verstuurd overeenkomstig met artikel {request_article} AVG.
-{Beschrijving van het probleem, bijv.: Helaas heb ik dusver nog geen antwoord ontvangen. De periode van een maand zoals beschreven in artikel 12(3) zin 1 GDPR is daarmee overschreden.}
+{Beschrijving van het probleem, bijv.: Helaas heb ik dusver nog geen antwoord ontvangen. De periode van een maand zoals beschreven in artikel 12(3) zin 1 AVG is daarmee overschreden.}
 
 Daarom neem ik nu opnieuw contact met u op. Na de aankomst van deze vermaning, gelieve mijn verzoek binnen twee weken adequaat te beantwoorden. Anders behoud ik het recht om juridische stappen te ondernemen en een klacht tegen u in te dienen bij de daarvoor verantwoordelijke toezichthoudende autoriteit.
 

--- a/templates/nl/admonition.txt
+++ b/templates/nl/admonition.txt
@@ -1,4 +1,4 @@
-Aan wie het aanbelangt:
+Geachte heer, mevrouw,
 
 op {request_date} heb ik u een verzoek verstuurd overeenkomstig met artikel {request_article} AVG.
 {Beschrijving van het probleem, bijv.: Helaas heb ik dusver nog geen antwoord ontvangen. De periode van een maand zoals beschreven in artikel 12(3) zin 1 AVG is daarmee overschreden.}

--- a/templates/nl/admonition.txt
+++ b/templates/nl/admonition.txt
@@ -4,7 +4,7 @@ op {request_date} heb ik u een verzoek verstuurd navenant artikel {request_artic
 {Beschrijving van het probleem, bijv.: Helaas heb ik dusver nog geen antwoord ontvangen. De periode van een maand zoals beschreven in artikel 12(3) zin 1 GDPR is daarmee overschreden.}
 
 
-Daarom neem ik nu opnieuw contact met u op. Na de aankomst van deze vermaning, gelieve mijn verzoek binnen twee weken adequaat te beantwoorden. Anders behoud ik mij het recht om juridische stappen tegen u te ondernemen en een klacht in te dienen bij de verantwoordelijke toezichthoudende autoriteit.
+Daarom neem ik nu opnieuw contact met u op. Na de aankomst van deze vermaning, gelieve mijn verzoek binnen twee weken adequaat te beantwoorden. Anders behoud ik het recht om juridische stappen te ondernemen en een klacht tegen u in te dienen bij de daarvoor verantwoordelijke toezichthoudende autoriteit.
 
 Dankuwel.
 

--- a/templates/nl/complaint.txt
+++ b/templates/nl/complaint.txt
@@ -1,6 +1,6 @@
 Aan wie het aanbelangt:
 
-Ik dien hierbij een klacht in op grond van artikel 77 GDPR. Op {request_date}, heb ik een verzoek verstuurd zoals beschreven in artikel {request_article} GDPR aan de volgende verantwoordelijke:
+Ik dien hierbij een klacht in op grond van artikel 77 AVG. Op {request_date}, heb ik een verzoek verstuurd zoals beschreven in artikel {request_article} AVG aan de volgende verantwoordelijke:
 {request_recipient_address}
 
 {Beschrijving van de overtredingen door de verantwoordelijke en de stappen die u ondernomen hebt (bijv. vermaningen of andere correspondentie, inclusief ontvangstbewijzen)}.

--- a/templates/nl/complaint.txt
+++ b/templates/nl/complaint.txt
@@ -1,4 +1,4 @@
-Aan wie het aanbelangt:
+Geachte heer, mevrouw,
 
 Ik dien hierbij een klacht in op grond van artikel 77 AVG. Op {request_date}, heb ik een verzoek verstuurd zoals beschreven in artikel {request_article} AVG aan de volgende verantwoordelijke:
 {request_recipient_address}

--- a/templates/nl/erasure-default.txt
+++ b/templates/nl/erasure-default.txt
@@ -1,4 +1,4 @@
-Aan wie het aanbelangt:
+Geachte heer, mevrouw,
 
 Ik verzoek hierbij om onmiddellijke verwijdering van de mij betreffende persoonsgegevens volgens artikel 17 AVG.
 

--- a/templates/nl/erasure-default.txt
+++ b/templates/nl/erasure-default.txt
@@ -8,7 +8,7 @@ Ik verzoek hierbij om onmiddellijke verwijdering van de mij betreffende persoons
 Ik ben ervan overtuigd dat er voldaan is aan de voorwaarden gesteld in artikel 17 lid 1. U kan geen aanspraak maken op een uitzondering op grond van artikel 17, lid 3, van de AVG, aangezien ik geen publiek figuur ben.
 
 Indien ik toestemmming gegeven heb om mijn persoonlijke gegevens te verwerken (bijvoorbeeld op basis van artikel 6 lid 1 of artikel 9 lid 2 van AVG), trek ik bij deze de toestemming daarvoor in.
-Daarnaast maak ik bezwaar tegen het verwerken van persoonlijke gegevens die op mij betrekking hebben (waaronder ook profilering valt), volgens artikel 21 AVG. Ik verzoek u de verwerking van de gegevens die op mij betrekking hebben te beperken in afwachting van de verificatie of uw legitieme gronden de mijne teniet doen, overeenkomstig met artikel 18, lid 1(d), onder AVG.
+Daarnaast maak ik bezwaar tegen het verwerken van persoonlijke gegevens die op mij betrekking hebben (waaronder ook profilering valt), volgens artikel 21 AVG. Ik verzoek u de verwerking van de gegevens die op mij betrekking hebben te beperken in afwachting van de verificatie of uw legitieme gronden de mijne teniet doen, overeenkomstig met artikel 18, lid 1(d), AVG.
 
 Indien u de eerder genoemde data gepubliceerd heeft, bent u verplicht deze volgens artikel 17, lid 2 AVG om alle redelijke stappen te ondernemen om deze beheerders in te lichten, waaronder ook zoekmachine-exploitanten, welke de hierboven genoemde gegevens verwerken, dat ik het verzoek heb gedaan om alle links, kopieën or replicaties te verwijderen. Dit geld niet alleen voor exacte kopieën van de betrokken gegevens, maar ook voor gegevens waaruit de informatie in de betrokken gegevens kan worden afgeleid.
 

--- a/templates/nl/erasure-default.txt
+++ b/templates/nl/erasure-default.txt
@@ -1,24 +1,24 @@
 Aan wie het aanbelangt:
 
-Ik verzoek hierbij om onmiddellijke verwijdering van de mij betreffende persoonsgegevens volgens artikel 17 van het GDPR.
+Ik verzoek hierbij om onmiddellijke verwijdering van de mij betreffende persoonsgegevens volgens artikel 17 AVG.
 
-[erase_all>Wis alle persoonsgegevens die op mij betrekking hebben zoals beschreven in artikel 4, lid 1, GDPR.][erase_some>Gelieve de volgende data met betrekking tot mij te verwijderen:
+[erase_all>Wis alle persoonsgegevens die op mij betrekking hebben zoals beschreven in artikel 4, lid 1, AVG.][erase_some>Gelieve de volgende data met betrekking tot mij te verwijderen:
 {erasure_data}]
 
-ik ben ervan overtuigd dat er voldaan is aan de voorwaarden gesteld in artikel 17 lid 1. U kan ook geen aanspraak maken op een uitzondering op grond van artikel 17, lid 3, van de GDPR, aangezien ik geen publiek figuur ben.
+Ik ben ervan overtuigd dat er voldaan is aan de voorwaarden gesteld in artikel 17 lid 1. U kan geen aanspraak maken op een uitzondering op grond van artikel 17, lid 3, van de AVG, aangezien ik geen publiek figuur ben.
 
-Indien ik toestemmming gegeven heb om mijn persoonlijke gegevens te verwerken (bijvoorbeeld navenant artikel 6 lid 1 of artikel 9 lid 2 van GDPR), trek ik bij deze de toestemming daarvoor in.
-Daarnaast maak ik bezwaar tegen het verwerken van persoonlijke gegevens die op mij betrekking hebben (waaronder ook profilering valt), volgens artikel 21 GDPR. Ik verzoek u de verwerking van de gegevens die op mij betrekking hebben te beperken in afwachting van de verificatie of uw legitieme gronden de mijne teniet doen, overeenkomstig met artikel 18, lid 1, onder GDPR.
+Indien ik toestemmming gegeven heb om mijn persoonlijke gegevens te verwerken (bijvoorbeeld op basis van artikel 6 lid 1 of artikel 9 lid 2 van AVG), trek ik bij deze de toestemming daarvoor in.
+Daarnaast maak ik bezwaar tegen het verwerken van persoonlijke gegevens die op mij betrekking hebben (waaronder ook profilering valt), volgens artikel 21 AVG. Ik verzoek u de verwerking van de gegevens die op mij betrekking hebben te beperken in afwachting van de verificatie of uw legitieme gronden de mijne teniet doen, overeenkomstig met artikel 18, lid 1(d), onder AVG.
 
-Indien u de eerder genoemde data gepubliceerd heeft, bent u verplicht deze volgens artikel 17, lid 2 GDPR om alle redelijke stappen te ondernemen om deze beheerders in te lichten, waaronder ook zoekmachine-exploitanten, welke de hierboven genoemde gegevens verwerken, dat ik het verzoek heb gedaan om alle links, kopieën or replicaties te verwijderen. Dit geld niet alleen voor exacte kopieën van de betrokken gegevens, maar ook voor gegevens waaruit de informatie in de betrokken gegevens kan worden afgeleid.
+Indien u de eerder genoemde data gepubliceerd heeft, bent u verplicht deze volgens artikel 17, lid 2 AVG om alle redelijke stappen te ondernemen om deze beheerders in te lichten, waaronder ook zoekmachine-exploitanten, welke de hierboven genoemde gegevens verwerken, dat ik het verzoek heb gedaan om alle links, kopieën or replicaties te verwijderen. Dit geld niet alleen voor exacte kopieën van de betrokken gegevens, maar ook voor gegevens waaruit de informatie in de betrokken gegevens kan worden afgeleid.
 
-In het geval dat u de betrokken persoonlijke gegevens met derden gedeeld heeft, dient u mijn verzoek voor verwijdering van de betrokken persoonlijke gegevens, inclusief alle referenties naar de gegevens, door te sturen naar iedere ontvanger zoals beschreven in artikel 19 GDPR. Gelieve mij ook te informeren over de ontvangers.
+In het geval dat u de betrokken persoonlijke gegevens met derden gedeeld heeft, dient u mijn verzoek voor verwijdering van de betrokken persoonlijke gegevens, inclusief alle referenties naar de gegevens, door te sturen naar iedere ontvanger zoals beschreven in artikel 19 AVG. Gelieve mij ook te informeren over de ontvangers.
 
 Als u bezwaar maakt tegen de verzochte verwijdering, moet u dat tegenover mij rechtvaardigen.
 
-Mijn verzoek bevat expliciet [runs>de volgende zowel als ]alle andere diensten en bedrijven voor wie u de beheerder bent zoals gedefinieerd in artikel 4, lid 7 GDPR[runs>: {runs_list}].
+Mijn verzoek omvat uitdrukkelijk [runs>het volgende, evenals ]alle andere diensten en bedrijven waarvoor u de verwerkingsverantwoordelijke bent zoals gedefinieerd in artikel 4, lid 7 AVG[runs>: {runs_list}].
 
-Zoals beschreven in artikel 12, lid 3 GDPR, u dient mij zonder onnodige vertraging en in ieder geval binnen een maand na ontvangst van het verzoek de gegevensverwijdering te bevestigen.
+Zoals beschreven in artikel 12, lid 3 AVG, dient u mij zonder onnodige vertraging en in ieder geval binnen een maand na ontvangst van het verzoek de gegevensverwijdering te bevestigen.
 [has_fields>
 Ik het de volgende informatie bijgevoegd die nodig is om mij te identificeren:
 {id_data}]

--- a/templates/nl/erasure-default.txt
+++ b/templates/nl/erasure-default.txt
@@ -22,8 +22,7 @@ Zoals beschreven in artikel 12, lid 3 GDPR, u dient mij zonder onnodige vertragi
 [has_fields>
 Ik het de volgende informatie bijgevoegd die nodig is om mij te identificeren:
 {id_data}]
-Als u mijn verzoek niet binnen de vermelde periode beantwoord, behoud ik het recht om juridische stappen te ondernemen tegen u en een klacht in te dienen bij de daarvoor verantwoordelijke autoriteit.
-
+Als u mijn verzoek niet binnen de vermelde periode beantwoordt, behoud ik het recht om juridische stappen te ondernemen en een klacht tegen u in te dienen bij de daarvoor verantwoordelijke toezichthoudende autoriteit.
 
 Alvast bedankt.
 

--- a/templates/nl/objection-default.txt
+++ b/templates/nl/objection-default.txt
@@ -1,4 +1,4 @@
-Aan wie het aanbelangt:
+Geachte heer, mevrouw,
 
 Ik maak hierbij bezwaar tegen de verwerking van persoonlijke gegevens die mij betreffen voor direct marketingdoeleinden in overeenstemming met artikel 21(2) AVG. Dit bezwaar omvat het gebruik voor profilering voor zover het verband houdt met direct marketing.
 

--- a/templates/nl/objection-default.txt
+++ b/templates/nl/objection-default.txt
@@ -12,7 +12,7 @@ Zoals beschreven in artikel 12, lid 3 AVG, dient u mij zonder onnodige vertragin
 
 Ik neem de volgende informatie op die nodig is om mij te identificeren:
 {id_data}
-Als u mijn verzoek niet binnen de vermelde periode beantwoord, behoud ik het recht om juridische stappen te ondernemen tegen u en een klacht in te dienen bij de daarvoor verantwoordelijke autoriteit.
+Als u mijn verzoek niet binnen de vermelde periode beantwoordt, behoud ik het recht om juridische stappen te ondernemen en een klacht tegen u in te dienen bij de daarvoor verantwoordelijke toezichthoudende autoriteit.
 
 Bij voorbaat dank.
 

--- a/templates/nl/rectification-default.txt
+++ b/templates/nl/rectification-default.txt
@@ -12,7 +12,7 @@ Zoals beschreven in artikel 12, lid 3 AVG, dient u mij zonder onnodige vertragin
 [has_fields>
 Ik neem de volgende informatie op die nodig is om mij te identificeren:
 {id_data}]
-Als u mijn verzoek niet binnen de vermelde periode beantwoord, behoud ik het recht om juridische stappen te ondernemen tegen u en een klacht in te dienen bij de daarvoor verantwoordelijke autoriteit.
+Als u mijn verzoek niet binnen de vermelde periode beantwoordt, behoud ik het recht om juridische stappen te ondernemen en een klacht tegen u in te dienen bij de daarvoor verantwoordelijke toezichthoudende autoriteit.
 
 Bij voorbaat dank.
 

--- a/templates/nl/rectification-default.txt
+++ b/templates/nl/rectification-default.txt
@@ -1,4 +1,4 @@
-Aan wie het aanbelangt:
+Geachte heer, mevrouw,
 
 Ik verzoek hierbij om rectificatie of aanvulling van onjuiste persoonlijke gegevens over mij in overeenstemming met artikel 16 AVG.
 


### PR DESCRIPTION
As requested by #1378, I took a look at the current Dutch translations and improved them to match more closely with the current English translations and fixed some subtle differences in translations of the same sentence across different templates. 

As discussed in the comments of #1378 I also changed the salutation of all the emails to a more common 'Geachte heer, mevrouw,' (comparable to 'Dear Sir / Madam,').
