### PR TITLE
Updated 'Facebook' company schema

### DIFF
--- a/companies/facebook.json
+++ b/companies/facebook.json
@@ -11,7 +11,7 @@
     "runs": [
         "Facebook, Inc.",
         "Messenger (www.messenger.com)",
-        "Audience Network",
+        "Facebook Audience Network",
         "Spark AR"
     ],
     "address": "4 Grand Canal Square\nGrand Canal Harbour\nDublin 2\nIreland",

--- a/companies/facebook.json
+++ b/companies/facebook.json
@@ -9,7 +9,11 @@
     ],
     "name": "Facebook Ireland Ltd.",
     "runs": [
-        "Facebook, Inc."
+        "Facebook, Inc.",
+        "Messenger (www.messenger.com)",
+        "Instagram (www.instagarm.com)",
+        "Audience Network",
+        "Spark AR"
     ],
     "address": "4 Grand Canal Square\nGrand Canal Harbour\nDublin 2\nIreland",
     "web": "https://www.facebook.com/",
@@ -21,7 +25,10 @@
         "https://github.com/datenanfragen/data/issues/92",
         "https://github.com/datenanfragen/data/issues/93",
         "https://www.facebook.com/help/contact/2032834846972583",
-        "https://github.com/datenanfragen/data/pull/974"
+        "https://github.com/datenanfragen/data/pull/974",
+        "https://www.facebook.com/help/1561485474074139?ref=dp",
+        "https://www.facebook.com/audiencenetwork/",
+        "https://sparkar.facebook.com/ar-studio/"
     ],
     "comments": [
         "Various privacy controls (including the ability to download your data as HTML or JSON) are available via the Facebook website: https://www.facebook.com/settings?tab=your_facebook_information",

--- a/companies/facebook.json
+++ b/companies/facebook.json
@@ -11,7 +11,6 @@
     "runs": [
         "Facebook, Inc.",
         "Messenger (www.messenger.com)",
-        "Instagram (www.instagarm.com)",
         "Audience Network",
         "Spark AR"
     ],


### PR DESCRIPTION
Added few verified products run by Facebook, which don't even have their separate schema, and also added the relevant authentic source for the same.