### PR TITLE
Add Czech translation of templates

### DIFF
--- a/templates/cz/access-default.txt
+++ b/templates/cz/access-default.txt
@@ -1,0 +1,29 @@
+Dobrý den, 
+
+tímto žádám o přístup k osobním údajům podle článku 15 Obecného nařízení o ochraně osobních údajů (GDPR). Prosím potvrďte, zda zpracováváte či nezpracováváte osobní údaje (jak jsou definovány v čl. 4, odst. 1 a 2 GDPR), které se týkají mé osoby.
+
+V případě, že ano, v souladu s čl. 15, odst. 3, prosím o poskytnutí kopie <italic>všech</italic> osobních údajů týkajících se mé osoby, které zpracováváte včetně jakýchkoliv pseudonymizovaných dat o mé osobě podle článku 4, odst. 5 GDPR. Dále žádám o přístup k následujícím informacím podle článku 15, odst. 1 GDPR:
+1. účely zpracování;
+2. kategorie dotčených osobních údajů;
+3. příjemci nebo kategorie příjemců, kterým osobní údaje byly nebo budou zpřístupněny, zejména příjemci ve třetích zemích nebo v mezinárodních organizacích;
+4. plánovaná doba, po kterou budou osobní údaje uloženy, nebo není-li ji možné určit, kritéria použitá ke stanovení této doby;
+5. veškeré dostupné informace o zdroji osobních údajů, pokud nejsou získány od subjektu údajů;
+6. skutečnost, že dochází k automatizovanému rozhodování, včetně profilování, uvedenému v čl. 22 odst. 1 a 4, a přinejmenším v těchto případech smysluplné informace týkající se použitého postupu, jakož i významu a předpoklá­daných důsledků takového zpracování pro subjekt údajů.
+
+V případě, že zpracováváte anonymizovaná data týkající se mé osoby, prosím nejen o informování mě o tom, ale také o vysvětlení použité procedury ve srozumitelné podobě. 
+
+Pokud předáváte mé osobní údaje do třetí země nebo mezinárodní organizaci, žádám být informován o vhodných zárukách podle článku 46 GDPR, které se vztahují k předávání.
+[data_portability>
+Prosím o zpřístupnění dat o mé osobě, které jsem Vám poskytl, ve strukturovaném, běžně používaném a strojově čitelném formátu v souladu s článkem 20, odst. 1 GDPR.
+]
+Moje žádost explicitně zahrnuje [runs>následující stejně jako ]jakékoliv další služby a společnosti, pro něž jste správcem podle článku 4, odst. 7 GDPR[runs>: {runs_list}].
+
+Podle článku 12, odst. 3 GDPR, máte povinnost mi poskytnout vyžadované informace bez zbytečného odkladu a v každém případě do jednoho měsíce od obdržení žádosti. Podle článku 15, odst. 3 GDPR máte povinnost odpovědět na tuto žádost bezplatně. 
+[has_fields>
+Přikládám následující informace nezbytné k identifikování mé osoby:
+{id_data}]
+Pokud neodpovíte na moji žádost ve stanovené lhůtě, vyhrazuji si právo učinit právní kroky a podat stížnost k odpovídajícímu kontrolnímu orgánu.
+
+Předem děkuji.
+
+S pozdravem,

--- a/templates/cz/erasure-default.txt
+++ b/templates/cz/erasure-default.txt
@@ -1,0 +1,29 @@
+Dobrý den, 
+
+tímto žádám o vymazání osobních údajů týkající se mé osoby bez zbytečného odkladu podle článku 17 Obecného nařízení o ochraně osobních údajů (GDPR).
+
+[erase_all>Prosím o vymazání všech osobních údajů týkajících se mé osoby, jak jsou definovány v článku 4, odst. 1 GDPR.][erase_some>Prosím o vymazání následujících osobních údajů týkajících se mé osoby:
+{erasure_data}]
+
+Jsem toho názoru, že jsou naplněny požadavky definované v článku 17, odst. 1 GDPR. A tedy nelze uplatnit výjimku podle článku 17, odst. 3 GDPR, neboť nejsem veřejně činnou osobou.
+
+Pokud jsem souhlasil se zpracováním osobních údajů (např. podle článku 6, odst. 1 nebo článku 9, odst. 2 GDPR), tímto odvolávám souhlas se zpracováním. 
+Kromě toho vznáším námitku ke zpracování osobních údajů týkajících se mé osoby (což zahrnuje profilování), podle článku 21 GDPR. Žádám, abyste omezili zpracování údajů týkajících se mé osoby do ověření, zda Vaše legitimní zájmy mají přednost před mými zájmy podle čl. 18, odst. 1, bodu d) GDPR.
+
+Pokud jste výše zmíněné údaje zveřejnili, jste povinni podle článku 17, odst. 2 GDPR učinit všechny opodstatněné kroky k informování ostatních správců osobních údajů, včetně provozovatelů vyhledávačů, kteří zpracovávají osobní údaje uvedené výše, že žádám o vymazání všech odkazů, kopií nebo replikací. To se týká nejen přesných kopií zmíněných údajů, ale také těch, ze kterých mohou být odvozeny informace obsažené v údajích. 
+
+V případě, že jste sdělili dotčené osobní údaje třetí straně, máte povinnost sdělit moji žádost o výmaz dotčených osobních údajů, jakož i jakékoliv reference na ně, každému příjemci, jak uvádí článek 19 GDPR. Prosím o informování mě o těchto příjemcích.
+
+Pokud nesouhlasíte s žádostí o výmaz, máte povinnost mi podat vysvětlení.
+
+Moje žádost explicitně zahrnuje [runs>následující stejně jako ]jakékoliv další služby a společnosti, pro které jste správcem osobních údajů podle článku 4, odst. 7 GDPR[runs>: {runs_list}].
+
+Jak je stanoveno v článku 12, odst. 3 GDPR, máte povinnost mi potvrdit výmaz bez zbytečného odkladu a v každém případě do jednoho měsíce od obdržení žádosti.
+[has_fields>
+Přikládám následující informace nezbytné k identifikování mé osoby:
+{id_data}]
+Pokud neodpovíte na moji žádost ve stanovené lhůtě, vyhrazuji si právo učinit právní kroky a podat stížnost k odpovídajícímu kontrolnímu orgánu.
+
+Předem děkuji.
+
+S pozdravem,

--- a/templates/cz/objection-default.txt
+++ b/templates/cz/objection-default.txt
@@ -1,0 +1,19 @@
+Dobrý den, 
+
+tímto vznáším námitku proti zpracování osobních údajů týkajících se mé osoby za účelem přímého marketingu podle článku 21, odst. 2 Obecného nařízení o ochraně osobních údajů (GDPR). Tato námitka zahrnuje použití profilování, pokud se týká přímého marketingu.
+
+Pokud jsem udělil souhlas ke zpracování osobních údajů za účelem přímého marketingu (např. podle článku článku 6, odst. 1 nebo článku 9, odst. 2 GDPR), tímto odvolávám tento souhlas.
+
+Prosím o informování mě v předstihu, pokud tato námitka povede ke smazání mého účtu, který u Vás mám, zrušení smlouvy a tak podobně. V případě, že ano, rozhodnu, zda k tomu má dojít.
+
+Moje žádost explicitně zahrnuje [runs>následující stejně jako ]jakékoliv další služby a společnosti, pro které jste správcem osobních údajů podle článku 4, odst. 7 GDPR[runs>: {runs_list}].
+
+Jak je stanoveno v článku 12, odst. 3 GDPR, máte povinnost mi potvrdit námitku bez zbytečného odkladu a v každém případě do jednoho měsíce od obdržení žádosti. 
+
+Přikládám následující informace nezbytné k identifikování mé osoby:
+{id_data}
+Pokud neodpovíte na moji žádost ve stanovené lhůtě, vyhrazuji si právo učinit právní kroky a podat stížnost k odpovídajícímu kontrolnímu orgánu.
+
+Předem děkuji.
+
+S pozdravem,

--- a/templates/cz/rectification-default.txt
+++ b/templates/cz/rectification-default.txt
@@ -1,0 +1,19 @@
+Dobrý den, 
+
+tímto žádám o opravu nebo doplnění nepřesných osobních údajů týkajících se mé osoby podle článku 16 Obecného nařízení o ochraně osobních údajů (GDPR).
+
+Prosím o provedení následujících změn:
+{rectification_data}
+V případě, že jste sdělili dotčené osobní údaje jednomu nebo více příjemcům definovných článkem 4, odst. 9 GDPR, máte povinnosti sdělit moji žádost o opravu dotčených osobních údajů každému příjemci, jak stanovuje článek 19 GDPR. Prosím informujte mě o těchto příjemcích. 
+
+Moje žádost explicitně zahrnuje [runs>následující stejně jako ]jakékoliv další služby a společnosti, pro které jste správcem osobních údajů podle článku 4, odst. 7 GDPR[runs>: {runs_list}].
+
+Jak je stanoveno v článku 12, odst. 3 GDPR, máte povinnost mi potvrdit opravu bez zbytečného odkladu a v každém případě do jednoho měsíce od obdržení žádosti.
+[has_fields>
+Přikládám následující informace nezbytné k identifikování mé osoby:
+{id_data}]
+Pokud neodpovíte na moji žádost ve stanovené lhůtě, vyhrazuji si právo učinit právní kroky a podat stížnost k odpovídajícímu kontrolnímu orgánu.
+
+Předem děkuji.
+
+S pozdravem,


### PR DESCRIPTION
I translated the templates to the Czech language (as mentioned in #229) . 
I checked the terminology with the official translation of GDPR, so it should be okay. 

(Also, @baltpeter I am willing to contribute more, so that datarequests.org website is useful for Czech users (and as a way how to learn more about the GDPR). However, I am not sure what is the priority in this case. Please, let me know, if you find any suitable issues for this case. Thanks!)