### PR TITLE
Add 'DHH - Deutscher Hochseesportverband HANSA e.V. ' (community contribution)

### DIFF
--- a/companies/dhh-de.json
+++ b/companies/dhh-de.json
@@ -4,7 +4,7 @@
         "de"
     ],
     "name": "Deutscher Hochseesportverband HANSA e.V. (DHH)",
-    "address": "Rothenbaumchaussee 58\n20148 Hamburg\nDeustchland",
+    "address": "Rothenbaumchaussee 58\n20148 Hamburg\nDeutschland",
     "email": "datenschutz@dhh.de",
     "web": "https://www.dhh.de",
     "sources": [


### PR DESCRIPTION
This suggestion was submitted through the website.

**[Edit](https://company-json.datenanfragen.de/#!doc=%7B%22slug%22%3A%22dhh-deutscher-hochseesportverband-hansa-e-v%22%2C%22relevant-countries%22%3A%5B%22de%22%5D%2C%22name%22%3A%22DHH%20-%20Deutscher%20Hochseesportverband%20HANSA%20e.V.%20%22%2C%22address%22%3A%22Rothenbaumchaussee%2058%20%5Cn20148%20Hamburg%22%2C%22sources%22%3A%5B%22https%3A%2F%2Fwww.dhh.de%2Fimpressum%22%2C%22https%3A%2F%2Fgithub.com%2Fdatenanfragen%2Fdata%2Fpull%2F1438%22%5D%2C%22quality%22%3A%22verified%22%7D)**