### PR TITLE
Add 'TV Licensing' (community contribution)

### DIFF
--- a/companies/tvlicensing-co.json
+++ b/companies/tvlicensing-co.json
@@ -1,0 +1,23 @@
+{
+    "slug": "tvlicensing-co",
+    "relevant-countries": [
+        "gb"
+    ],
+    "categories": [
+        "telecommunication"
+    ],
+    "name": "TV Licensing",
+    "address": "BBC TV Licensing Management Team\nBroadcast Centre BC2 C6\nWhite City Place\n201 Wood Lane\nLondon \nW12 7TP",
+    "email": "DataProtection.Officer@bbc.co.uk",
+    "web": "https://www.tvlicensing.co.uk/",
+    "sources": [
+        "https://www.tvlicensing.co.uk/privacy-security-policies",
+        "https://www.bbc.co.uk/privacy/",
+        "https://github.com/datenanfragen/data/pull/1440"
+    ],
+    "suggested-transport-medium": "email",
+    "comments": [
+        "The British Broadcasting Corporations ICO registration number is Z517352X"
+    ],
+    "quality": "verified"
+}


### PR DESCRIPTION
This suggestion was submitted through the website.

**[Edit](https://company-json.datenanfragen.de/#!doc=%7B%22slug%22%3A%22tvlicensing-co%22%2C%22relevant-countries%22%3A%5B%22gb%22%5D%2C%22categories%22%3A%5B%22telecommunication%22%5D%2C%22name%22%3A%22TV%20Licensing%22%2C%22address%22%3A%22BBC%20TV%20Licensing%20Management%20Team%5CnBroadcast%20Centre%20BC2%20C6%5CnWhite%20City%20Place%5Cn201%20Wood%20Lane%5CnLondon%20%5CnW12%207TP%22%2C%22email%22%3A%22DataProtection.Officer%40bbc.co.uk%22%2C%22web%22%3A%22https%3A%2F%2Fwww.tvlicensing.co.uk%2F%22%2C%22sources%22%3A%5B%22https%3A%2F%2Fwww.tvlicensing.co.uk%2Fprivacy-security-policies%22%2C%22https%3A%2F%2Fwww.bbc.co.uk%2Fprivacy%2F%22%2C%22https%3A%2F%2Fgithub.com%2Fdatenanfragen%2Fdata%2Fpull%2F1440%22%5D%2C%22suggested-transport-medium%22%3A%22email%22%2C%22comments%22%3A%5B%22The%20British%20Broadcasting%20Corporations%20ICO%20registration%20number%20is%20Z517352X%22%5D%2C%22quality%22%3A%22verified%22%7D)**