### PR TITLE
Update 'Delticom AG' (community contribution)

### DIFF
--- a/companies/delticom.json
+++ b/companies/delticom.json
@@ -11,7 +11,6 @@
         "Reifen-Online-Shop ReifenDirekt.de",
         "Motorradreifen-Online-Shop MotorradreifenDirekt.de",
         "Reifen-Testportal Reifentest.com",
-        "Schneeketten-Online-Shop Schneeketten-24.de",
         "Kompletträder-Online-Shop Komplettraeder24.de",
         "Autoteile-Online-Shop Autoteile-Meile.de (formerly)",
         "Katalysatoren-Online-Shop Katdirekt.de (formerly)",
@@ -27,14 +26,14 @@
         "https://www.reifendirekt.de/datenschutz.html",
         "https://www.motorradreifendirekt.de/i/datenschutz",
         "https://www.reifentest.com/web/pages/datenschutz",
-        "https://www.schneeketten-24.de/datenschutz.html",
         "https://www.komplettraeder24.de/datenschutz.html",
         "https://www.reifendirekt.de/Impressum.html",
-        "https://github.com/datenanfragen/data/pull/1276"
+        "https://github.com/datenanfragen/data/pull/1276",
+        "https://github.com/datenanfragen/data/pull/1454"
     ],
     "suggested-transport-medium": "email",
     "comments": [
-        "Autoteile-Meile.de, Katdirekt.de, Motoroel-direkt.de und Sportfahrwerk.biz wurden mittlerweile von der Delticom AG and die Autodoc Group verkauft. Delticom kann nur Anfragen für vor dem Verkauf verarbeitete Daten beantworten, Anfragen bezogen auf den Zeitraum danach müssen an Autodoc gestellt werden"
+        "Autoteile-Meile.de, Katdirekt.de, Motoroel-direkt.de und Sportfahrwerk.biz wurden mittlerweile von der Delticom AG and die Autodoc Group verkauft. Delticom kann nur Anfragen für vor dem Verkauf verarbeitete Daten beantworten, Anfragen bezogen auf den Zeitraum danach müssen an Autodoc gestellt werden."
     ],
     "quality": "verified"
 }


### PR DESCRIPTION
This suggestion was submitted through the website.

**[Edit](https://company-json.datenanfragen.de/#!doc=%7B%22slug%22%3A%22delticom%22%2C%22relevant-countries%22%3A%5B%22de%22%5D%2C%22categories%22%3A%5B%22commerce%22%5D%2C%22name%22%3A%22Delticom%20AG%22%2C%22runs%22%3A%5B%22Reifen-Online-Shop%20ReifenDirekt.de%22%2C%22Motorradreifen-Online-Shop%20MotorradreifenDirekt.de%22%2C%22Reifen-Testportal%20Reifentest.com%22%2C%22Komplettr%C3%A4der-Online-Shop%20Komplettraeder24.de%22%2C%22Autoteile-Online-Shop%20Autoteile-Meile.de%20(formerly)%22%2C%22Katalysatoren-Online-Shop%20Katdirekt.de%20(formerly)%22%2C%22Motor%C3%B6l-Online-Shop%20Motoroel-direkt.de%20(formerly)%22%2C%22Sportfahrwerk.biz%20(formerly)%22%5D%2C%22address%22%3A%22Br%C3%BChlstra%C3%9Fe%2011%5Cn30169%20Hannover%5CnDeutschland%22%2C%22phone%22%3A%22%2B49%20511%2093634960%22%2C%22fax%22%3A%22%2B49%20511%2087989071%22%2C%22email%22%3A%22datenschutz%40delti.com%22%2C%22web%22%3A%22https%3A%2F%2Fwww.delti.com%2F%22%2C%22sources%22%3A%5B%22https%3A%2F%2Fwww.reifendirekt.de%2Fdatenschutz.html%22%2C%22https%3A%2F%2Fwww.motorradreifendirekt.de%2Fi%2Fdatenschutz%22%2C%22https%3A%2F%2Fwww.reifentest.com%2Fweb%2Fpages%2Fdatenschutz%22%2C%22https%3A%2F%2Fwww.komplettraeder24.de%2Fdatenschutz.html%22%2C%22https%3A%2F%2Fwww.reifendirekt.de%2FImpressum.html%22%2C%22https%3A%2F%2Fgithub.com%2Fdatenanfragen%2Fdata%2Fpull%2F1276%22%2C%22https%3A%2F%2Fgithub.com%2Fdatenanfragen%2Fdata%2Fpull%2F1454%22%5D%2C%22suggested-transport-medium%22%3A%22email%22%2C%22comments%22%3A%5B%22Autoteile-Meile.de%2C%20Katdirekt.de%2C%20Motoroel-direkt.de%20und%20Sportfahrwerk.biz%20wurden%20mittlerweile%20von%20der%20Delticom%20AG%20and%20die%20Autodoc%20Group%20verkauft.%20Delticom%20kann%20nur%20Anfragen%20f%C3%BCr%20vor%20dem%20Verkauf%20verarbeitete%20Daten%20beantworten%2C%20Anfragen%20bezogen%20auf%20den%20Zeitraum%20danach%20m%C3%BCssen%20an%20Autodoc%20gestellt%20werden.%22%5D%2C%22quality%22%3A%22verified%22%7D)**