### PR TITLE
Add 'Bayern Card-Services GmbH - S-Finanzgruppe' (community contribution)

### DIFF
--- a/companies/bayern-card-services-gmbh.json
+++ b/companies/bayern-card-services-gmbh.json
@@ -1,5 +1,5 @@
 {
-    "slug": "bayern-card-services-gmbh-s-finanzgruppe",
+    "slug": "bayern-card-services-gmbh",
     "relevant-countries": [
         "de"
     ],
@@ -7,7 +7,10 @@
         "finance"
     ],
     "name": "Bayern Card-Services GmbH - S-Finanzgruppe",
-    "address": "Barer Straße 24\n80333 München",
+    "address": "Barer Straße 24\n80333 München\nDeutschland",
+    "phone": "+49 89 9040760",
+    "email": "info@bayerncard.de",
+    "web": "https://www.bayerncard.de",
     "sources": [
         "https://www.bayerncard.de/impressum",
         "https://github.com/datenanfragen/data/pull/1462"


### PR DESCRIPTION
This suggestion was submitted through the website.

**[Edit](https://company-json.datenanfragen.de/#!doc=%7B%22slug%22%3A%22bayern-card-services-gmbh-s-finanzgruppe%22%2C%22relevant-countries%22%3A%5B%22de%22%5D%2C%22categories%22%3A%5B%22finance%22%5D%2C%22name%22%3A%22Bayern%20Card-Services%20GmbH%20-%20S-Finanzgruppe%22%2C%22address%22%3A%22Barer%20Stra%C3%9Fe%2024%5Cn80333%20M%C3%BCnchen%22%2C%22sources%22%3A%5B%22https%3A%2F%2Fwww.bayerncard.de%2Fimpressum%22%2C%22https%3A%2F%2Fgithub.com%2Fdatenanfragen%2Fdata%2Fpull%2F1462%22%5D%2C%22quality%22%3A%22verified%22%7D)**