### PR TITLE
Add 'Proxalto Lebensversicherung AG' (community contribution)

### DIFF
--- a/companies/proxalto-lv.json
+++ b/companies/proxalto-lv.json
@@ -1,0 +1,23 @@
+{
+    "slug": "proxalto-lv",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "insurance"
+    ],
+    "name": "Proxalto Lebensversicherung AG",
+    "runs": [
+        "hat die Veträge von Generali Lebensversicherung übernommen"
+    ],
+    "address": "Adenauerring 7\n81737 München",
+    "phone": "022841080",
+    "fax": "022841081550",
+    "email": "datenschutz@viridium-gruppe.com",
+    "web": "https://www.proxalto-lv.de",
+    "sources": [
+        "https://www.proxalto-lv.de/datenschutzbestimmungen/",
+        "https://github.com/datenanfragen/data/pull/1550"
+    ],
+    "quality": "verified"
+}

--- a/companies/proxalto-lv.json
+++ b/companies/proxalto-lv.json
@@ -7,17 +7,15 @@
         "insurance"
     ],
     "name": "Proxalto Lebensversicherung AG",
-    "runs": [
-        "hat die Veträge von Generali Lebensversicherung übernommen"
-    ],
-    "address": "Adenauerring 7\n81737 München",
-    "phone": "022841080",
-    "fax": "022841081550",
+    "address": "20083 Hamburg\nDeutschland",
+    "phone": "+49 40 55554400",
+    "fax": "+49 40 55554499",
     "email": "datenschutz@viridium-gruppe.com",
     "web": "https://www.proxalto-lv.de",
     "sources": [
         "https://www.proxalto-lv.de/datenschutzbestimmungen/",
         "https://github.com/datenanfragen/data/pull/1550"
     ],
+    "suggested-transport-medium": "email",
     "quality": "verified"
 }


### PR DESCRIPTION
This suggestion was submitted through the website.

**[Edit](https://company-json.datenanfragen.de/#!doc=%7B%22slug%22%3A%22proxalto-lv%22%2C%22relevant-countries%22%3A%5B%22de%22%5D%2C%22categories%22%3A%5B%22insurance%22%5D%2C%22name%22%3A%22Proxalto%20Lebensversicherung%20AG%22%2C%22runs%22%3A%5B%22hat%20die%20Vetr%C3%A4ge%20von%20Generali%20Lebensversicherung%20%C3%BCbernommen%22%5D%2C%22address%22%3A%22Adenauerring%207%5Cn81737%20M%C3%BCnchen%22%2C%22phone%22%3A%22022841080%22%2C%22fax%22%3A%22022841081550%22%2C%22email%22%3A%22datenschutz%40viridium-gruppe.com%22%2C%22web%22%3A%22https%3A%2F%2Fwww.proxalto-lv.de%22%2C%22sources%22%3A%5B%22https%3A%2F%2Fwww.proxalto-lv.de%2Fdatenschutzbestimmungen%2F%22%2C%22https%3A%2F%2Fgithub.com%2Fdatenanfragen%2Fdata%2Fpull%2F1550%22%5D%2C%22quality%22%3A%22verified%22%7D )**