### PR TITLE
Add Recharge.com International B.V.

### DIFF
--- a/companies/rechargecom.json
+++ b/companies/rechargecom.json
@@ -24,6 +24,5 @@
         "https://www.guthaben.de/impressum"
     ],
     "suggested-transport-medium": "email",
-    "quality": "verified",
-    "nsfw": false
+    "quality": "verified"
 }

--- a/companies/rechargecom.json
+++ b/companies/rechargecom.json
@@ -23,6 +23,19 @@
         "https://www.guthaben.de/datenschutzerklaerung",
         "https://www.guthaben.de/impressum"
     ],
+    "required-elements": [
+        {
+            "desc": "Name",
+            "type": "name",
+            "optional": true
+        },
+        {
+            "desc": "Email",
+            "type": "email",
+            "optional": false
+        }
+    ],
     "suggested-transport-medium": "email",
-    "quality": "verified"
+    "needs-id-document": false,
+    "quality": "tested"
 }

--- a/companies/rechargecom.json
+++ b/companies/rechargecom.json
@@ -16,7 +16,7 @@
         "guthaben.de",
         "beltegoed.nl"
     ],
-    "address": "Amsteldijk 216\n1079 LK Amsterdam\nNetherlands",
+    "address": "Amsteldijk 216\n1079 LK Amsterdam\nThe Netherlands",
     "phone": "+31 88 006 4109",
     "email": "datarequest@cg.nl",
     "sources": [

--- a/companies/rechargecom.json
+++ b/companies/rechargecom.json
@@ -1,0 +1,29 @@
+{
+    "slug": "rechargecom",
+    "relevant-countries": [
+        "all"
+    ],
+    "categories": [
+        "telecommunication"
+    ],
+    "name": "Recharge.com International B.V.",
+    "runs": [
+        "recharge.com",
+        "rapido.com",
+        "mobiletopup.co.uk",
+        "recharge.fr",
+        "herladen.com",
+        "guthaben.de",
+        "beltegoed.nl"
+    ],
+    "address": "Amsteldijk 216\n1079 LK Amsterdam\nNetherlands",
+    "phone": "+31 88 006 4109",
+    "email": "datarequest@cg.nl",
+    "sources": [
+        "https://www.guthaben.de/datenschutzerklaerung",
+        "https://www.guthaben.de/impressum"
+    ],
+    "suggested-transport-medium": "email",
+    "quality": "verified",
+    "nsfw": false
+}

--- a/companies/rechargecom.json
+++ b/companies/rechargecom.json
@@ -4,7 +4,9 @@
         "all"
     ],
     "categories": [
-        "telecommunication"
+        "telecommunication",
+        "finance",
+        "entertainment"
     ],
     "name": "Recharge.com International B.V.",
     "runs": [


### PR DESCRIPTION
There are conflicting sources for the address: https://www.recharge.com/de/AGB
Google Maps says the one in Amsterdam is correct.

Also, they say they will ask for identification documents:

> In diesen Fällen können wir Sie um eine Kopie Ihres Ausweisdokuments oder Ihres Reisepasses bitten. Wenn Sie uns eine Kopie Ihres Ausweises oder Reisepasses schicken, schwärzen Sie bitte das Foto, die MLZ (maschinenlesbare Zone, den Streifen mit den Zahlen, der sich unten auf Ihrem Reisepass befindet), die Passnummer sowie Ihre Bürgerdienste-Nummer. 

I will test that and I will be happy to complain if neccessary.