### PR TITLE
New PGP-key for Berlin BfDI

### DIFF
--- a/supervisory-authorities/deberlbdi.json
+++ b/supervisory-authorities/deberlbdi.json
@@ -8,8 +8,8 @@
     "phone": "+49 30 138890",
     "fax": "+49 30 2155050",
     "email": "mailbox@datenschutz-berlin.de",
-    "pgp-fingerprint": "D3C9 AEEA B403 7F96 7EF6  C77F B607 1D0F B27C 29A7",
-    "pgp-url": "https://www.datenschutz-berlin.de/email/mailbox_blnbdi.asc",
+    "pgp-fingerprint": "E60A A848 A60A 423A 9F1C  2D08 87E8 7B1C F73B 7E44",
+    "pgp-url": "https://www.datenschutz-berlin.de/fileadmin/user_upload/email/mailbox_blnbdi.asc",
     "web": "https://www.datenschutz-berlin.de",
     "sources": [
         "https://www.datenschutz-berlin.de/kontakt.html"


### PR DESCRIPTION
Apparently the PGP-key (and the link to it *sigh*) for the Berlin BfDI changed.