### PR TITLE
Fixes #1692: Fix broken marked import

### DIFF
--- a/companies/aseag.json
+++ b/companies/aseag.json
@@ -1,5 +1,5 @@
 {
-    "slug": "aseag-de",
+    "slug": "aseag",
     "relevant-countries": [
         "de"
     ],

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
         "@segment/ajv-human-errors": "^2.0.0",
         "@types/all-the-cities": "^3.1.0",
         "@types/glob": "^7.1.4",
+        "@types/marked": "^4.0.2",
         "@types/marked-terminal": "^3.1.2",
         "@types/node": "^14.14.20",
         "@typescript-eslint/eslint-plugin": "^4.12.0",

--- a/src/test-records.ts
+++ b/src/test-records.ts
@@ -177,6 +177,11 @@ const validate = async (dir: string) => {
     if (check_results.flat().filter((r) => r.severity === 'ERROR').length > 0) exit_code = 1;
 };
 
+process.on('unhandledRejection', (err) => {
+    console.error('An unhandled promise rejection occurred:', err);
+    process.exit(1);
+});
+
 (async () => {
     await validate(join(base_dir, 'companies'));
     await validate(join(base_dir, 'supervisory-authorities'));

--- a/src/test-records.ts
+++ b/src/test-records.ts
@@ -7,7 +7,7 @@ import { omit, pick } from 'filter-anything';
 import * as jsonpointer from 'jsonpointer';
 import pc from 'picocolors';
 import asTable from 'as-table';
-import marked = require('marked');
+import { marked } from 'marked';
 import TerminalRenderer from 'marked-terminal';
 import _linters from './checks';
 import { locatorFactory } from './common/locator';

--- a/yarn.lock
+++ b/yarn.lock
@@ -254,6 +254,11 @@
   resolved "https://registry.yarnpkg.com/@types/marked/-/marked-3.0.2.tgz#4a639575542ae7715fabbe450b08118e9093eb35"
   integrity sha512-mGYI9qFs+i5eYaytWKBbtEMbIkrXGKuhsDpDcj70ogKS2gk1NmgEy9Z3VEKz922Lfms6eITXXqv5idlX7C/irw==
 
+"@types/marked@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@types/marked/-/marked-4.0.2.tgz#cb2dbf10da2f41cf20bd91fb5f89b67540c282f7"
+  integrity sha512-auNrZ/c0w6wsM9DccwVxWHssrMDezHUAXNesdp2RQrCVCyrQbOiSq7yqdJKrUQQpw9VTm7CGYJH2A/YG7jjrjQ==
+
 "@types/minimatch@*":
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"


### PR DESCRIPTION
Seems like they removed/broke their TypeScript types between releases.
We now need to use the DefinitelyTyped ones.

See also: markedjs/marked#2364