### PR TITLE
Update deploy script for Typesense 0.22.2

### DIFF
--- a/deploy-typesense.js
+++ b/deploy-typesense.js
@@ -33,18 +33,6 @@ const getFieldsForSchema = function (schema) {
     return fields;
 };
 
-// TODO: No. Please. We *need* to find something better than this. :'(
-const intifySlug = (slug) =>
-    Math.min(
-        Number(
-            Array.from(new TextEncoder().encode(slug))
-                .slice(0, 7)
-                .map((i) => i.toString().padStart(3, '0'))
-                .join('')
-        ),
-        2147483640
-    );
-
 const setupCollection = async function (collection_name, schema_filename) {
     const schema = require(path.resolve(schema_filename));
     const fields = getFieldsForSchema(schema);
@@ -65,7 +53,7 @@ const deploy = async function (index, schema_filename, directory) {
     const records = glob
         .sync(`./${directory}/*.json`)
         .map((file) => require(path.resolve(file)))
-        .map((obj) => ({ ...obj, 'sort-index': intifySlug(obj.slug) }));
+        .map((obj) => ({ ...obj, 'sort-index': 1 }));
 
     // Insert in chunks of 1000 records (Typesense recommends packages < 1MB).
     for (const chunk of chunk_array(records, 1000)) await client.collections(collection_name).documents().import(chunk);

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
         "arg": "^5.0.1",
         "as-table": "^1.0.55",
         "babel-eslint": "^10.1.0",
-        "bent": "^7.3.9",
         "chunk": "^0.0.2",
         "countries-list": "^2.6.1",
         "eslint": "^7.17.0",
@@ -42,7 +41,7 @@
         "ts-node": "^10.2.1",
         "type-fest": "^2.5.1",
         "typescript": "^4.4.3",
-        "typesense": "^0.6.1"
+        "typesense": "^1.2.2"
     },
     "scripts": {
         "test": "eslint --ext .json --ext .js --ext .ts && ts-node-transpile-only src/test-records.ts",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
         "@babel/runtime": "^7.11.0",
         "@segment/ajv-human-errors": "^2.0.0",
         "@types/all-the-cities": "^3.1.0",
+        "@types/chunk": "^0.0.0",
         "@types/glob": "^7.1.4",
         "@types/marked": "^4.0.2",
         "@types/marked-terminal": "^3.1.2",
@@ -45,7 +46,7 @@
     },
     "scripts": {
         "test": "eslint --ext .json --ext .js --ext .ts && ts-node-transpile-only src/test-records.ts",
-        "deploy": "node deploy-typesense.js"
+        "deploy": "ts-node-transpile-only src/deploy-typesense.ts"
     },
     "husky": {
         "hooks": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -534,12 +534,12 @@ astral-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
   integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
 
-axios@^0.20.0:
-  version "0.20.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.20.0.tgz#057ba30f04884694993a8cd07fa394cff11c50bd"
-  integrity sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==
+axios@^0.21.1:
+  version "0.21.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
+  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
   dependencies:
-    follow-redirects "^1.10.0"
+    follow-redirects "^1.14.0"
 
 babel-eslint@^10.1.0:
   version "10.1.0"
@@ -557,15 +557,6 @@ balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
-
-bent@^7.3.9:
-  version "7.3.12"
-  resolved "https://registry.yarnpkg.com/bent/-/bent-7.3.12.tgz#e0a2775d4425e7674c64b78b242af4f49da6b035"
-  integrity sha512-T3yrKnVGB63zRuoco/7Ybl7BwwGZR0lceoVG5XmQyMIH9s19SV5m+a8qam4if0zQuAmOQTyPTPmsQBdAorGK3w==
-  dependencies:
-    bytesish "^0.4.1"
-    caseless "~0.12.0"
-    is-stream "^2.0.0"
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -607,11 +598,6 @@ buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
 
-bytesish@^0.4.1:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/bytesish/-/bytesish-0.4.4.tgz#f3b535a0f1153747427aee27256748cff92347e6"
-  integrity sha512-i4uu6M4zuMUiyfZN4RU2+i9+peJh//pXhd9x1oSe1LBkZ3LEbCoygu8W0bXTukU1Jme2txKuotpCZRaC3FLxcQ==
-
 call-bind@^1.0.0, call-bind@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.2.tgz#b1d4e89e688119c3c9a903ad30abb2f6a919be3c"
@@ -637,11 +623,6 @@ cardinal@^2.1.1:
   dependencies:
     ansicolors "~0.3.2"
     redeyed "~2.1.0"
-
-caseless@~0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
-  integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
 chalk@^2.0.0, chalk@^2.4.1:
   version "2.4.2"
@@ -1380,10 +1361,10 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.2.tgz#64bfed5cb68fe3ca78b3eb214ad97b63bedce561"
   integrity sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==
 
-follow-redirects@^1.10.0:
-  version "1.14.8"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.8.tgz#016996fb9a11a100566398b1c6839337d7bfa8fc"
-  integrity sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==
+follow-redirects@^1.14.0:
+  version "1.14.9"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.9.tgz#dd4ea157de7bfaf9ea9b3fbd85aa16951f78d8d7"
+  integrity sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==
 
 foreach@^2.0.5:
   version "2.0.5"
@@ -2030,10 +2011,10 @@ log-update@^4.0.0:
     slice-ansi "^4.0.0"
     wrap-ansi "^6.2.0"
 
-loglevel@^1.7.0:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.7.1.tgz#005fde2f5e6e47068f935ff28573e125ef72f197"
-  integrity sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw==
+loglevel@^1.7.1:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.8.0.tgz#e7ec73a57e1e7b419cb6c6ac06bf050b67356114"
+  integrity sha512-G6A/nJLRgWOuuwdNuA6koovfEV1YpqqAG4pRUlFaz3jj2QNZ8M4vBqnVA+HBTmU/AMNUtlOsMmSpF6NyOjztbA==
 
 lru-cache@^6.0.0:
   version "6.0.0"
@@ -3285,13 +3266,13 @@ typescript@~3.2.1:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.4.tgz#c585cb952912263d915b462726ce244ba510ef3d"
   integrity sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==
 
-typesense@^0.6.1:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/typesense/-/typesense-0.6.2.tgz#34541077a8e27d54cc157111c9f99181dd0d9bbb"
-  integrity sha512-NGDUDkBeKnz1aWpEWt1sj14FUSbqp5fUGVkQx/WitBOEcBaiKXD8s6Io8IMp7Uh9lG6FCiwJkO1UvRHmwTduIA==
+typesense@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/typesense/-/typesense-1.2.2.tgz#f70ea67177d9ab26d1fc4760ecaa9c3f08473a37"
+  integrity sha512-MOKAIGTXbL0RkbHOvpr8RHP7it7UhCc0x4KJ8+p5lwh6Q9bSht6pJqMn6bXybomYA7CHVzIm4+IWVz6dHdUBow==
   dependencies:
-    axios "^0.20.0"
-    loglevel "^1.7.0"
+    axios "^0.21.1"
+    loglevel "^1.7.1"
 
 typical@^2.6.0, typical@^2.6.1:
   version "2.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -223,6 +223,11 @@
   resolved "https://registry.yarnpkg.com/@types/all-the-cities/-/all-the-cities-3.1.0.tgz#bd8384d3ff95093bf991f3aeef34a5ed8a6d4934"
   integrity sha512-u8Y0xAStECwEpgWlzNkwW9mqV19iAIY8aHFlLabhQBF3cRUlIspQe6ZzKSqGu5mLlLVzYX7jyCHgksVzU72CcA==
 
+"@types/chunk@^0.0.0":
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/@types/chunk/-/chunk-0.0.0.tgz#644651a09113cb500a8563f5c8a9de657aa292c9"
+  integrity sha512-8z7Z9E1UoxUfwb4SUuWZZCAa5T+vi2daACygqUed7NpPnq04CJo0L3l0heHh3R9fLi/pOUbfR/ZwHd2+YEQIxg==
+
 "@types/glob@^7.1.4":
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.4.tgz#ea59e21d2ee5c517914cb4bc8e4153b99e566672"


### PR DESCRIPTION
I have updated our Typesense server to the newest version (0.22.2). The client in `website` still works (though we should also update to gain advantage of the new features). But the deploy script needs to be updated as the import endpoint now returns a JSONL of `{ success: bool }` objects instead of a single `{ success: bool, num_imported: number }` object. We won't be able to deploy until this is merged.

While we're at it, this PR also:

* Uses the Typesense lib for the import endpoint (previously, we manually POSTed to the endpoint as the older Typesense lib didn't support that feature yet.
* Gets rid of our horrible `intifySlug()` hack that I thought we needed but luckily don't actually (see #1209).
* Converts the deploy script to TypeScript in line with what we did for the test script.

I've already done a manual production deploy with the updated script.

Please keep the commit history when merging.