### PR TITLE
Set token separators for Typesense

### DIFF
--- a/src/deploy-typesense.ts
+++ b/src/deploy-typesense.ts
@@ -50,6 +50,7 @@ const setupCollection = async function (collection_name: string, schema_filename
         name: collection_name,
         fields,
         default_sorting_field: 'sort-index',
+        token_separators: ['-', '&', '.', ',', '*', '/', '|', '+'],
     });
 };
 


### PR DESCRIPTION
With these, "all inkl" will now match "all-inkl" for example, which it previously didn't. See the Typesense issue for more details: https://github.com/typesense/typesense/issues/122#issuecomment-907489433

I used the following script to collect candidates for the characters:

```js
const glob = require('glob');
const path = require('path');

const chars = [
    ...new Set(
        glob
            .sync(`./companies/*.json`)
            .map((file) => require(path.resolve(file)))
            .map((obj) => obj.name.split('').filter(
                (c) => !c.match(/\p{Letter}|\p{Number}/gu)
            ))
            .flat()
    ),
];
console.log(chars);
```