### PR TITLE
CRIFBÜRGEL has been rebranded to CRIF

### DIFF
--- a/companies/crifbuergel.json
+++ b/companies/crifbuergel.json
@@ -5,7 +5,12 @@
         "addresses"
     ],
     "name": "CRIF GmbH",
-    "address": "Friesenweg 4\nLeopoldstraße 244\n80807 München\nDeutschland",
+    "runs": [
+        "HYBRIGHT",
+        "KYC MORE",
+        "CRIF Bürgel (ehem.)"
+    ],
+    "address": "Leopoldstraße 244\n80807 München\nDeutschland",
     "phone": "+49 40 89803 0",
     "fax": "+49 40 89803 309",
     "email": "datenschutz.de@crif.com",
@@ -24,9 +29,6 @@
             "desc": "Adresse",
             "type": "address"
         }
-    ],
-    "comments": [
-        "Entgegen der Angabe auf der CRIF-Webseite sollte eine Personalausweiskopie – wenn überhaupt – nur auf explizite Nachfrage verschickt werden und nicht direkt mit dem ersten Schreiben."
     ],
     "relevant-countries": [
         "de"

--- a/companies/crifbuergel.json
+++ b/companies/crifbuergel.json
@@ -4,15 +4,15 @@
         "credit agency",
         "addresses"
     ],
-    "name": "CRIF Bürgel GmbH",
-    "address": "Friesenweg 4\nHaus 12\n22763 Hamburg\nDeutschland",
+    "name": "CRIF GmbH",
+    "address": "Friesenweg 4\nLeopoldstraße 244\n80807 München\nDeutschland",
     "phone": "+49 40 89803 0",
     "fax": "+49 40 89803 309",
-    "email": "datenschutz@crifbuergel.de",
-    "web": "https://www.crifbuergel.de",
+    "email": "datenschutz.de@crif.com",
+    "web": "https://www.crif.de",
     "sources": [
-        "https://www.crifbuergel.de/de/kontakt/selbstauskunft",
-        "https://www.crifbuergel.de/de/datenschutz",
+        "https://www.crif.de/konsumenten/selbstauskunft/",
+        "https://www.crif.de/datenschutz",
         "https://github.com/datenanfragen/data/issues/636"
     ],
     "required-elements": [
@@ -26,7 +26,7 @@
         }
     ],
     "comments": [
-        "Entgegen der Angabe auf der CRIF Bürgel-Webseite sollte eine Personalausweiskopie – wenn überhaupt – nur auf explizite Nachfrage verschickt werden und nicht direkt mit dem ersten Schreiben."
+        "Entgegen der Angabe auf der CRIF-Webseite sollte eine Personalausweiskopie – wenn überhaupt – nur auf explizite Nachfrage verschickt werden und nicht direkt mit dem ersten Schreiben."
     ],
     "relevant-countries": [
         "de"

--- a/companies/crifbuergel.json
+++ b/companies/crifbuergel.json
@@ -35,5 +35,5 @@
     ],
     "needs-id-document": false,
     "suggested-transport-medium": "email",
-    "quality": "tested"
+    "quality": "verified"
 }


### PR DESCRIPTION
…apparently…

Also they have changed nearly everything (even their headquarter?), only the phone number stayed the same.

See https://www.crif.de/pr-events/pressemitteilungen/2021/november/04/crifbuergel-heisst-jetzt-crif-informationsdienstleister-positioniert-sich-als-partner-fuer-digital-customer-journey-management/