### PR TITLE
Change closing sentence to 'Met vriendelijke groet,'

### DIFF
--- a/templates/nl/access-default.txt
+++ b/templates/nl/access-default.txt
@@ -22,6 +22,6 @@ Ik neem de volgende informatie op die nodig is om mij te identificeren:
 {id_data}]
 Als u mijn verzoek niet binnen de vermelde periode beantwoordt, behoud ik het recht om juridische stappen te ondernemen en een klacht tegen u in te dienen bij de daarvoor verantwoordelijke toezichthoudende autoriteit.
 
-Bij voorbaat dank,
+Bij voorbaat dank.
 
-Hoogachtend,
+Met vriendelijke groet,

--- a/templates/nl/access-tracking.txt
+++ b/templates/nl/access-tracking.txt
@@ -24,6 +24,6 @@ Mijn contactgegevens zijn:
 {id_data}]
 Als u mijn verzoek niet binnen de vermelde periode beantwoordt, behoud ik het recht om juridische stappen te ondernemen en een klacht tegen u in te dienen bij de daarvoor verantwoordelijke toezichthoudende autoriteit.
 
-Bij voorbaat dank,
+Bij voorbaat dank.
 
-Hoogachtend,
+Met vriendelijke groet,

--- a/templates/nl/admonition.txt
+++ b/templates/nl/admonition.txt
@@ -7,4 +7,4 @@ Daarom neem ik nu opnieuw contact met u op. Na de aankomst van deze vermaning, g
 
 Dankuwel.
 
-Hoogachtend,
+Met vriendelijke groet,

--- a/templates/nl/complaint.txt
+++ b/templates/nl/complaint.txt
@@ -10,4 +10,4 @@ Daarom wend ik mij tot u met deze klacht. Ik zou u willen vragen om de procedure
 Indien u meer details nodig heeft, kunt u mij contacteren. U kan mijn bereiken via {beschrijving van manieren om jou contact op te nemen. bijv. emailadres, briefadres, telefoonnummer}. [optional: ik vraag u om deze informatie niet te delen met derden, om mijn anonimiteit te kunnen waarborgen.]
 Alvast bedankt voor uw hulp.
 
-Hoogachtend,
+Met vriendelijke groet,

--- a/templates/nl/erasure-default.txt
+++ b/templates/nl/erasure-default.txt
@@ -24,6 +24,6 @@ Ik het de volgende informatie bijgevoegd die nodig is om mij te identificeren:
 {id_data}]
 Als u mijn verzoek niet binnen de vermelde periode beantwoordt, behoud ik het recht om juridische stappen te ondernemen en een klacht tegen u in te dienen bij de daarvoor verantwoordelijke toezichthoudende autoriteit.
 
-Alvast bedankt.
+Bij voorbaat dank.
 
-Hoogachtend,
+Met vriendelijke groet,

--- a/templates/nl/objection-default.txt
+++ b/templates/nl/objection-default.txt
@@ -16,4 +16,4 @@ Als u mijn verzoek niet binnen de vermelde periode beantwoordt, behoud ik het re
 
 Bij voorbaat dank.
 
-Hoogachtend,
+Met vriendelijke groet,

--- a/templates/nl/rectification-default.txt
+++ b/templates/nl/rectification-default.txt
@@ -16,4 +16,4 @@ Als u mijn verzoek niet binnen de vermelde periode beantwoordt, behoud ik het re
 
 Bij voorbaat dank.
 
-Hoogachtend,
+Met vriendelijke groet,


### PR DESCRIPTION
I personally think that using 'Hoogachtend' as a closing sentence is outdated. Even in formal emails, I never see people using 'Hoogachtend' anymore.

I propose changing it to the more common closing sentence "Met vriendelijke groet" which translates to "With kind regards". According to the Dutch site taaladvies.net, [both options are acceptable](https://taaladvies.net/met-vriendelijke-groeten-of-hoogachtend/). Taaladvies.net mentions that with the greeting we're currently using (Geachte), both options are acceptable.