### PR TITLE
Add 'Corona Schnelltest Hamburg UG (haftungsbeschränkt)' (community contribution)

### DIFF
--- a/companies/corona-schnelltest-hamburg.json
+++ b/companies/corona-schnelltest-hamburg.json
@@ -1,0 +1,15 @@
+{
+    "slug": "corona-schnelltest-hamburg",
+    "relevant-countries": [
+        "de"
+    ],
+    "name": "CHS Corona Schnelltest Hamburg UG",
+    "address": "Rellinger Straße 16\n20257 Hamburg\nDeutschland",
+    "phone": "+49 173 2461073",
+    "email": "info@corona-schnelltest-hamburg.de",
+    "web": "https://corona-schnelltest-hamburg.de/",
+    "quality": "verified",
+    "sources": [
+        "https://github.com/datenanfragen/data/pull/1910"
+    ]
+}

--- a/companies/corona-schnelltest-hamburg.json
+++ b/companies/corona-schnelltest-hamburg.json
@@ -3,13 +3,17 @@
     "relevant-countries": [
         "de"
     ],
-    "name": "CHS Corona Schnelltest Hamburg UG",
+    "categories": [
+        "health"
+    ],
+    "name": "Corona Schnelltest Hamburg UG (haftungsbeschränkt)",
     "address": "Rellinger Straße 16\n20257 Hamburg\nDeutschland",
-    "phone": "+49 173 2461073",
+    "phone": "+49 173 8699859",
     "email": "info@corona-schnelltest-hamburg.de",
     "web": "https://corona-schnelltest-hamburg.de/",
-    "quality": "verified",
     "sources": [
+        "https://corona-schnelltest-hamburg.de/datenschutzerklaerung",
         "https://github.com/datenanfragen/data/pull/1910"
-    ]
+    ],
+    "quality": "verified"
 }


### PR DESCRIPTION
This suggestion was submitted through the website.

**[Edit in company JSON generator](https://company-json.datenanfragen.de/#!url=https%3A%2F%2Fraw.githubusercontent.com%2Fdatenanfragen-community-edits%2Fdata%2Fsuggest_corona-schnelltest-hamburg_1666367222728%2Fcompanies%2Fcorona-schnelltest-hamburg.json )**