### PR TITLE
Circle: Upgrade Docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   test:
       docker:
-        - image: circleci/node:14-buster
+        - image: cimg/node:18.13
       steps:
         - checkout
 
@@ -22,7 +22,7 @@ jobs:
               - ./node_modules
   deploy:
     docker:
-        - image: circleci/node:14-buster
+        - image: cimg/node:18.13
     steps:
       - checkout
 


### PR DESCRIPTION
CircleCI has been complaining for quite a while (e.g. in https://app.circleci.com/pipelines/github/datenanfragen/data/4938/workflows/0f379abf-0e82-4271-b1c4-57df15373d68/jobs/5945):
> You’re using a deprecated Docker convenience image. Upgrade to a next-gen Docker convenience image.

While we're at it, I've also switched to Node 18 (instead of 14) in CI. Main advantage: Unhandled promise rejections cause a non-zero exit code in that version, which we definitely want, especially in CI.

I have not increased the `engines` value in the `package.json` since everything still works just fine with Node 14.