### PR TITLE
Update schema.json

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -170,7 +170,7 @@
             "type": "string",
             "title": "Suggested transport medium",
             "description": "The transport medium a user should use for their privacy-related inquiries and requests. If a specific privacy@[domain.tld] email address is available, 'email' should be specified. If no value is specified, the default is 'email' if the record has an email address specified or 'letter' otherwise.",
-            "enum": [ "fax", "letter", "email" ]
+            "enum": [ "fax", "letter", "email", "webform" ]
         },
         "comments": {
             "type": "array",


### PR DESCRIPTION
@baltpeter Working on #1474 and noticed that the yarn tester was complaining about the new option for `suggested-transport-medium`. 

Tested locally editing the schema.json file and can confirm yarn/CircleCI no longer yell. 

````faisalmisle@Faisals-MacBook-Pro gdpr-data % yarn test
yarn run v1.22.19
$ eslint --ext .json --ext .js --ext .ts && ts-node-transpile-only src/test-records.ts
✨  Done in 1.20s.
```