### PR TITLE
Add 'Lufthansa AirPlus Servicekarten GmbH' (community contribution)

### DIFF
--- a/companies/lufthansa-airplus-servicekarten-gmbh.json
+++ b/companies/lufthansa-airplus-servicekarten-gmbh.json
@@ -7,14 +7,21 @@
         "finance"
     ],
     "name": "Lufthansa AirPlus Servicekarten GmbH",
-    "runs": [
-        "airplus.com"
-    ],
-    "address": "Lufthansa AirPlus Servicekarten GmbH\nDatenschutzbeauftragter JX LD\nDornhofstraße 10\n63263 Neu-Isenburg\nDeutschland",
+    "address": "Dornhofstraße 10\n63263 Neu-Isenburg\nDeutschland",
     "email": "datenschutz@airplus.com",
     "sources": [
         "https://www.airplus.com/de/de/rechtliches/datenschutz/",
         "https://github.com/datenanfragen/data/pull/2488"
     ],
-    "quality": "verified"
+    "suggested-transport-medium": "email",
+    "quality": "verified",
+    "runs": [
+        "AirPlus International Srl",
+        "AirPlus International Ltd",
+        "AirPlus International SA/NV",
+        "AirPlus International Inc",
+        "AirPlus Payment Management Co., Ltd",
+        "AirPlus Int. Soluções de Pagamento",
+        "AirPlus International AG"
+    ]
 }

--- a/companies/lufthansa-airplus-servicekarten-gmbh.json
+++ b/companies/lufthansa-airplus-servicekarten-gmbh.json
@@ -1,0 +1,20 @@
+{
+    "slug": "lufthansa-airplus-servicekarten-gmbh",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "finance"
+    ],
+    "name": "Lufthansa AirPlus Servicekarten GmbH",
+    "runs": [
+        "airplus.com"
+    ],
+    "address": "Lufthansa AirPlus Servicekarten GmbH\nDatenschutzbeauftragter JX LD\nDornhofstraße 10\n63263 Neu-Isenburg\nDeutschland",
+    "email": "datenschutz@airplus.com",
+    "sources": [
+        "https://www.airplus.com/de/de/rechtliches/datenschutz/",
+        "https://github.com/datenanfragen/data/pull/2488"
+    ],
+    "quality": "verified"
+}


### PR DESCRIPTION
This suggestion was submitted through the website.

**[Edit in company JSON generator](https://company-json.datenanfragen.de/#!url=https%3A%2F%2Fraw.githubusercontent.com%2Fdatenanfragen-community-edits%2Fdata%2Fsuggest_lufthansa-airplus-servicekarten-gmbh_1703458456047%2Fcompanies%2Flufthansa-airplus-servicekarten-gmbh.json )**