### PR TITLE
Add 'APC ENGLAND' (community contribution)

### DIFF
--- a/companies/apc-england.json
+++ b/companies/apc-england.json
@@ -1,0 +1,12 @@
+{
+    "slug": "apc-england",
+    "relevant-countries": [
+        "gb"
+    ],
+    "name": "APC ENGLAND",
+    "address": "48 LEXINGTON SRTEET LONDON GB",
+    "quality": "verified",
+    "sources": [
+        "https://github.com/datenanfragen/data/pull/2527"
+    ]
+}


### PR DESCRIPTION
This suggestion was submitted through the website.

**[Edit in company JSON generator](https://company-json.datenanfragen.de/#!url=https%3A%2F%2Fraw.githubusercontent.com%2Fdatenanfragen-community-edits%2Fdata%2Fsuggest_apc-england_1707474647014%2Fcompanies%2Fapc-england.json )**