### PR TITLE
Add Krankenkassennummer as input for Barmer

### DIFF
--- a/companies/barmer.json
+++ b/companies/barmer.json
@@ -17,6 +17,9 @@
         "https://www.barmer.de/consent/bestmoeglicher-schutz-fuer-ihre-daten-1003830",
         "https://www.barmer.de/ueber-diese-website/impressum-1003148"
     ],
+    "required-elements": [
+        "desc": "Krankenkassennummer"
+    ],
     "suggested-transport-medium": "email",
     "quality": "verified"
 }


### PR DESCRIPTION
I guess for Krankenkassen this makes sense.

Ideally, you could also validate the input: https://de.wikipedia.org/wiki/Krankenversichertennummer#Pr%C3%BCfung_des_unver%C3%A4nderbaren_Teils_der_Krankenversichertennummer

https://patientenrechte-datenschutz.de/krankenkassendaten/?gp=result has a similar generator and I wonder what is better here.