### PR TITLE
Add 'Thüringer Allgemeine' (community contribution)

### DIFF
--- a/companies/thueringer-allgemeine.json
+++ b/companies/thueringer-allgemeine.json
@@ -1,0 +1,19 @@
+{
+    "slug": "thueringer-allgemeine",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "entertainment"
+    ],
+    "name": "Thüringer Allgemeine",
+    "address": "c/o FUNKE Medien Thüringen GmbH\nJuri-Gagarin-Ring 86-88\n99084 Erfurt\nDeutschland",
+    "email": "datenschutz.thueringen@funkemedien.de",
+    "web": "https://www.thueringer-allgemeine.de",
+    "sources": [
+        "https://www.thueringer-allgemeine.de/service/datenschutzerklaerung/",
+        "https://github.com/datenanfragen/data/pull/3065"
+    ],
+    "suggested-transport-medium": "email",
+    "quality": "verified"
+}


### PR DESCRIPTION
This suggestion was submitted through the website.

**Edit in: [company JSON generator](https://company-json.datenanfragen.de/#!url=https%3A%2F%2Fraw.githubusercontent.com%2Fdatenanfragen-community-edits%2Fdata%2Fsuggest_thueringer-allgemeine_1743105811128%2Fcompanies%2Fthueringer-allgemeine.json), [data editor](https://data-editor.datenanfragen.de/#/review/3065)[^1]**

[^1]: Closed beta