### PR TITLE
Add SimYo and Sparhandy for Telefonica (O2)

### DIFF
--- a/companies/o2-de.json
+++ b/companies/o2-de.json
@@ -27,7 +27,9 @@
         "Saturn Prepaid",
         "Saturn Super Select",
         "Simfinity",
-        "WhatsApp SIM"
+        "WhatsApp SIM",
+        "Sparhandy",
+        "simyo"
     ],
     "address": "Georg-Brauchle-Ring 50\n80992 München\nDeutschland",
     "phone": "+49 89 787979400",


### PR DESCRIPTION
SimYo only lists Telefonica: https://www.simyo.de/datenschutz https://www.simyo.de/impressum (mail: blau.de); as for technical development mobilezone GmbH is listed for the page simyo.de and is also the contract partner in case one has one

Also if you have a contract at SimYo you manage it in the Blau.de portal, so I guess it's the same.

Sparhandy lists mobilezone GmbH  https://www.sparhandy.de/impressum but for a privacy policy (https://www.sparhandy.de/datenschutz) they also refer to Datenschutz@mobilezone.org also impress says "Sparhandy – eine Marke der mobilezone GmbH" and they also list all other network providers.

I am quite unsure of this company construct as Mobilezone also has it's own privacy mail here: Datenschutz@mobilezone.org

See also: https://de.wikipedia.org/wiki/Mobilezone

> Sparhandy, DEINHANDY, Handystar und HIGH mobile

also belong to Mobilezone GmbH