### PR TITLE
Update Adhese: email address changed

### DIFF
--- a/companies/adhese.json
+++ b/companies/adhese.json
@@ -1,19 +1,19 @@
 {
-    "slug": "adhese",
-    "relevant-countries": [
-        "all"
-    ],
-    "categories": [
-        "ads"
-    ],
-    "name": "Adhese",
-    "address": "Dulle-grietlaan 1/0001\n9050 Gentbrugge\nBelgium",
-    "phone": "+32 9 329 57 67",
-    "email": "info@adhese.com",
-    "web": "https://www.adhese.eu",
-    "sources": [
-        "https://www.adhese.eu/adheseanddata.html",
-        "https://github.com/datenanfragen/data/pull/1198"
-    ],
-    "quality": "verified"
+  "slug": "adhese",
+  "relevant-countries": [
+    "all"
+  ],
+  "categories": [
+    "ads"
+  ],
+  "name": "Adhese",
+  "address": "Dulle-grietlaan 1/0001\n9050 Gentbrugge\nBelgium",
+  "phone": "+32 9 329 57 67",
+  "email": "privacy@adhese.eu",
+  "web": "https://www.adhese.eu",
+  "sources": [
+    "https://www.adhese.eu/adheseanddata.html",
+    "https://github.com/datenanfragen/data/pull/1198"
+  ],
+  "quality": "verified"
 }

--- a/companies/adhese.json
+++ b/companies/adhese.json
@@ -1,19 +1,19 @@
 {
-  "slug": "adhese",
-  "relevant-countries": [
-    "all"
-  ],
-  "categories": [
-    "ads"
-  ],
-  "name": "Adhese",
-  "address": "Dulle-grietlaan 1/0001\n9050 Gentbrugge\nBelgium",
-  "phone": "+32 9 329 57 67",
-  "email": "privacy@adhese.eu",
-  "web": "https://www.adhese.eu",
-  "sources": [
-    "https://www.adhese.eu/adheseanddata.html",
-    "https://github.com/datenanfragen/data/pull/1198"
-  ],
-  "quality": "verified"
+    "slug": "adhese",
+    "relevant-countries": [
+        "all"
+    ],
+    "categories": [
+        "ads"
+    ],
+    "name": "Adhese",
+    "address": "Dulle-grietlaan 1/0001\n9050 Gentbrugge\nBelgium",
+    "phone": "+32 9 329 57 67",
+    "email": "privacy@adhese.eu",
+    "web": "https://www.adhese.eu",
+    "sources": [
+        "https://www.adhese.eu/adheseanddata.html",
+        "https://github.com/datenanfragen/data/pull/1198"
+    ],
+    "quality": "verified"
 }


### PR DESCRIPTION
The registered address `info@adhese.com` no longer appears on the source page (`https://www.adhese.eu/adheseanddata.html`). That page currently lists `privacy@adhese.eu` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #7.