### PR TITLE
Update NextRoll Limited: email address changed

### DIFF
--- a/companies/adroll.json
+++ b/companies/adroll.json
@@ -1,28 +1,28 @@
 {
-  "slug": "adroll",
-  "relevant-countries": [
-    "all"
-  ],
-  "categories": [
-    "ads"
-  ],
-  "name": "NextRoll Limited",
-  "runs": [
-    "AdRoll (www.adroll.com)",
-    "RollWorks (www.rollworks.com)",
-    "NextRoll, Inc.",
-    "AdRoll Advertising Ltd. (formerly)",
-    "AdRoll, Inc. (formerly)"
-  ],
-  "address": "Floor 3, Block 3\nMiesian Plaza\nDublin 2\nD02 Y754\nIreland",
-  "email": "dpo@nextroll.com",
-  "webform": "https://nextroll-privacy.relyance.ai/",
-  "web": "https://www.adroll.com/",
-  "sources": [
-    "https://www.nextroll.com/privacy",
-    "https://github.com/datenanfragen/data/pull/753"
-  ],
-  "custom-access-template": "access-tracking",
-  "suggested-transport-medium": "webform",
-  "quality": "verified"
+    "slug": "adroll",
+    "relevant-countries": [
+        "all"
+    ],
+    "categories": [
+        "ads"
+    ],
+    "name": "NextRoll Limited",
+    "runs": [
+        "AdRoll (www.adroll.com)",
+        "RollWorks (www.rollworks.com)",
+        "NextRoll, Inc.",
+        "AdRoll Advertising Ltd. (formerly)",
+        "AdRoll, Inc. (formerly)"
+    ],
+    "address": "Floor 3, Block 3\nMiesian Plaza\nDublin 2\nD02 Y754\nIreland",
+    "email": "dpo@nextroll.com",
+    "webform": "https://nextroll-privacy.relyance.ai/",
+    "web": "https://www.adroll.com/",
+    "sources": [
+        "https://www.nextroll.com/privacy",
+        "https://github.com/datenanfragen/data/pull/753"
+    ],
+    "custom-access-template": "access-tracking",
+    "suggested-transport-medium": "webform",
+    "quality": "verified"
 }

--- a/companies/adroll.json
+++ b/companies/adroll.json
@@ -1,28 +1,28 @@
 {
-    "slug": "adroll",
-    "relevant-countries": [
-        "all"
-    ],
-    "categories": [
-        "ads"
-    ],
-    "name": "NextRoll Limited",
-    "runs": [
-        "AdRoll (www.adroll.com)",
-        "RollWorks (www.rollworks.com)",
-        "NextRoll, Inc.",
-        "AdRoll Advertising Ltd. (formerly)",
-        "AdRoll, Inc. (formerly)"
-    ],
-    "address": "Floor 3, Block 3\nMiesian Plaza\nDublin 2\nD02 Y754\nIreland",
-    "email": "support@nextroll.com",
-    "webform": "https://nextroll-privacy.relyance.ai/",
-    "web": "https://www.adroll.com/",
-    "sources": [
-        "https://www.nextroll.com/privacy",
-        "https://github.com/datenanfragen/data/pull/753"
-    ],
-    "custom-access-template": "access-tracking",
-    "suggested-transport-medium": "webform",
-    "quality": "verified"
+  "slug": "adroll",
+  "relevant-countries": [
+    "all"
+  ],
+  "categories": [
+    "ads"
+  ],
+  "name": "NextRoll Limited",
+  "runs": [
+    "AdRoll (www.adroll.com)",
+    "RollWorks (www.rollworks.com)",
+    "NextRoll, Inc.",
+    "AdRoll Advertising Ltd. (formerly)",
+    "AdRoll, Inc. (formerly)"
+  ],
+  "address": "Floor 3, Block 3\nMiesian Plaza\nDublin 2\nD02 Y754\nIreland",
+  "email": "dpo@nextroll.com",
+  "webform": "https://nextroll-privacy.relyance.ai/",
+  "web": "https://www.adroll.com/",
+  "sources": [
+    "https://www.nextroll.com/privacy",
+    "https://github.com/datenanfragen/data/pull/753"
+  ],
+  "custom-access-template": "access-tracking",
+  "suggested-transport-medium": "webform",
+  "quality": "verified"
 }


### PR DESCRIPTION
The registered address `support@nextroll.com` no longer appears on the source page (`https://www.nextroll.com/privacy`). That page currently lists `dpo@nextroll.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #7.