### PR TITLE
Update Ärzte ohne Grenzen e. V.: email address changed

### DIFF
--- a/companies/aerzte-ohne-grenzen.json
+++ b/companies/aerzte-ohne-grenzen.json
@@ -1,21 +1,21 @@
 {
-    "slug": "aerzte-ohne-grenzen",
-    "relevant-countries": [
-        "de"
-    ],
-    "categories": [
-        "nonprofit",
-        "health"
-    ],
-    "name": "Ärzte ohne Grenzen e. V.",
-    "address": "Schwedenstraße 9\n13359 Berlin\nDeutschland",
-    "phone": "+49 30 7001300",
-    "fax": "+49 30 700130340",
-    "email": "office@berlin.msf.org",
-    "web": "https://www.aerzte-ohne-grenzen.de",
-    "sources": [
-        "https://www.aerzte-ohne-grenzen.de/datenschutz-und-datensicherheit",
-        "https://github.com/datenanfragen/data/pull/877"
-    ],
-    "quality": "verified"
+  "slug": "aerzte-ohne-grenzen",
+  "relevant-countries": [
+    "de"
+  ],
+  "categories": [
+    "nonprofit",
+    "health"
+  ],
+  "name": "Ärzte ohne Grenzen e. V.",
+  "address": "Schwedenstraße 9\n13359 Berlin\nDeutschland",
+  "phone": "+49 30 7001300",
+  "fax": "+49 30 700130340",
+  "email": "datenschutz@berlin.msf.org",
+  "web": "https://www.aerzte-ohne-grenzen.de",
+  "sources": [
+    "https://www.aerzte-ohne-grenzen.de/datenschutz-und-datensicherheit",
+    "https://github.com/datenanfragen/data/pull/877"
+  ],
+  "quality": "verified"
 }

--- a/companies/aerzte-ohne-grenzen.json
+++ b/companies/aerzte-ohne-grenzen.json
@@ -1,21 +1,21 @@
 {
-  "slug": "aerzte-ohne-grenzen",
-  "relevant-countries": [
-    "de"
-  ],
-  "categories": [
-    "nonprofit",
-    "health"
-  ],
-  "name": "Ärzte ohne Grenzen e. V.",
-  "address": "Schwedenstraße 9\n13359 Berlin\nDeutschland",
-  "phone": "+49 30 7001300",
-  "fax": "+49 30 700130340",
-  "email": "datenschutz@berlin.msf.org",
-  "web": "https://www.aerzte-ohne-grenzen.de",
-  "sources": [
-    "https://www.aerzte-ohne-grenzen.de/datenschutz-und-datensicherheit",
-    "https://github.com/datenanfragen/data/pull/877"
-  ],
-  "quality": "verified"
+    "slug": "aerzte-ohne-grenzen",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "nonprofit",
+        "health"
+    ],
+    "name": "Ärzte ohne Grenzen e. V.",
+    "address": "Schwedenstraße 9\n13359 Berlin\nDeutschland",
+    "phone": "+49 30 7001300",
+    "fax": "+49 30 700130340",
+    "email": "datenschutz@berlin.msf.org",
+    "web": "https://www.aerzte-ohne-grenzen.de",
+    "sources": [
+        "https://www.aerzte-ohne-grenzen.de/datenschutz-und-datensicherheit",
+        "https://github.com/datenanfragen/data/pull/877"
+    ],
+    "quality": "verified"
 }


### PR DESCRIPTION
The registered address `office@berlin.msf.org` no longer appears on the source page (`https://www.aerzte-ohne-grenzen.de/datenschutz-und-datensicherheit`). That page currently lists `datenschutz@berlin.msf.org` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #7.