### PR TITLE
Update E-Plus Service GmbH: email address changed

### DIFF
--- a/companies/alditalk.json
+++ b/companies/alditalk.json
@@ -1,23 +1,23 @@
 {
-    "slug": "alditalk",
-    "relevant-countries": [
-        "de"
-    ],
-    "categories": [
-        "telecommunication"
-    ],
-    "name": "E-Plus Service GmbH",
-    "runs": [
-        "ALDI TALK",
-        "mein ALDI TALK"
-    ],
-    "address": "E-Plus-Straße 1\n40472 Düsseldorf\nDeutschland",
-    "email": "datenschutz@eplus.de",
-    "web": "https://www.alditalk.de",
-    "sources": [
-        "https://www.alditalk.de/datenschutz",
-        "https://media.medion.com/s/ALDItalk/PDF/Datenschutzmerkblatt-ALDITALK_14092020_n.pdf"
-    ],
-    "suggested-transport-medium": "email",
-    "quality": "verified"
+  "slug": "alditalk",
+  "relevant-countries": [
+    "de"
+  ],
+  "categories": [
+    "telecommunication"
+  ],
+  "name": "E-Plus Service GmbH",
+  "runs": [
+    "ALDI TALK",
+    "mein ALDI TALK"
+  ],
+  "address": "E-Plus-Straße 1\n40472 Düsseldorf\nDeutschland",
+  "email": "datenschutz@medion.com",
+  "web": "https://www.alditalk.de",
+  "sources": [
+    "https://www.alditalk.de/datenschutz",
+    "https://media.medion.com/s/ALDItalk/PDF/Datenschutzmerkblatt-ALDITALK_14092020_n.pdf"
+  ],
+  "suggested-transport-medium": "email",
+  "quality": "verified"
 }

--- a/companies/alditalk.json
+++ b/companies/alditalk.json
@@ -1,23 +1,23 @@
 {
-  "slug": "alditalk",
-  "relevant-countries": [
-    "de"
-  ],
-  "categories": [
-    "telecommunication"
-  ],
-  "name": "E-Plus Service GmbH",
-  "runs": [
-    "ALDI TALK",
-    "mein ALDI TALK"
-  ],
-  "address": "E-Plus-Straße 1\n40472 Düsseldorf\nDeutschland",
-  "email": "datenschutz@medion.com",
-  "web": "https://www.alditalk.de",
-  "sources": [
-    "https://www.alditalk.de/datenschutz",
-    "https://media.medion.com/s/ALDItalk/PDF/Datenschutzmerkblatt-ALDITALK_14092020_n.pdf"
-  ],
-  "suggested-transport-medium": "email",
-  "quality": "verified"
+    "slug": "alditalk",
+    "relevant-countries": [
+        "de"
+    ],
+    "categories": [
+        "telecommunication"
+    ],
+    "name": "E-Plus Service GmbH",
+    "runs": [
+        "ALDI TALK",
+        "mein ALDI TALK"
+    ],
+    "address": "E-Plus-Straße 1\n40472 Düsseldorf\nDeutschland",
+    "email": "datenschutz@medion.com",
+    "web": "https://www.alditalk.de",
+    "sources": [
+        "https://www.alditalk.de/datenschutz",
+        "https://media.medion.com/s/ALDItalk/PDF/Datenschutzmerkblatt-ALDITALK_14092020_n.pdf"
+    ],
+    "suggested-transport-medium": "email",
+    "quality": "verified"
 }


### PR DESCRIPTION
The registered address `datenschutz@eplus.de` no longer appears on the source page (`https://www.alditalk.de/datenschutz`). That page currently lists `datenschutz@medion.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #7.