### PR TITLE
Update ABOUT YOU GmbH: email address changed

### DIFF
--- a/companies/aboutyou-shop.json
+++ b/companies/aboutyou-shop.json
@@ -11,7 +11,7 @@
     "name": "ABOUT YOU GmbH",
     "address": "Domstraße 10\n20095 Hamburg\nDeutschland",
     "phone": "+49 800 3015085",
-    "email": "kundenservice@aboutyou.de",
+    "email": "datenschutzbeauftragter@aboutyou.de",
     "web": "https://www.aboutyou.de",
     "sources": [
         "https://www.aboutyou.de/datenschutz"


### PR DESCRIPTION
The registered address `kundenservice@aboutyou.de` no longer appears on the source page (`https://www.aboutyou.de/datenschutz`). That page currently lists `datenschutzbeauftragter@aboutyou.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #9.