### PR TITLE
Update ADAC SE: email address changed

### DIFF
--- a/companies/adac.json
+++ b/companies/adac.json
@@ -16,7 +16,7 @@
     "address": "Hansastraße 19\n80686 München\nDeutschland",
     "phone": "+49 89 76765019",
     "fax": "+49 89 76765362",
-    "email": "dsb-mail@adac.de",
+    "email": "datenschutz.ug@adac.de",
     "web": "https://www.adac.de/",
     "sources": [
         "https://www.adac.de/datenschutz-cookies/",


### PR DESCRIPTION
The registered address `dsb-mail@adac.de` no longer appears on the source page (`https://www.adac.de/datenschutz-cookies/`). That page currently lists `datenschutz.ug@adac.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #9.