### PR TITLE
Update Accor S.A.: email address changed

### DIFF
--- a/companies/accor-all.json
+++ b/companies/accor-all.json
@@ -33,7 +33,7 @@
     ],
     "address": "82 rue Henri Farman\n92130 Issy-les-Moulineaux\nFrance",
     "phone": "+1 877 856 1464",
-    "email": "data.privacy@accor.com",
+    "email": "privacy.au@accor.com",
     "web": "https://all.accor.com",
     "sources": [
         "https://all.accor.com/information/legal/data-protection.de.shtml",


### PR DESCRIPTION
The registered address `data.privacy@accor.com` no longer appears on the source page (`https://all.accor.com/a/en/information/data-protection.html`). That page currently lists `privacy.au@accor.com` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #11.