### PR TITLE
Update ADARA, Inc.: email address changed

### DIFF
--- a/companies/adara.json
+++ b/companies/adara.json
@@ -9,7 +9,7 @@
     "name": "ADARA, Inc.",
     "address": "1070 E. Meadow Circle\nPalo Alto\nCA 94303\nUnited States of America",
     "phone": "+1 408 876 6360",
-    "email": "dpo@adara.com",
+    "email": "privacy@adara.com",
     "web": "https://adara.com/",
     "sources": [
         "https://adara.com/privacy-promise/",


### PR DESCRIPTION
The registered address `dpo@adara.com` no longer appears on the source page (`https://adara.com/blogs/adara-gdpr-faq/`). That page currently lists `privacy@adara.com` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #11.