### PR TITLE
Update ADP, LLC: email address changed

### DIFF
--- a/companies/adp-com.json
+++ b/companies/adp-com.json
@@ -38,7 +38,7 @@
         "ADP Tax Services, Inc."
     ],
     "address": "31 Avenue Jules Quentin\n92000 Nanterre\nFrance",
-    "email": "DataProtectionOfficer.ADPEMEA@adp.com",
+    "email": "privacy@adp.com",
     "web": "https://www.adp.com",
     "sources": [
         "https://github.com/datenanfragen/data/issues/395",


### PR DESCRIPTION
The registered address `DataProtectionOfficer.ADPEMEA@adp.com` no longer appears on the source page (`https://www.adp.com/about-adp/data-privacy.aspx`). That page currently lists `privacy@adp.com` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #11.