### PR TITLE
Update B2B Monster UG haftungsbeschränkt: email address changed

### DIFF
--- a/companies/adressmonster.json
+++ b/companies/adressmonster.json
@@ -13,7 +13,7 @@
     ],
     "address": "Am Mantel 4\n76646 Bruchsal\nDeutschland",
     "phone": "+49 7251 3266873",
-    "email": "support@adressmonster.de",
+    "email": "datenschutz@addressmonster.de",
     "web": "https://adressmonster.de",
     "sources": [
         "https://adressmonster.de/impressum",


### PR DESCRIPTION
The registered address `support@adressmonster.de` no longer appears on the source page (`https://adressmonster.de/datenschutz`). That page currently lists `datenschutz@addressmonster.de` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #11.