### PR TITLE
Update Hybrid Theory Global Ltd.: email address changed

### DIFF
--- a/companies/affectv.json
+++ b/companies/affectv.json
@@ -12,7 +12,7 @@
     ],
     "address": "Epworth House\n25 City Road\nLondon\nEC1Y 1AA\nUnited Kingdom",
     "phone": "+44 20 3934 2174",
-    "email": "privacy@hybridtheory.com",
+    "email": "dpo@azerion.com",
     "web": "https://hybridtheory.com",
     "sources": [
         "https://hybridtheory.com/privacy-policy/",


### PR DESCRIPTION
The registered address `privacy@hybridtheory.com` no longer appears on the source page (`https://hybridtheory.com/privacy-notice`). That page currently lists `dpo@azerion.com` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #11.