### PR TITLE
Update Alphonso Inc.: email address changed

### DIFF
--- a/companies/alphonso-tv.json
+++ b/companies/alphonso-tv.json
@@ -8,7 +8,7 @@
     ],
     "name": "Alphonso Inc.",
     "address": "2440 W El Camino Real\nMountain View\nCA 94040\nUnited States of America",
-    "email": "infoEU@alphonso.tv",
+    "email": "info@alphonso.tv",
     "web": "https://alphonso.tv/",
     "sources": [
         "https://alphonso.tv/privacy/smart-tvs/smart-tv-privacy-policy-eu/"


### PR DESCRIPTION
The registered address `infoEU@alphonso.tv` no longer appears on the source page (`None`). That page currently lists `info@alphonso.tv` as the privacy contact (screenshot scan).

Found and verified by the Privacy Engine optimizer, run #14.