### PR TITLE
Update Allianz SE: email address changed

### DIFF
--- a/companies/allianz.json
+++ b/companies/allianz.json
@@ -9,7 +9,7 @@
     "name": "Allianz SE",
     "address": "Königinstraße 28\n80802 München\nDeutschland",
     "phone": "+49 89 38000",
-    "email": "goodprivacy@allianz.com",
+    "email": "dpo@allianz.com",
     "web": "https://www.allianz.com",
     "sources": [
         "https://www.allianz.com/de/datenschutzprinzipien.html#Datenschutzerklaerung",


### PR DESCRIPTION
The registered address `goodprivacy@allianz.com` no longer appears on the source page (`None`). That page currently lists `dpo@allianz.com` as the privacy contact (groq scan).

Found and verified by the Privacy Engine optimizer, run #14.