### PR TITLE
Update AliExpress.com: email address changed

### DIFF
--- a/companies/aliexpress.json
+++ b/companies/aliexpress.json
@@ -8,7 +8,7 @@
     ],
     "name": "AliExpress.com",
     "address": "c/o Alibaba.com Singapore E-Commerce Private Limited\n10 Collyer Quay\n#10-01 Ocean Financial Centre\nSingapore 049315\nRepublic of Singapore",
-    "email": "dataprotection.ae@aliexpress.com",
+    "email": "dpo@aliexpress.com",
     "web": "https://www.aliexpress.com/",
     "sources": [
         "https://rule.alibaba.com/rule/detail/2034.htm",


### PR DESCRIPTION
The registered address `dataprotection.ae@aliexpress.com` no longer appears on the source page (`None`). That page currently lists `dpo@aliexpress.com` as the privacy contact (groq scan).

Found and verified by the Privacy Engine optimizer, run #14.