### PR TITLE
Update Alibaba.com Singapore E-Commerce Private Limited: email address changed

### DIFF
--- a/companies/alibaba.json
+++ b/companies/alibaba.json
@@ -8,7 +8,7 @@
     ],
     "name": "Alibaba.com Singapore E-Commerce Private Limited",
     "address": "8 Shenton Way\n#45-01\nAxa Tower\nSingapore 068811\nRepublic of Singapore",
-    "email": "dataprotection@service.alibaba.com",
+    "email": "privacy@alibaba-inc.com",
     "web": "https://www.alibaba.com",
     "sources": [
         "https://rule.alibaba.com/rule/detail/2034.htm",


### PR DESCRIPTION
The registered address `dataprotection@service.alibaba.com` no longer appears on the source page (`None`). That page currently lists `privacy@alibaba-inc.com` as the privacy contact (groq scan).

Found and verified by the Privacy Engine optimizer, run #14.