### PR TITLE
Update Advanzia Bank S.A.: email address changed

### DIFF
--- a/companies/advanzia.json
+++ b/companies/advanzia.json
@@ -20,7 +20,7 @@
         "Advanzia deposit account (www.advanziakonto.com)"
     ],
     "address": "14, Rue Gabriel Lippmann\nL-5365 Munsbach\nLuxembourg",
-    "email": "dataprotection@advanzia.com",
+    "email": "dpo@advanzia.com",
     "web": "https://www.advanzia.com",
     "sources": [
         "https://www.advanzia.com/en-gb/Documents/Corporate-Data-Protection-Notice-EN-202507.pdf",


### PR DESCRIPTION
The registered address `dataprotection@advanzia.com` no longer appears on the source page (`None`). That page currently lists `dpo@advanzia.com` as the privacy contact (groq scan).

Found and verified by the Privacy Engine optimizer, run #14.