### PR TITLE
Update Adjust GmbH: email address changed

### DIFF
--- a/companies/adjust-com.json
+++ b/companies/adjust-com.json
@@ -9,7 +9,7 @@
     "name": "Adjust GmbH",
     "address": "Saarbrücker Str. 37a\n10405 Berlin\nGermany",
     "phone": "+49 173 8014805",
-    "email": "privacy@adjust.com",
+    "email": "dpo@adjust.com",
     "web": "https://www.adjust.com/",
     "sources": [
         "https://www.adjust.com/terms/privacy-policy/"


### PR DESCRIPTION
The registered address `privacy@adjust.com` no longer appears on the source page (`None`). That page currently lists `dpo@adjust.com` as the privacy contact (groq scan).

Found and verified by the Privacy Engine optimizer, run #14.