### PR TITLE
Update 3D Hubs B.V.: email address changed

### DIFF
--- a/companies/3dhubs.json
+++ b/companies/3dhubs.json
@@ -13,7 +13,7 @@
     ],
     "address": "Danzigerkade 23A\n1013 AP Amsterdam\nThe Netherlands",
     "phone": "+31 85 888 7380",
-    "email": "legal@3dhubs.com",
+    "email": "networklegal@protolabs.com",
     "web": "https://www.hubs.com/",
     "sources": [
         "https://www.hubs.com/privacy-policy/"


### PR DESCRIPTION
The registered address `legal@3dhubs.com` no longer appears on the source page (`None`). That page currently lists `networklegal@protolabs.com` as the privacy contact (screenshot scan).

Found and verified by the Privacy Engine optimizer, run #14.