### PR TITLE
Update Abel & Cole: email address changed

### DIFF
--- a/companies/abel-cole.json
+++ b/companies/abel-cole.json
@@ -9,7 +9,7 @@
     "name": "Abel & Cole",
     "address": "The Riverside Building\nLivingstone Road\nHessle\nEast Yorkshire\nHU13 0DZ\nUnited Kingdom",
     "phone": "+44 345 262 6262",
-    "email": "privacy@abelandcole.co.uk",
+    "email": "data.privacy@wjfg.co.uk",
     "web": "https://www.abelandcole.co.uk/",
     "sources": [
         "https://www.abelandcole.co.uk/ContentPage?folder=gdpr&file=privacy_policy.htm",


### PR DESCRIPTION
The registered address `privacy@abelandcole.co.uk` no longer appears on the source page (`None`). That page currently lists `data.privacy@wjfg.co.uk` as the privacy contact (screenshot scan).

Found and verified by the Privacy Engine optimizer, run #14.