### PR TITLE
Update Adelphic LLC: email address changed

### DIFF
--- a/companies/adelphic.json
+++ b/companies/adelphic.json
@@ -8,7 +8,7 @@
     ],
     "name": "Adelphic LLC",
     "address": "880 Main Street\nFloor 3\nWaltham\nMA 02451\nUnited States of America",
-    "email": "dpo@adelphic.com",
+    "email": "privacy@viantinc.com",
     "web": "https://www.adelphic.com/",
     "sources": [
         "https://www.adelphic.com/privacy-policy/"


### PR DESCRIPTION
The registered address `dpo@adelphic.com` no longer works: the record's own listed source page (`https://www.adelphic.com/privacy-policy/`) now returns 404, and adelphic.com has no privacy contact of its own anymore.

Adelphic was absorbed into Viant. adelphic.com's own site configuration (visible in its page source) explicitly redirects `adelphic.com`, `ccpa.adelphic.com`, and `help.adelphic.com` to viantinc.com equivalents (e.g. `ccpa.adelphic.com` -> Viant's CCPA/privacy webform). Viant's current privacy contact, `privacy@viantinc.com`, is live on https://www.viantinc.com/privacy-center/ and is used throughout that page for data-subject requests (access, deletion, correction, objection).

Verified independently against both the old and new live pages before submitting (not from an LLM/AI response).