### PR TITLE
Update 4sigma GmbH: email address changed

### DIFF
--- a/companies/4sigma.json
+++ b/companies/4sigma.json
@@ -11,7 +11,7 @@
     "address": "Bajuwarenring 9\n82041 Oberhaching\nDeutschland",
     "phone": "+49 89 9500840",
     "fax": "+49 89 95008410",
-    "email": "info@4sigma.de",
+    "email": "datenschutz@4sigma.de",
     "web": "https://www.4sigma.de",
     "sources": [
         "https://www.4sigma.de/j/privacy",


### PR DESCRIPTION
The registered address `info@4sigma.de` is the company's general contact address (Impressum/footer), not the privacy contact. The source page (`https://www.4sigma.de/j/privacy`, already listed in this record's own sources) explicitly labels `datenschutz@4sigma.de` as the "Datenschutzbeauftragte" (data protection officer) contact, with a named DPO (Karen-Maria Gyüge) and repeated use throughout the page for data-subject rights requests.

Verified independently against the live page before submitting (not from an LLM/AI response) — content requires JS rendering to display (client-side rendered page).