### PR TITLE
Update scondoo GmbH: email address changed

### DIFF
--- a/companies/scondoo.json
+++ b/companies/scondoo.json
@@ -10,7 +10,7 @@
     "address": "Friedrichstraße 153a\n10117 Berlin\nDeutschland",
     "phone": "+49 30 652120088",
     "fax": "+49 30 652120089",
-    "email": "datenschutzbeauftragter@datenschutzexperte.de",
+    "email": "datenschutz@scondoo.de",
     "web": "https://scondoo.de/",
     "sources": [
         "https://scondoo.de/wp/datenschutz/",


### PR DESCRIPTION
The registered address `datenschutzbeauftragter@datenschutzexperte.de` (an external DPO service) no longer appears on the source page. The current privacy policy (`https://scondoo.de/datenschutz`) explicitly names Fieldfisher Tech Rechtsanwaltsgesellschaft mbH as the external DPO, with contact via `datenschutz@scondoo.de`.

Verified independently against the live page before submitting (not from an LLM/AI response).