### PR TITLE
Update Inside Lead GmbH: email address changed

### DIFF
--- a/companies/inside-lead.json
+++ b/companies/inside-lead.json
@@ -10,7 +10,7 @@
     ],
     "name": "Inside Lead GmbH",
     "address": "Hanauer Landstrasse 291 B\n60314 Frankfurt\nDeutschland",
-    "email": "service@inside-lead.com",
+    "email": "info@stolzenhain-anwalt.de",
     "web": "https://www.inside-lead.com",
     "sources": [
         "https://www.inside-lead.com/#datenschutz",


### PR DESCRIPTION
The source page (`https://www.inside-lead.com/#datenschutz`) explicitly states: "Unser externer Datenschutzbeauftragter ist: ... Kaspar-Ludwig Stolzenhain ... Kontakt: info@stolzenhain-anwalt.de" — an external DPO, distinct from the registered general contact address `service@inside-lead.com`.

Verified independently against the live page before submitting (not from an LLM/AI response).