### PR TITLE
Update Goldbach Germany GmbH: email address changed

### DIFF
--- a/companies/goldbach-de.json
+++ b/companies/goldbach-de.json
@@ -9,7 +9,7 @@
     "name": "Goldbach Germany GmbH",
     "address": "c/o ePrivacy GmbH\nGroße Bleichen 21\n20354 Hamburg\nDeutschland",
     "phone": "+49 89 614240400",
-    "email": "oba@de.goldbach.com",
+    "email": "oba@ch.goldbach.com",
     "web": "https://goldbach.com/de/de",
     "sources": [
         "https://goldbach.com/de/de/datenschutz/goldbach-germany",


### PR DESCRIPTION
The registered source (`https://goldbach.com/de/de/datenschutz/goldbach-germany`) now redirects to a different domain (goldvertise.com) with no DPO contact listed. The current Goldbach Group privacy page (`https://goldbach.com/de/datenschutz/`) lists `oba@ch.goldbach.com` as the data protection contact ("Goldbach Group ist eine Aktiengesellschaft nach schweizerischem Recht ... oba@ch.goldbach.com"); the previously registered `oba@de.goldbach.com` no longer appears anywhere.

Verified independently against the live page before submitting (not from an LLM/AI response).