### PR TITLE
Update Ancestry Ireland Unlimited Company: email address changed

### DIFF
--- a/companies/ancestry-com.json
+++ b/companies/ancestry-com.json
@@ -11,7 +11,7 @@
     ],
     "address": "52–55 Sir John Rogerson’s Quay\nDublin D02 NA07\nIreland",
     "phone": "+353 1800 303 667",
-    "email": "dpo@ancestry.com",
+    "email": "privacy@ancestry.com",
     "web": "https://www.ancestry.com",
     "sources": [
         "https://www.ancestry.com/cs/legal/privacystatement"


### PR DESCRIPTION
The registered address `dpo@ancestry.com` no longer appears on the source page (`https://ancestry.com/privacy`). That page currently lists `privacy@ancestry.com` as the privacy contact (render scan).

Found and verified by the Privacy Engine optimizer, run #70.