### PR TITLE
Update Sumo Group Inc.: email address changed

### DIFF
--- a/companies/appsumo.json
+++ b/companies/appsumo.json
@@ -13,7 +13,7 @@
         "KingSumo"
     ],
     "address": "1305 E. 6th St #3\nAustin TX 78702\nUnited States of America",
-    "email": "support@appsumo.com",
+    "email": "privacy@appsumo.com",
     "web": "https://appsumo.com/",
     "sources": [
         "https://appsumo.com/privacy/"


### PR DESCRIPTION
The registered address `support@appsumo.com` no longer appears on the source page (`https://appsumo.com/privacy/`). That page currently lists `privacy@appsumo.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #61.