### PR TITLE
Update Atlassian B.V.: email address changed

### DIFF
--- a/companies/atlassian.json
+++ b/companies/atlassian.json
@@ -20,7 +20,7 @@
     ],
     "address": "c/o Atlassian, Inc.\n350 Bush Street, Floor 13\nSan Francisco, CA 94104\nUnited States of America",
     "phone": "+31 20 796 0060",
-    "email": "eudatarep@atlassian.com",
+    "email": "privacy@atlassian.com",
     "web": "https://www.atlassian.com/",
     "sources": [
         "https://www.atlassian.com/legal/privacy-policy",


### PR DESCRIPTION
The registered address `eudatarep@atlassian.com` no longer appears on the source page (`https://www.atlassian.com/legal/privacy-policy`). That page currently lists `privacy@atlassian.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #61.