### PR TITLE
Update ATP Auto-Teile-Pöllath Handels GmbH: email address changed

### DIFF
--- a/companies/atp-autoteile.json
+++ b/companies/atp-autoteile.json
@@ -7,7 +7,7 @@
     "address": "Am Heidweg 1\n92690 Pressath\nDeutschland",
     "phone": "+49 9647 9273510",
     "fax": "+49 9647 929039399",
-    "email": "info@atp-autoteile.de",
+    "email": "datenschutz@atp-autoteile.de",
     "web": "https://www.atp-autoteile.de",
     "sources": [
         "https://www.atp-autoteile.de/de/privacy",


### PR DESCRIPTION
The registered address `info@atp-autoteile.de` no longer appears on the source page (`https://www.atp-autoteile.de/de/privacy`). That page currently lists `datenschutz@atp-autoteile.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #61.