### PR TITLE
Update BRUNO BADER GmbH + Co. KG: email address changed

### DIFF
--- a/companies/bader-shop.json
+++ b/companies/bader-shop.json
@@ -7,7 +7,7 @@
     "address": "Maximilianstraße 48\n75172 Pforzheim\nDeutschland",
     "phone": "+49 7231 3030",
     "fax": "+49 7231 303777",
-    "email": "service@bader.de",
+    "email": "datenschutz@bader.de",
     "web": "https://www.bader.de/",
     "sources": [
         "https://www.bader.de/datenschutz",


### PR DESCRIPTION
The registered address `service@bader.de` no longer appears on the source page (`https://www.bader.de/datenschutz`). That page currently lists `datenschutz@bader.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #61.