### PR TITLE
Update Bundesamt für Wirtschaft und Ausfuhrkontrolle (BAFA): email address changed

### DIFF
--- a/companies/bafa-bund.json
+++ b/companies/bafa-bund.json
@@ -10,7 +10,7 @@
     "address": "Frankfurter Straße 29 – 35\n65760 Eschborn\nDeutschland",
     "phone": "+49 6196 9080",
     "fax": "+49 6196 9081800",
-    "email": "poststelle@bafa.bund.de",
+    "email": "datenschutz@bafa.bund.de",
     "web": "https://www.bafa.de",
     "sources": [
         "https://www.bafa.de/DE/Service/Datenschutzerklaerung/datenschutzerklaerung_node.html"


### PR DESCRIPTION
The registered address `poststelle@bafa.bund.de` no longer appears on the source page (`https://www.bafa.de/DE/Service/Datenschutzerklaerung/datenschutzerklaerung_node.html`). That page currently lists `datenschutz@bafa.bund.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #61.