### PR TITLE
Update BB Services GmbH: email address changed

### DIFF
--- a/companies/bb-services-gmbh.json
+++ b/companies/bb-services-gmbh.json
@@ -12,7 +12,7 @@
     ],
     "address": "Böttgerstr. 14\n65439 Flörsheim\nDeutschland",
     "phone": "+49 6145 5456192",
-    "email": "contact@bluebrixx.com",
+    "email": "datenschutz@bluebrixx.com",
     "web": "https://www.bluebrixx.com",
     "sources": [
         "https://www.bluebrixx.com/de/policy_privacy",


### PR DESCRIPTION
The registered address `contact@bluebrixx.com` no longer appears on the source page (`https://www.bluebrixx.com/de/policy_privacy`). That page currently lists `datenschutz@bluebrixx.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #66.