### PR TITLE
Update Bundesamt für Bevölkerungsschutz und Katastrophenhilfe (BBK): email address changed

### DIFF
--- a/companies/bbk-bund.json
+++ b/companies/bbk-bund.json
@@ -10,7 +10,7 @@
     "address": "Provinzialstraße 93\n53127 Bonn\nDeutschland",
     "phone": "+49 228 995500",
     "fax": "+49 228 995501620",
-    "email": "datenschutz@bbk.bund.de",
+    "email": "datenschutzbeauftragter@bbk.bund.de",
     "web": "https://www.bbk.bund.de",
     "sources": [
         "https://www.bbk.bund.de/DE/Service/Datenschutz/datenschutz_node.html"


### PR DESCRIPTION
The registered address `datenschutz@bbk.bund.de` no longer appears on the source page (`https://www.bbk.bund.de/DE/Service/Datenschutz/datenschutz_node.html`). That page currently lists `datenschutzbeauftragter@bbk.bund.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #67.