### PR TITLE
Update Verlag C.H. Beck GmbH & Co. KG: email address changed

### DIFF
--- a/companies/beck.json
+++ b/companies/beck.json
@@ -17,7 +17,7 @@
     ],
     "address": "Postfach 40 03 40\n80703 München\nDeutschland",
     "phone": "+49 89 381890",
-    "email": "datenschutzauskunft@beck.de",
+    "email": "datenschutzbeauftragter@beck.de",
     "web": "https://www.beck.de/",
     "sources": [
         "https://rsw.beck.de/beck-online-service/datenschutz",


### PR DESCRIPTION
The registered address `datenschutzauskunft@beck.de` no longer appears on the source page (`https://rsw.beck.de/beck-online-service/datenschutz`). That page currently lists `datenschutzbeauftragter@beck.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #67.