### PR TITLE
Update BeReal: email address changed

### DIFF
--- a/companies/bereal.json
+++ b/companies/bereal.json
@@ -9,7 +9,7 @@
     ],
     "name": "BeReal",
     "address": "30/32 Boulevard de Sébastopol\n75004 Paris\nFrance",
-    "email": "contact@bere.al",
+    "email": "dpo@bere.al",
     "web": "https://bere.al/",
     "sources": [
         "https://bere.al/en/privacy"


### PR DESCRIPTION
The registered address `contact@bere.al` no longer appears on the source page (`https://bere.al/en/privacy`). That page currently lists `dpo@bere.al` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.