### PR TITLE
Update Bundesinstitut für Bevölkerungsforschung (BiB): email address changed

### DIFF
--- a/companies/bib-bund.json
+++ b/companies/bib-bund.json
@@ -10,7 +10,7 @@
     "address": "65180 Wiesbaden\nDeutschland",
     "phone": "+49 611 753929",
     "fax": "+49 611 753972",
-    "email": "datenschutzbeauftragter@destatis.de",
+    "email": "datenschutz@destatis.de",
     "web": "https://www.bib.bund.de",
     "sources": [
         "https://www.bib.bund.de/DE/Service/Datenschutz/Datenschutz.html"


### PR DESCRIPTION
The registered address `datenschutzbeauftragter@destatis.de` no longer appears on the source page (`https://www.bib.bund.de/DE/Service/Datenschutz/Datenschutz.html`). That page currently lists `datenschutz@destatis.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.