### PR TITLE
Update Bigpoint GmbH: email address changed

### DIFF
--- a/companies/bigpoint.json
+++ b/companies/bigpoint.json
@@ -27,7 +27,7 @@
     "address": "Sachsenstraße 20\n20097 Hamburg\nGermany",
     "phone": "+49 40 8814130",
     "fax": "+49 40 881413906",
-    "email": "privacy@bigpoint.net",
+    "email": "datenschutz@bigpoint.net",
     "web": "https://www.bigpoint.net/",
     "sources": [
         "https://legal.bigpoint.com/DE/privacy-policy/de-DE",


### PR DESCRIPTION
The registered address `privacy@bigpoint.net` no longer appears on the source page (`https://legal.bigpoint.com/DE/privacy-policy/de-DE`). That page currently lists `datenschutz@bigpoint.net` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.