### PR TITLE
Update Booking.com B.V.: email address changed

### DIFF
--- a/companies/booking-com.json
+++ b/companies/booking-com.json
@@ -14,7 +14,7 @@
     "address": "Herengracht 597\n1017 CE Amsterdam\nThe Netherlands",
     "phone": "+31 70 770 3884",
     "fax": "+31 20 712 5609",
-    "email": "dataprotectionoffice@booking.com",
+    "email": "privacy.kr@booking.com",
     "web": "https://www.booking.com",
     "sources": [
         "https://www.booking.com/content/privacy.de.html",


### PR DESCRIPTION
The registered address `dataprotectionoffice@booking.com` no longer appears on the source page (`https://www.booking.com/content/privacy.de.html`). That page currently lists `privacy.kr@booking.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.