### PR TITLE
Update Wunderkind Corporation: email address changed

### DIFF
--- a/companies/bouncex.json
+++ b/companies/bouncex.json
@@ -11,7 +11,7 @@
         "Bounce Exchange, Inc. (BounceX, formerly)"
     ],
     "address": "c/o ePrivacy Holding GmbH\nGroße Bleichen 21\n20354 Hamburg\nGermany",
-    "email": "privacyrequests@wunderkind.co",
+    "email": "gdpr@wunderkind.co",
     "web": "https://www.wunderkind.co",
     "sources": [
         "https://www.wunderkind.co/uk/privacy/"


### PR DESCRIPTION
The registered address `privacyrequests@wunderkind.co` no longer appears on the source page (`https://www.wunderkind.co/privacy/global_dpa/`). That page currently lists `gdpr@wunderkind.co` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #73.