### PR TITLE
Update Bundesamt für Sicherheit in der Informationstechnik (BSI): email address changed

### DIFF
--- a/companies/bsi-bund.json
+++ b/companies/bsi-bund.json
@@ -10,7 +10,7 @@
     "address": "Godesberger Allee 185 – 189\n53175 Bonn\nDeutschland",
     "phone": "+49 228 9995825775",
     "fax": "+49 228 991095820",
-    "email": "datenschutzbeauftragte@bsi.bund.de",
+    "email": "datenschutzbeauftragter@bsi.bund.de",
     "web": "https://www.bsi.bund.de",
     "sources": [
         "https://www.bsi.bund.de/DE/Service/Datenschutz/datenschutz_node.html"


### PR DESCRIPTION
The registered address `datenschutzbeauftragte@bsi.bund.de` no longer appears on the source page (`https://www.bsi.bund.de/DE/Service/Datenschutz/datenschutz_node.html`). That page currently lists `datenschutzbeauftragter@bsi.bund.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.