### PR TITLE
Update Buffer Inc.: email address changed

### DIFF
--- a/companies/bufferapp.json
+++ b/companies/bufferapp.json
@@ -11,7 +11,7 @@
         "Buffer Reply"
     ],
     "address": "2443 Fillmore St #380-7163\nSan Francisco\nCA 94115\nUnited States of America",
-    "email": "hello@buffer.com",
+    "email": "privacy@buffer.com",
     "web": "https://buffer.com/",
     "sources": [
         "https://buffer.com/privacy"


### PR DESCRIPTION
The registered address `hello@buffer.com` no longer appears on the source page (`https://buffer.com/privacy`). That page currently lists `privacy@buffer.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.