### PR TITLE
Update Catalina Marketing Corporation: email address changed

### DIFF
--- a/companies/catalina.json
+++ b/companies/catalina.json
@@ -11,7 +11,7 @@
         "Catalina Deutschland GmbH"
     ],
     "address": "200 Carillon Parkway\nSt. Petersburg\nFL 33716\nUnited States of America",
-    "email": "privacyteam@catalina.com",
+    "email": "dpo@catalina.com",
     "webform": "https://privacyportal.onetrust.com/webform/7665c53e-aae8-4a03-9dd3-66fb6bce8f55/6c428920-a20e-4932-a5c9-a16f4a7abea2",
     "web": "https://www.catalina.com",
     "sources": [


### PR DESCRIPTION
The registered address `privacyteam@catalina.com` no longer appears on the source page (`https://www.catalina.com/legal`). That page currently lists `dpo@catalina.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.