### PR TITLE
Update Cloudflare, Ltd.: email address changed

### DIFF
--- a/companies/cloudflare.json
+++ b/companies/cloudflare.json
@@ -13,7 +13,7 @@
     ],
     "address": "2nd Floor\n25 Lavington Street\nLondon\nSE1 0NZ\nUnited Kingdom",
     "phone": "+1 650 319 8930",
-    "email": "sar@cloudflare.com",
+    "email": "dpo@cloudflare.com",
     "web": "https://www.cloudflare.com/",
     "sources": [
         "https://www.cloudflare.com/privacypolicy/"


### PR DESCRIPTION
The registered address `sar@cloudflare.com` no longer appears on the source page (`https://www.cloudflare.com/privacypolicy/`). That page currently lists `dpo@cloudflare.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.