### PR TITLE
Update Cognizant Technology Solutions Benelux BV: email address changed

### DIFF
--- a/companies/cognizant-nl.json
+++ b/companies/cognizant-nl.json
@@ -6,7 +6,7 @@
     "name": "Cognizant Technology Solutions Benelux BV",
     "address": "Cognizant Digital Studio\nPaul van Vlissingenstraat 10\n1096 BK Amsterdam\nThe Netherlands",
     "phone": "+31 20 595 0550",
-    "email": "SAR@cognizant.com",
+    "email": "dataprotectionofficer@cognizant.com",
     "web": "https://www.cognizant.com/nl-nl/",
     "sources": [
         "https://www.cognizant.com/privacy-statement",


### PR DESCRIPTION
The registered address `SAR@cognizant.com` no longer appears on the source page (`https://www.cognizant.com/us/en/privacy-notice`). That page currently lists `dataprotectionofficer@cognizant.com` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #73.