### PR TITLE
Update CRIF GmbH: email address changed

### DIFF
--- a/companies/crif-at.json
+++ b/companies/crif-at.json
@@ -12,7 +12,7 @@
     "address": "Rothschildplatz 3/Top 3.06.B\n1020 Wien\nÖsterreich",
     "phone": "+43 1 89742440",
     "fax": "+43 1 8974244831",
-    "email": "auskunft@crif.com",
+    "email": "datenschutz.at@crif.com",
     "web": "https://www.crif.at/",
     "sources": [
         "https://www.crif.at/datenschutzerklaerung-auskunftei-und-adressverlag/",


### PR DESCRIPTION
The registered address `auskunft@crif.com` no longer appears on the source page (`https://www.crif.at/datenschutzerklaerung-auskunftei-und-adressverlag/`). That page currently lists `datenschutz.at@crif.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.