### PR TITLE
Update Crisp IM SAS: email address changed

### DIFF
--- a/companies/crisp.json
+++ b/companies/crisp.json
@@ -9,7 +9,7 @@
     "name": "Crisp IM SAS",
     "address": "2 Boulevard de Launay\n44100 Nantes\nFrance",
     "phone": "+33 2 40 03 11 87",
-    "email": "support@crisp.chat",
+    "email": "dpo@crisp.chat",
     "web": "https://crisp.chat/",
     "sources": [
         "https://help.crisp.chat/en/article/whats-crisp-eu-gdpr-compliance-status-nhv54c/",


### PR DESCRIPTION
The registered address `support@crisp.chat` no longer appears on the source page (`https://help.crisp.chat/en/article/whats-crisp-eu-gdpr-compliance-status-nhv54c/`). That page currently lists `dpo@crisp.chat` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.