### PR TITLE
Update Christlich-Soziale Union in Bayern e.V. (CSU): email address changed

### DIFF
--- a/companies/csu.json
+++ b/companies/csu.json
@@ -10,7 +10,7 @@
     "address": "Mies-van-der-Rohe-Straße 1\n80807 München\nDeutschland",
     "phone": "+49 89 12430",
     "fax": "+49 89 12434297",
-    "email": "datenschutzbeauftragter@csu-bayern.de",
+    "email": "datenschutz@csu-bayern.de",
     "web": "https://www.csu.de/",
     "sources": [
         "https://www.csu.de/datenschutz/",


### PR DESCRIPTION
The registered address `datenschutzbeauftragter@csu-bayern.de` no longer appears on the source page (`https://www.csu.de/datenschutz/`). That page currently lists `datenschutz@csu-bayern.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.