### PR TITLE
Update Danske Bank A/S: email address changed

### DIFF
--- a/companies/danskebank.json
+++ b/companies/danskebank.json
@@ -16,7 +16,7 @@
     "name": "Danske Bank A/S",
     "address": "Holmens Kanal 2-12\n1092 København K\nDenmark",
     "phone": "+45 70 12 34 56",
-    "email": "dpofunction@danskebank.com",
+    "email": "gdpr_data_subject_rights@danskebank.com",
     "web": "https://danskebank.com/",
     "sources": [
         "https://danskebank.dk/PDF/GDPR/Danske_Bank_privacy_notice.pdf",


### PR DESCRIPTION
The registered address `dpofunction@danskebank.com` no longer appears on the source page (`https://danskebank.dk/PDF/GDPR/Danske_Bank_privacy_notice.pdf`). That page currently lists `gdpr_data_subject_rights@danskebank.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.