### PR TITLE
Update Dataport AöR: email address changed

### DIFF
--- a/companies/dataport.json
+++ b/companies/dataport.json
@@ -10,7 +10,7 @@
     "name": "Dataport AöR",
     "address": "Altenholzer Straße 10-14\n24161 Altenholz\nDeutschland",
     "phone": "+49 40 428466912",
-    "email": "dataportdatenschutzbeauftragter@dataport.de",
+    "email": "datenschutzbeauftragter@dataport.de",
     "web": "https://www.dataport.de",
     "sources": [
         "https://www.dataport.de/datenschutz/",


### PR DESCRIPTION
The registered address `dataportdatenschutzbeauftragter@dataport.de` no longer appears on the source page (`https://www.dataport.de/datenschutz/`). That page currently lists `datenschutzbeauftragter@dataport.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.