### PR TITLE
Update Statistisches Bundesamt: email address changed

### DIFF
--- a/companies/destatis.json
+++ b/companies/destatis.json
@@ -10,7 +10,7 @@
     "address": "65180 Wiesbaden\nDeutschland",
     "phone": "+49 611 753929",
     "fax": "+49 611 753972",
-    "email": "datenschutzbeauftragter@destatis.de",
+    "email": "datenschutz@destatis.de",
     "web": "https://www.destatis.de",
     "sources": [
         "https://www.destatis.de/DE/Meta/Datenschutz/Datenschutz.html"


### PR DESCRIPTION
The registered address `datenschutzbeauftragter@destatis.de` no longer appears on the source page (`https://www.destatis.de/DE/Meta/Datenschutz/Datenschutz.html`). That page currently lists `datenschutz@destatis.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.