### PR TITLE
Update DB Vertrieb GmbH: email address changed

### DIFF
--- a/companies/deutsche-bahn.json
+++ b/companies/deutsche-bahn.json
@@ -16,7 +16,7 @@
         "DB Fernverkehr AG"
     ],
     "address": "Europa-Allee 78-84\n60486 Frankfurt\nGermany",
-    "email": "p.d-datenschutz@deutschebahn.com",
+    "email": "datenschutz.regio@deutschebahn.com",
     "web": "https://www.bahn.de",
     "sources": [
         "https://www.bahn.de/datenschutz",


### PR DESCRIPTION
The registered address `p.d-datenschutz@deutschebahn.com` no longer appears on the source page (`https://www.bahn.de/datenschutz`). That page currently lists `datenschutz.regio@deutschebahn.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.