### PR TITLE
Update DIHK Deutscher Industrie- und Handelskammertag e.V.: email address changed

### DIFF
--- a/companies/dihk-de.json
+++ b/companies/dihk-de.json
@@ -6,7 +6,7 @@
     "name": "DIHK Deutscher Industrie- und Handelskammertag e.V.",
     "address": "Breite Straße 29\n10178 Berlin\nDeutschland",
     "phone": "+49 30 203080",
-    "email": "info@dihk.de",
+    "email": "datenschutz@dihk.de",
     "web": "https://www.dihk.de",
     "sources": [
         "https://www.dihk.de/wir-ueber-uns/datenschutz",


### PR DESCRIPTION
The registered address `info@dihk.de` no longer appears on the source page (`https://dihk.de/de/datenschutz`). That page currently lists `datenschutz@dihk.de` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #73.