### PR TITLE
Update DRK-Landesverband Brandenburg e.V.: email address changed

### DIFF
--- a/companies/drk-brandenburg.json
+++ b/companies/drk-brandenburg.json
@@ -13,7 +13,7 @@
     "address": "c/o BfbA GmbH\nEisenbahnstraße 109\n14542 Werder (Havel)\nDeutschland",
     "phone": "+49 331 28640",
     "fax": "+49 3327 7322561",
-    "email": "info@drk-lv-brandenburg.de",
+    "email": "datenschutz@drk-lv-brandenburg.de",
     "web": "https://www.drk-brandenburg.de",
     "sources": [
         "https://www.drk-brandenburg.de/footer/service/datenschutz/"


### PR DESCRIPTION
The registered address `info@drk-lv-brandenburg.de` no longer appears on the source page (`https://www.drk-brandenburg.de/footer/service/datenschutz/`). That page currently lists `datenschutz@drk-lv-brandenburg.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.