### PR TITLE
Update DuckDuckGo: email address changed

### DIFF
--- a/companies/duckduckgo.json
+++ b/companies/duckduckgo.json
@@ -8,7 +8,7 @@
     ],
     "name": "DuckDuckGo",
     "address": "20 Paoli Pike\nPaoli\nPA 19301\nUnited States of America",
-    "email": "legal@duckduckgo.com",
+    "email": "privacy@duckduckgo.com",
     "web": "https://duckduckgo.com",
     "sources": [
         "https://help.duckduckgo.com/duckduckgo-help-pages/company/contact-us/",


### PR DESCRIPTION
The registered address `legal@duckduckgo.com` no longer appears on the source page (`https://help.duckduckgo.com/duckduckgo-help-pages/company/contact-us/`). That page currently lists `privacy@duckduckgo.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.