### PR TITLE
Update EfficientIP, SAS: email address changed

### DIFF
--- a/companies/efficientip-com.json
+++ b/companies/efficientip-com.json
@@ -6,7 +6,7 @@
     "name": "EfficientIP, SAS",
     "address": "90 Boulevard National\n92250 La Garenne Colombes\nFrance",
     "phone": "+33 1 75 84 88 98",
-    "email": "info@efficientip.com",
+    "email": "privacy@efficientip.com",
     "web": "https://www.efficientip.com",
     "sources": [
         "https://www.efficientip.com/de/kontakt/",


### PR DESCRIPTION
The registered address `info@efficientip.com` no longer appears on the source page (`https://efficientip.com/privacy/`). That page currently lists `privacy@efficientip.com` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #55.