### PR TITLE
Update Elitenetzwerk Bayern: email address changed

### DIFF
--- a/companies/elitenetzwerk-bayern.json
+++ b/companies/elitenetzwerk-bayern.json
@@ -11,7 +11,7 @@
     "address": "Bayerisches Staatsministerium für Wissenschaft und Kunst\nSalvatorstraße 2\n80333 München\nDeutschland",
     "phone": "+49 89 21862405",
     "fax": "+49 89 21862840",
-    "email": "Klaus.Molitoris@stmwk.bayern.de",
+    "email": "datenschutzbeauftragter@stmwk.bayern.de",
     "web": "https://www.elitenetzwerk.bayern.de/start",
     "sources": [
         "https://www.elitenetzwerk.bayern.de/datenschutz",


### PR DESCRIPTION
The registered address `Klaus.Molitoris@stmwk.bayern.de` no longer appears on the source page (`https://www.elitenetzwerk.bayern.de/datenschutz`). That page currently lists `datenschutzbeauftragter@stmwk.bayern.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.