### PR TITLE
Update Renaissance: email address changed

### DIFF
--- a/companies/en-marche.json
+++ b/companies/en-marche.json
@@ -11,7 +11,7 @@
         "La République en marche (formerly)"
     ],
     "address": "68 rue du Rocher\n75008 Paris\nFrance",
-    "email": "mes-donnees@parti-renaissance.fr",
+    "email": "dpo@parti-renaissance.fr",
     "web": "https://parti-renaissance.fr/",
     "sources": [
         "https://parti-renaissance.fr/politique-de-protection-des-donnees",


### PR DESCRIPTION
The registered address `mes-donnees@parti-renaissance.fr` no longer appears on the source page (`https://parti-renaissance.fr/politique-de-protection-des-donnees`). That page currently lists `dpo@parti-renaissance.fr` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.