### PR TITLE
Update DREWAG - Stadtwerke Dresden GmbH: email address changed

### DIFF
--- a/companies/energiemanufaktur.json
+++ b/companies/energiemanufaktur.json
@@ -13,7 +13,7 @@
     "address": "Friedrich-List-Platz 2\n01069 Dresden\nDeutschland",
     "phone": "+49 351 8604444",
     "fax": "+49 351 8604647",
-    "email": "drewag-datenschutz@SachsenEnergie.de",
+    "email": "datenschutz@sachsenenergie.de",
     "web": "https://www.energiemanufaktur.net",
     "sources": [
         "https://www.energiemanufaktur.net/datenschutz/",


### PR DESCRIPTION
The registered address `drewag-datenschutz@SachsenEnergie.de` no longer appears on the source page (`https://www.energiemanufaktur.net/datenschutz/`). That page currently lists `datenschutz@sachsenenergie.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.