### PR TITLE
Update Flaconi GmbH: email address changed

### DIFF
--- a/companies/flaconi.json
+++ b/companies/flaconi.json
@@ -7,7 +7,7 @@
     "address": "Franklinstraße 13\n10587 Berlin\nDeutschland",
     "phone": "+49 30 92036363",
     "fax": "+49 30 609861289",
-    "email": "service@flaconi.de",
+    "email": "datenschutz@flaconi.de",
     "web": "https://www.flaconi.de/",
     "sources": [
         "https://www.flaconi.de/datenschutz/",


### PR DESCRIPTION
The registered address `service@flaconi.de` no longer appears on the source page (`https://flaconi.de/datenschutz`). That page currently lists `datenschutz@flaconi.de` as the privacy contact (render scan).

Found and verified by the Privacy Engine optimizer, run #73.