### PR TITLE
Update Ganz Einfach GmbH: email address changed

### DIFF
--- a/companies/ganzeinfach.json
+++ b/companies/ganzeinfach.json
@@ -12,7 +12,7 @@
     "name": "Ganz Einfach GmbH",
     "address": "Wohlenbergstr. 16\n30179 Hannover\nDeutschland",
     "phone": "+49 511 13221710",
-    "email": "info@ganzeinfach.de",
+    "email": "datenschutz@ganzeinfach.de",
     "web": "https://www.ganzeinfach.de",
     "sources": [
         "https://www.ganzeinfach.de/de/datenschutz.html"


### PR DESCRIPTION
The registered address `info@ganzeinfach.de` no longer appears on the source page (`https://www.ganzeinfach.de/de/datenschutz.html`). That page currently lists `datenschutz@ganzeinfach.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.