### PR TITLE
Update Garmin Würzburg GmbH: email address changed

### DIFF
--- a/companies/garmin.json
+++ b/companies/garmin.json
@@ -13,7 +13,7 @@
         "Garmin Connect"
     ],
     "address": "Leightonstr. 7\n97074 Würzburg\nDeutschland",
-    "email": "euprivacy@garmin.com",
+    "email": "privacy@garmin.com",
     "webform": "https://www.garmin.com/account/datamanagement",
     "web": "https://garmin.com",
     "sources": [


### PR DESCRIPTION
The registered address `euprivacy@garmin.com` no longer appears on the source page (`https://www.garmin.com/en-GB/privacy/global/policy/`). That page currently lists `privacy@garmin.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.