### PR TITLE
Update G DATA Software AG: email address changed

### DIFF
--- a/companies/gdata.json
+++ b/companies/gdata.json
@@ -18,7 +18,7 @@
     "address": "G DATA Campus\nKönigsallee 178\n44799 Bochum\nDeutschland",
     "phone": "+49 234 97620",
     "fax": "+49 234 9762299",
-    "email": "dsgvo@gdata.de",
+    "email": "info@gdata.de",
     "web": "https://www.gdata.de/",
     "sources": [
         "https://www.gdata.de/datenschutzerklaerung",


### PR DESCRIPTION
The registered address `dsgvo@gdata.de` no longer appears on the source page (`https://gdata.de/privacy`). That page currently lists `info@gdata.de` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #73.