### PR TITLE
Update Generali Deutschland Krankenversicherung AG: email address changed

### DIFF
--- a/companies/generali-deutschland-krankenversicherung.json
+++ b/companies/generali-deutschland-krankenversicherung.json
@@ -9,7 +9,7 @@
     "name": "Generali Deutschland Krankenversicherung AG",
     "address": "Adenauering 7\n81737 München\nDeutschland",
     "phone": "+49 89 51212138",
-    "email": "datenschutz-gesundheit@generali.com",
+    "email": "konzerndatenschutz.de@generali.com",
     "web": "https://www.generali.de/ueber-uns/gesellschaften-marken/generali-deutschland-versicherungen/krankenversicherung-ag",
     "sources": [
         "https://www.generali.de/resource/blob/37544/c3287ecdafb7bae20e50b9f29055697b/TA%2040%20231107%20DSGVO%20GEDK_G.pdf"


### PR DESCRIPTION
The registered address `datenschutz-gesundheit@generali.com` no longer appears on the source page (`https://generali.de/datenschutz`). That page currently lists `konzerndatenschutz.de@generali.com` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #73.