### PR TITLE
Update Generali Deutschland Services GmbH: email address changed

### DIFF
--- a/companies/generali-deutschland-services.json
+++ b/companies/generali-deutschland-services.json
@@ -9,7 +9,7 @@
     "name": "Generali Deutschland Services GmbH",
     "address": "Anton-Kurze-Alle 16\n52064 Aachen\nDeutschland",
     "phone": "+49 89 51210",
-    "email": "datenschutzbeauftragter.de@generali.com",
+    "email": "konzerndatenschutz.de@generali.com",
     "sources": [
         "https://www.generali.de/resource/blob/37568/8e090988152cf8f766a0c4387b484230/TA%2025%20231107%20DSGVO%20GDS_G.pdf"
     ],


### PR DESCRIPTION
The registered address `datenschutzbeauftragter.de@generali.com` no longer appears on the source page (`https://generali.de/datenschutz`). That page currently lists `konzerndatenschutz.de@generali.com` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #73.