### PR TITLE
Update Popken Fashion GmbH: email address changed

### DIFF
--- a/companies/happy-size-shop.json
+++ b/companies/happy-size-shop.json
@@ -13,7 +13,7 @@
     ],
     "address": "Am Waldrand 19\n26180 Rastede\nDeutschland",
     "phone": "+49 4402 8622020",
-    "email": "service@happy-size.de",
+    "email": "datenschutz@happy-size.de",
     "web": "https://www.happy-size.de/",
     "sources": [
         "https://www.happy-size.de/de/datenschutz"


### PR DESCRIPTION
The registered address `service@happy-size.de` no longer appears on the source page (`https://www.happy-size.de/de/datenschutz`). That page currently lists `datenschutz@happy-size.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.