### PR TITLE
Update Headspace, Inc.: email address changed

### DIFF
--- a/companies/headspace.json
+++ b/companies/headspace.json
@@ -10,7 +10,7 @@
     "name": "Headspace, Inc.",
     "address": "425 California Street\n2nd Floor\nSan Francisco\nCA 94104\nUnited States of America",
     "phone": "+1 855 432 3822",
-    "email": "help@headspace.com",
+    "email": "privacy@headspace.com",
     "web": "https://www.headspace.com/",
     "sources": [
         "https://www.headspace.com/contact-us",


### PR DESCRIPTION
The registered address `help@headspace.com` no longer appears on the source page (`https://headspace.com/notice-of-privacy-practices-es`). That page currently lists `privacy@headspace.com` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #55.