### PR TITLE
Update htp GmbH: email address changed

### DIFF
--- a/companies/htp-net.json
+++ b/companies/htp-net.json
@@ -7,7 +7,7 @@
     "address": "Mailänder Straße 2\n30539 Hannover\nDeutschland",
     "phone": "+49 511 60001010",
     "fax": "+49 511 60001088",
-    "email": "info@htp.net",
+    "email": "datenschutz@htp.net",
     "web": "https://www.htp.net/",
     "sources": [
         "https://www.htp.net/datenschutz/",


### PR DESCRIPTION
The registered address `info@htp.net` no longer appears on the source page (`https://www.htp.net/datenschutz/`). That page currently lists `datenschutz@htp.net` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.