### PR TITLE
Update Ikano Bank AB: email address changed

### DIFF
--- a/companies/ikano-bank.json
+++ b/companies/ikano-bank.json
@@ -9,7 +9,7 @@
     "name": "Ikano Bank AB",
     "address": "Box 21066\n200 21 Malmö\nSweden",
     "phone": "+46 476 880 00",
-    "email": "dataskydd@ikano.se",
+    "email": "dpo@ikano.se",
     "web": "https://ikanobank.se",
     "sources": [
         "https://ikanobank.se/personuppgifter",


### PR DESCRIPTION
The registered address `dataskydd@ikano.se` no longer appears on the source page (`https://ikanobank.se/personuppgifter`). That page currently lists `dpo@ikano.se` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.