### PR TITLE
Update Riverty Services GmbH: email address changed

### DIFF
--- a/companies/infoscore-forderungsmanagement.json
+++ b/companies/infoscore-forderungsmanagement.json
@@ -15,7 +15,7 @@
     "address": "Gütersloher Straße 123\n33415 Verl\nDeutschland",
     "phone": "+49 5246 9051000",
     "fax": "+49 5246 9055000",
-    "email": "datenschutzbeauftragter@riverty.com",
+    "email": "datenschutz_monatsabrechnung@riverty.com",
     "web": "https://de.flow.riverty.com/de-de",
     "sources": [
         "https://de.flow.riverty.com/de-de/datenschutz",


### PR DESCRIPTION
The registered address `datenschutzbeauftragter@riverty.com` no longer appears on the source page (`https://www.riverty.com/en/privacy-policy/monthly-invoice/`). That page currently lists `datenschutz_monatsabrechnung@riverty.com` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #55.