### PR TITLE
Update Ministerium der Justiz des Landes Nordrhein-Westfalen: email address changed

### DIFF
--- a/companies/justiz-nrw-de.json
+++ b/companies/justiz-nrw-de.json
@@ -13,7 +13,7 @@
     ],
     "address": "Martin-Luther-Platz 40\n40212 Düsseldorf\nDeutschland",
     "phone": "+49 211 87920",
-    "email": "justiz-online@jm.nrw.de",
+    "email": "datenschutz@jm.nrw.de",
     "web": "https://www.justiz.nrw.de/JM",
     "sources": [
         "https://www.justiz.nrw.de/Service/datenschutz",


### PR DESCRIPTION
The registered address `justiz-online@jm.nrw.de` no longer appears on the source page (`https://www.justiz.nrw.de/Service/datenschutz`). That page currently lists `datenschutz@jm.nrw.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.