### PR TITLE
Update Kantar GmbH: email address changed

### DIFF
--- a/companies/kantar-de.json
+++ b/companies/kantar-de.json
@@ -6,7 +6,7 @@
     "name": "Kantar GmbH",
     "address": "Landsberger Straße 284\n80687 München\nDeutschland",
     "phone": "+49 89 56001176",
-    "email": "datenschutz@kantar.com",
+    "email": "gdpr@kantar.com",
     "web": "https://www.kantar.com/de",
     "sources": [
         "https://www.kantar.com/de/-/media/project/kantar/germany/datenschutz/datenschutzerklaerung-markt-sozialforschung.pdf",


### PR DESCRIPTION
The registered address `datenschutz@kantar.com` no longer appears on the source page (`https://www.kantar.com/privacy-statement-media-insights`). That page currently lists `gdpr@kantar.com` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #75.