### PR TITLE
Update Kirchengemeinde Martin Luther Bad Harzburg: email address changed

### DIFF
--- a/companies/kirchengemeinde-martin-luther-bad-harzburg.json
+++ b/companies/kirchengemeinde-martin-luther-bad-harzburg.json
@@ -10,7 +10,7 @@
     "address": "Lutherstraße 7\n38667 Bad Harzburg\nDeutschland",
     "phone": "+49 5322 4823",
     "fax": "+49 5322 54692",
-    "email": "harzburg.pfa@lk-bs.de",
+    "email": "datenschutz@lk-bs.de",
     "web": "http://www.luthergemeinde-evangelisch.de/",
     "sources": [
         "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=704"


### PR DESCRIPTION
The registered address `harzburg.pfa@lk-bs.de` no longer appears on the source page (`https://luthergemeinde-evangelisch.de/service/datenschutz`). That page currently lists `datenschutz@lk-bs.de` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #57.