### PR TITLE
Update Kirchengemeinde St. Petrus/Heiliggeist Vorsfelde in Wolfsburg: email address changed

### DIFF
--- a/companies/kirchengemeinde-st-petrus-heiliggeist-vorsfelde-in-wolfsburg.json
+++ b/companies/kirchengemeinde-st-petrus-heiliggeist-vorsfelde-in-wolfsburg.json
@@ -10,7 +10,7 @@
     "address": "Amtsstraße 31\n38448 Wolfsburg\nDeutschland",
     "phone": "+49 5363 7773",
     "fax": "+49 5363 73497",
-    "email": "petrus-vorsfelde.buero@lk-bs.de",
+    "email": "datenschutz@lk-bs.de",
     "web": "http://www.kirche-vorsfelde.de/",
     "sources": [
         "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1051"


### PR DESCRIPTION
The registered address `petrus-vorsfelde.buero@lk-bs.de` no longer appears on the source page (`https://kirche-vorsfelde.de/service/datenschutz`). That page currently lists `datenschutz@lk-bs.de` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #58.