### PR TITLE
Update KKH Kaufmännische Krankenkasse: email address changed

### DIFF
--- a/companies/kkh-krankenkasse.json
+++ b/companies/kkh-krankenkasse.json
@@ -16,7 +16,7 @@
     ],
     "address": "Karl-Wiechert-Allee 61\n30625 Hannover\nDeutschland",
     "phone": "+49 800 5548640554",
-    "email": "datenschutzservice@kkh.de",
+    "email": "datenschutz@kkh.de",
     "web": "https://www.kkh.de",
     "sources": [
         "https://www.kkh.de/datenschutz",


### PR DESCRIPTION
The registered address `datenschutzservice@kkh.de` no longer appears on the source page (`https://www.kkh.de/datenschutz`). That page currently lists `datenschutz@kkh.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.