### PR TITLE
Update KLM Royal Dutch Airlines: email address changed

### DIFF
--- a/companies/klm.json
+++ b/companies/klm.json
@@ -12,7 +12,7 @@
         "Flying Blue Miles"
     ],
     "address": "Privacy Office - AMSPI\nPO Box 7700\nNL-1117 ZL Luchthaven Schiphol\nThe Netherlands",
-    "email": "KLMPrivacyOffice@klm.com",
+    "email": "dataprotectionofficer@klm.com",
     "web": "https://klm.nl",
     "sources": [
         "https://www.klm.nl/en/information/legal/privacy-policy",


### PR DESCRIPTION
The registered address `KLMPrivacyOffice@klm.com` no longer appears on the source page (`https://www.klm.nl/en/information/legal/privacy-policy`). That page currently lists `dataprotectionofficer@klm.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.