### PR TITLE
Update Luftfahrt-Bundesamt (LBA): email address changed

### DIFF
--- a/companies/lba-bund.json
+++ b/companies/lba-bund.json
@@ -10,7 +10,7 @@
     "address": "38144 Braunschweig\nDeutschland",
     "phone": "+49 531 23550",
     "fax": "+49 531 23559099",
-    "email": "Datenschutzbeauftragter@lba.de",
+    "email": "datenschutz@lba.de",
     "web": "https://www.lba.de",
     "sources": [
         "https://www.lba.de/DE/TopServiceStartseite/Datenschutz/Datenschutz_node.html",


### PR DESCRIPTION
The registered address `Datenschutzbeauftragter@lba.de` no longer appears on the source page (`https://www.lba.de/DE/TopServiceStartseite/Datenschutz/Datenschutz_node.html`). That page currently lists `datenschutz@lba.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.