### PR TITLE
Update lekker Energie GmbH: email address changed

### DIFF
--- a/companies/lekker.json
+++ b/companies/lekker.json
@@ -10,7 +10,7 @@
     "address": "Boos-Fremery-Str. 62\n52525 Heinsberg\nDeutschland",
     "phone": "+49 30 430949499",
     "fax": "+49 30 430949498",
-    "email": "kundenservice@lekker.de",
+    "email": "datenschutz@lekker.de",
     "web": "https://lekker.de",
     "sources": [
         "https://www.lekker.de/datenschutz",


### PR DESCRIPTION
The registered address `kundenservice@lekker.de` no longer appears on the source page (`https://www.lekker.de/datenschutz`). That page currently lists `datenschutz@lekker.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.