### PR TITLE
Update Lufthansa AirPlus Servicekarten GmbH: email address changed

### DIFF
--- a/companies/lufthansa-airplus-servicekarten-gmbh.json
+++ b/companies/lufthansa-airplus-servicekarten-gmbh.json
@@ -8,7 +8,7 @@
     ],
     "name": "Lufthansa AirPlus Servicekarten GmbH",
     "address": "Dornhofstraße 10\n63263 Neu-Isenburg\nDeutschland",
-    "email": "datenschutz@airplus.com",
+    "email": "dataprotection@airplus.com",
     "sources": [
         "https://www.airplus.com/de/de/rechtliches/datenschutz/",
         "https://github.com/datenanfragen/data/pull/2488"


### PR DESCRIPTION
The registered address `datenschutz@airplus.com` no longer appears on the source page (`https://www.airplus.com/de/de/rechtliches/datenschutz/`). That page currently lists `dataprotection@airplus.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.