### PR TITLE
Update marcapo GmbH: email address changed

### DIFF
--- a/companies/marcapo.json
+++ b/companies/marcapo.json
@@ -9,7 +9,7 @@
     "name": "marcapo GmbH",
     "address": "Bahnhofstraße 4\n96106 Ebern\nDeutschland",
     "phone": "+49 9531 92200",
-    "email": "kontakt@marcapo.com",
+    "email": "datenschutz@marcapo.com",
     "web": "https://www.marcapo.com/",
     "sources": [
         "https://www.marcapo.com/datenschutz.html",


### PR DESCRIPTION
The registered address `kontakt@marcapo.com` no longer appears on the source page (`https://www.marcapo.com/datenschutz.html`). That page currently lists `datenschutz@marcapo.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.