### PR TITLE
Update Marketscan Ltd.: email address changed

### DIFF
--- a/companies/marketscan-gb.json
+++ b/companies/marketscan-gb.json
@@ -9,7 +9,7 @@
     "name": "Marketscan Ltd.",
     "address": "8 Duke’s Court\nBognor Road\nChichester\nPO19 8FX\nUnited Kingdom",
     "phone": "+44 1243 786711",
-    "email": "info@marketscan.co.uk",
+    "email": "dataprotection@marketscan.co.uk",
     "web": "https://www.marketscan.co.uk/terms-privacy/",
     "sources": [
         "https://www.marketscan.co.uk/terms-privacy/",


### PR DESCRIPTION
The registered address `info@marketscan.co.uk` no longer appears on the source page (`https://www.marketscan.co.uk/terms-privacy/`). That page currently lists `dataprotection@marketscan.co.uk` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.