### PR TITLE
Update Luitpold Apotheke e.K.: email address changed

### DIFF
--- a/companies/medikamente-per-klick-de.json
+++ b/companies/medikamente-per-klick-de.json
@@ -7,7 +7,7 @@
     "address": "Poststraße 2\n95138 Bad Steben\nDeutschland",
     "phone": "+49 9280 984444",
     "fax": "+49 9280 9844479",
-    "email": "ilius@medikamente-per-klick.de",
+    "email": "datenschutzbeauftragter@medikamente-per-klick.de",
     "web": "https://www.medikamente-per-klick.de/",
     "sources": [
         "https://www.medikamente-per-klick.de/Datenschutz",


### PR DESCRIPTION
The registered address `ilius@medikamente-per-klick.de` no longer appears on the source page (`https://www.medikamente-per-klick.de/Datenschutz`). That page currently lists `datenschutzbeauftragter@medikamente-per-klick.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.