### PR TITLE
Update Ministry of Justice: email address changed

### DIFF
--- a/companies/ministry-of-justice-gb.json
+++ b/companies/ministry-of-justice-gb.json
@@ -8,7 +8,7 @@
     ],
     "name": "Ministry of Justice",
     "address": "Post point 5.22\n102 Petty France\nLondon\nSW1H 9AJ\nUnited Kingdom",
-    "email": "data.access@justice.gov.uk",
+    "email": "dataprotection@justice.gov.uk",
     "webform": "https://request-personal-info.form.service.justice.gov.uk",
     "web": "https://www.gov.uk/government/organisations/ministry-of-justice",
     "sources": [


### PR DESCRIPTION
The registered address `data.access@justice.gov.uk` no longer appears on the source page (`https://www.gov.uk/government/organisations/ministry-of-justice/about/personal-information-charter`). That page currently lists `dataprotection@justice.gov.uk` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.