### PR TITLE
Update SB-Möbel BOSS Onlineshop GmbH & Co. KG: email address changed

### DIFF
--- a/companies/moebel-boss-online.json
+++ b/companies/moebel-boss-online.json
@@ -10,7 +10,7 @@
     "address": "Bakenweg 16 – 20\n32457 Porta Westfalica\nDeutschland",
     "phone": "+49 5731 609861",
     "fax": "+49 34602 25589",
-    "email": "widerruf@moebel-boss.de",
+    "email": "datenschutz@moebel-boss.de",
     "web": "https://moebel-boss.de/",
     "sources": [
         "https://moebel-boss.de/privacy",


### PR DESCRIPTION
The registered address `widerruf@moebel-boss.de` no longer appears on the source page (`https://moebel-boss.de/privacy`). That page currently lists `datenschutz@moebel-boss.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.