### PR TITLE
Update Monzo Bank Limited: email address changed

### DIFF
--- a/companies/monzo-gb.json
+++ b/companies/monzo-gb.json
@@ -9,7 +9,7 @@
     "name": "Monzo Bank Limited",
     "address": "Broadwalk House\n5 Appold Street\nLondon\nEC2A 2DA\nUnited Kingdom",
     "phone": "+44 800 802 1281",
-    "email": "help@monzo.com",
+    "email": "dpo@monzo.com",
     "web": "https://monzo.com",
     "sources": [
         "https://monzo.com/legal/privacy-notice",


### PR DESCRIPTION
The registered address `help@monzo.com` no longer appears on the source page (`https://monzo.com/legal/privacy-notice`). That page currently lists `dpo@monzo.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.