### PR TITLE
Update Mühlenkreiskliniken AöR: email address changed

### DIFF
--- a/companies/muehlenkreiskliniken.json
+++ b/companies/muehlenkreiskliniken.json
@@ -10,7 +10,7 @@
     "address": "Hans-Nolte-Straße 1\n32429 Minden\nDeutschland",
     "phone": "+49 571 7900",
     "fax": "+49 571 790292929",
-    "email": "info@muehlenkreiskliniken.de",
+    "email": "datenschutzbeauftragter@muehlenkreiskliniken.de",
     "web": "https://www.muehlenkreiskliniken.de/",
     "sources": [
         "https://www.muehlenkreiskliniken.de/mkk/impressum.html",


### PR DESCRIPTION
The registered address `info@muehlenkreiskliniken.de` no longer appears on the source page (`https://www.muehlenkreiskliniken.de/mkk/impressum.html`). That page currently lists `datenschutzbeauftragter@muehlenkreiskliniken.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.