### PR TITLE
Update mytheresa.com GmbH: email address changed

### DIFF
--- a/companies/mytheresa-com.json
+++ b/companies/mytheresa-com.json
@@ -7,7 +7,7 @@
     "address": "Einsteinring 9\n85609 Aschheim/München\nDeutschland",
     "phone": "+49 89 1276950",
     "fax": "+49 89 127695200",
-    "email": "info@mytheresa.com",
+    "email": "privacy@mytheresa.com",
     "web": "https://www.mytheresa.com/",
     "sources": [
         "https://www.mytheresa.com/de-de/service/privacy-policy/",


### PR DESCRIPTION
The registered address `info@mytheresa.com` no longer appears on the source page (`https://www.mytheresa.com/de-de/service/privacy-policy/`). That page currently lists `privacy@mytheresa.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.