### PR TITLE
Update N26 Bank GmbH: email address changed

### DIFF
--- a/companies/n26-bank.json
+++ b/companies/n26-bank.json
@@ -12,7 +12,7 @@
     ],
     "address": "Rungestr. 22 (3. Hinterhof)\n10179 Berlin\nGermany",
     "fax": "+49 30 364285082",
-    "email": "datenschutz@n26.com",
+    "email": "dpo@n26.com",
     "web": "https://n26.com",
     "sources": [
         "https://docs.n26.com/legal/01+DE/03+Privacy+Policy/en/01privacy-policy-en.pdf",


### PR DESCRIPTION
The registered address `datenschutz@n26.com` no longer appears on the source page (`https://docs.n26.com/legal/01+DE/03+Privacy+Policy/en/01privacy-policy-en.pdf`). That page currently lists `dpo@n26.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.