### PR TITLE
Update Napster Luxembourg S.a.r.l.: email address changed

### DIFF
--- a/companies/napster.json
+++ b/companies/napster.json
@@ -8,7 +8,7 @@
     ],
     "name": "Napster Luxembourg S.a.r.l.",
     "address": "60, Route de Luxembourg\nL-5408 Bous\nLuxembourg",
-    "email": "privacy@napster.com",
+    "email": "dataprivacy@napster.com",
     "web": "https://www.napster.com",
     "sources": [
         "https://www.napster.com/de/privacy/",


### PR DESCRIPTION
The registered address `privacy@napster.com` no longer appears on the source page (`https://www.napster.com/privacy-policy`). That page currently lists `dataprivacy@napster.com` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #75.