### PR TITLE
Update navabi GmbH: email address changed

### DIFF
--- a/companies/navabi.json
+++ b/companies/navabi.json
@@ -10,7 +10,7 @@
     "address": "Jülicher Straße 344\n52070 Aachen\nDeutschland",
     "phone": "+49 89 18917360",
     "fax": "+49 241 900533720",
-    "email": "privacy@navabi.de",
+    "email": "info@navabi.de",
     "web": "https://www.navabi.de",
     "sources": [
         "https://www.navabi.de/datenschutz/",


### PR DESCRIPTION
The registered address `privacy@navabi.de` no longer appears on the source page (`https://navabi.de/datenschutz`). That page currently lists `info@navabi.de` as the privacy contact (screenshot scan).

Found and verified by the Privacy Engine optimizer, run #76.