### PR TITLE
Update Nextdoor EMEA Limited: email address changed

### DIFF
--- a/companies/nextdoor.json
+++ b/companies/nextdoor.json
@@ -14,7 +14,7 @@
     ],
     "name": "Nextdoor EMEA Limited",
     "address": "Digital Depot\nThomas Street West\nDublin 8\nIreland",
-    "email": "privacy@nextdoor.com",
+    "email": "dpo@nextdoor.com",
     "web": "https://nextdoor.com/",
     "sources": [
         "https://legal.nextdoor.com/us-privacy-policy-2021/",


### PR DESCRIPTION
The registered address `privacy@nextdoor.com` no longer appears on the source page (`https://nextdoor.com/privacy_policy`). That page currently lists `dpo@nextdoor.com` as the privacy contact (screenshot scan).

Found and verified by the Privacy Engine optimizer, run #76.