### PR TITLE
Update NortonLifeLock Ireland Limited: email address changed

### DIFF
--- a/companies/nortonlifelock.json
+++ b/companies/nortonlifelock.json
@@ -9,7 +9,7 @@
         "LifeLock"
     ],
     "address": "Ballycoolin Business Park\nBlanchardstown\nDublin 15\nIreland",
-    "email": "nll_privacy@GenDigital.com",
+    "email": "dpo@gendigital.com",
     "webform": "https://privacyportal.onetrust.com/webform/25b84167-55d3-4099-84e2-c9e08ec67d54/4d9f34ca-cc1d-4578-9590-35834c92f17b",
     "web": "https://www.nortonlifelock.com/",
     "sources": [


### PR DESCRIPTION
The registered address `nll_privacy@GenDigital.com` no longer appears on the source page (`https://www.nortonlifelock.com/gb/en/privacy/global-privacy-statement/`). That page currently lists `dpo@gendigital.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.