### PR TITLE
Update ON THAT ASS INTERNATIONAL B.V.: email address changed

### DIFF
--- a/companies/onthatass-de.json
+++ b/companies/onthatass-de.json
@@ -6,7 +6,7 @@
     "name": "ON THAT ASS INTERNATIONAL B.V.",
     "address": "Graafsebaan 135 A\n5248 NL Rosmalen\nThe Netherlands",
     "phone": "+31 73 303 5855",
-    "email": "hello-de@onthatass.com",
+    "email": "dpo@onthatass.com",
     "web": "https://onthatass.com/de-de/",
     "sources": [
         "https://onthatass.com/de-de/imprint",


### PR DESCRIPTION
The registered address `hello-de@onthatass.com` no longer appears on the source page (`https://onthatass.com/at-de/privacy-statement`). That page currently lists `dpo@onthatass.com` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #57.