### PR TITLE
Update OpenX Software Ltd.: email address changed

### DIFF
--- a/companies/openx.json
+++ b/companies/openx.json
@@ -13,7 +13,7 @@
     ],
     "address": "Aleja 29 Listopada 20\n31-401 Krakow\nPoland",
     "phone": "+1 626 466 1141",
-    "email": "privacy@openx.com",
+    "email": "dpo@openx.com",
     "web": "https://www.openx.com/",
     "sources": [
         "https://www.openx.com/legal/privacy-policy/",


### PR DESCRIPTION
The registered address `privacy@openx.com` no longer appears on the source page (`https://www.openx.com/legal/privacy-policy/`). That page currently lists `dpo@openx.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.