### PR TITLE
Update Palantir Technologies Inc.: email address changed

### DIFF
--- a/companies/palantir.json
+++ b/companies/palantir.json
@@ -5,7 +5,7 @@
     ],
     "name": "Palantir Technologies Inc.",
     "address": "100 Hamilton Ave\nSuite 300\nPalo Alto\nCA 94301\nUnited States of America",
-    "email": "data-subject-request@palantir.com",
+    "email": "privacy@palantir.com",
     "sources": [
         "https://www.palantir.com/privacy-and-security/",
         "https://github.com/datenanfragen/data/pull/836"


### PR DESCRIPTION
The registered address `data-subject-request@palantir.com` no longer appears on the source page (`https://www.palantir.com/privacy-and-security/`). That page currently lists `privacy@palantir.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.