### PR TITLE
Update PlagAware GmbH: email address changed

### DIFF
--- a/companies/plagaware-gmbh.json
+++ b/companies/plagaware-gmbh.json
@@ -9,7 +9,7 @@
     "name": "PlagAware GmbH",
     "address": "Brumersweg 35/1\n89233 Neu-Ulm\nDeutschland",
     "phone": "+49 731 80159900",
-    "email": "info@plagaware.com",
+    "email": "datenschutz@plagaware.com",
     "web": "https://www.plagaware.com/",
     "sources": [
         "https://www.plagaware.com/de/service/datenschutz",


### PR DESCRIPTION
The registered address `info@plagaware.com` no longer appears on the source page (`https://www.plagaware.com/de/service/datenschutz`). That page currently lists `datenschutz@plagaware.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.