### PR TITLE
Update Quelle GmbH: email address changed

### DIFF
--- a/companies/quelle-shop.json
+++ b/companies/quelle-shop.json
@@ -7,7 +7,7 @@
     "address": "Bahnhofstraße 10\n96224 Burgkunstadt\nDeutschland",
     "phone": "+49 180 6 111100",
     "fax": "+49 180 5 311552",
-    "email": "online-team@quelle.de",
+    "email": "datenschutz@quelle.de",
     "web": "https://www.quelle.de/",
     "sources": [
         "https://www.quelle.de/service-hilfe/ueber-uns/datenschutz/",


### PR DESCRIPTION
The registered address `online-team@quelle.de` no longer appears on the source page (`https://www.quelle.de/service-hilfe/ueber-uns/datenschutz/`). That page currently lists `datenschutz@quelle.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.