### PR TITLE
Update RABOT Energy DE GmbH: email address changed

### DIFF
--- a/companies/rabot-energy.json
+++ b/companies/rabot-energy.json
@@ -9,7 +9,7 @@
     "name": "RABOT Energy DE GmbH",
     "address": "Hopfenmarkt 33\n20457 Hamburg\nDeutschland",
     "phone": "+49 40 593622030",
-    "email": "support@rabot.energy",
+    "email": "datenschutz@rabot.energy",
     "web": "https://www.rabot.energy",
     "sources": [
         "https://www.rabot-charge.de/datenschutzerklaerung/",


### PR DESCRIPTION
The registered address `support@rabot.energy` no longer appears on the source page (`https://www.rabot-charge.de/datenschutzerklaerung/`). That page currently lists `datenschutz@rabot.energy` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.