### PR TITLE
Update Resonate Networks, Inc.: email address changed

### DIFF
--- a/companies/resonate-com.json
+++ b/companies/resonate-com.json
@@ -8,7 +8,7 @@
     ],
     "name": "Resonate Networks, Inc.",
     "address": "11720 Plaza America Drive\n3rd Floor\nReston\nVA 20190\nUnited States of America",
-    "email": "info@resonate.com",
+    "email": "privacy@resonate.com",
     "web": "https://www.resonate.com/",
     "sources": [
         "https://www.resonate.com/privacy-policy/"


### PR DESCRIPTION
The registered address `info@resonate.com` no longer appears on the source page (`https://www.resonate.com/privacy-policy/`). That page currently lists `privacy@resonate.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.