### PR TITLE
Update Reveal Mobile, Inc.: email address changed

### DIFF
--- a/companies/revealmobile.json
+++ b/companies/revealmobile.json
@@ -8,7 +8,7 @@
     ],
     "name": "Reveal Mobile, Inc.",
     "address": "c/o ePrivacy GmbH\nGroße Bleichen 21\n20354 Hamburg\nGermany",
-    "email": "optout@revealmobile.com",
+    "email": "privacy@revealmobile.com",
     "web": "https://revealmobile.com/",
     "sources": [
         "https://revealmobile.com/privacy/"


### PR DESCRIPTION
The registered address `optout@revealmobile.com` no longer appears on the source page (`https://revealmobile.com/privacy/`). That page currently lists `privacy@revealmobile.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.