### PR TITLE
Update Risk.Ident GmbH: email address changed

### DIFF
--- a/companies/riskident.json
+++ b/companies/riskident.json
@@ -6,7 +6,7 @@
     "name": "Risk.Ident GmbH",
     "address": "Am Sandtorkai 50\n20457 Hamburg\nDeutschland",
     "phone": "+49 40 609452590",
-    "email": "contact@riskident.com",
+    "email": "datenschutz@riskident.com",
     "web": "https://riskident.com",
     "sources": [
         "https://riskident.com/en/legal-disclosure/"


### PR DESCRIPTION
The registered address `contact@riskident.com` no longer appears on the source page (`https://riskident.com/en/legal-disclosure/`). That page currently lists `datenschutz@riskident.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.