### PR TITLE
Update RWE Aktiengesellschaft: email address changed

### DIFF
--- a/companies/rwe.json
+++ b/companies/rwe.json
@@ -19,7 +19,7 @@
     "address": "Altenessener Straße 35\n45141 Essen\nDeutschland",
     "phone": "+49 201 51790",
     "fax": "+49 201 51795005",
-    "email": "datenschutz@rwe.com",
+    "email": "dataprotection@rwe.com",
     "web": "https://www.group.rwe",
     "sources": [
         "https://www.group.rwe/datenschutz",


### PR DESCRIPTION
The registered address `datenschutz@rwe.com` no longer appears on the source page (`https://www.group.rwe/datenschutz`). That page currently lists `dataprotection@rwe.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.