### PR TITLE
Update Samsung Electronics (UK) Limited: email address changed

### DIFF
--- a/companies/samsung.json
+++ b/companies/samsung.json
@@ -8,7 +8,7 @@
         "Samsung Electronics Co., Ltd."
     ],
     "address": "Samsung House\n2000 Hillswood Drive\nChertsey, Surrey\nKT16 0RS\nUnited Kingdom",
-    "email": "dataprotection@samsung.com",
+    "email": "dataprotection.seuk@samsung.com",
     "webform": "https://www.samsung.com/request-desk/",
     "web": "https://www.samsung.com/",
     "sources": [


### PR DESCRIPTION
The registered address `dataprotection@samsung.com` no longer appears on the source page (`https://www.samsung.com/uk/info/privacy/`). That page currently lists `dataprotection.seuk@samsung.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.