### PR TITLE
Update Schweinske Franchise GmbH: email address changed

### DIFF
--- a/companies/schweinske-de.json
+++ b/companies/schweinske-de.json
@@ -7,7 +7,7 @@
     "address": "Alsterufer 37\n20354 Hamburg\nDeutschland",
     "phone": "+49 40 87877890",
     "fax": "+49 40 878778999",
-    "email": "info@schweinske.de",
+    "email": "datenschutz@schweinske.de",
     "web": "https://schweinske.de",
     "sources": [
         "https://schweinske.de/impressum",


### PR DESCRIPTION
The registered address `info@schweinske.de` no longer appears on the source page (`https://schweinske.de/datenschutz`). That page currently lists `datenschutz@schweinske.de` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #57.