### PR TITLE
Update Sectigo Limited: email address changed

### DIFF
--- a/companies/sectigo.json
+++ b/companies/sectigo.json
@@ -5,7 +5,7 @@
     ],
     "name": "Sectigo Limited",
     "address": "Unit 7 & 9\nListerhills, Science Park, Campus Road\nBradford\nBD7 1HR\nUnited Kingdom",
-    "email": "DPOfficer@sectigo.com",
+    "email": "privacy@sectigo.com",
     "webform": "https://www.sectigo.com/privacy-portal",
     "web": "https://www.sectigo.com/",
     "sources": [


### PR DESCRIPTION
The registered address `DPOfficer@sectigo.com` no longer appears on the source page (`https://www.sectigo.com/privacy-policy`). That page currently lists `privacy@sectigo.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.