### PR TITLE
Update Sedo GmbH: email address changed

### DIFF
--- a/companies/sedo-de.json
+++ b/companies/sedo-de.json
@@ -10,7 +10,7 @@
     "address": "Im Mediapark 6 B\n50670 Köln\nDeutschland",
     "phone": "+49 221 34030571",
     "fax": "+49 221 34030102",
-    "email": "datenschutz@sedo.de",
+    "email": "dataprotection@sedo.de",
     "web": "https://sedo.de",
     "sources": [
         "https://sedo.com/de/ueber-uns/policies-gmbh/datenschutzrichtlinien-der-sedo-gmbh/",


### PR DESCRIPTION
The registered address `datenschutz@sedo.de` no longer appears on the source page (`https://sedo.com/de/ueber-uns/policies-gmbh/datenschutzrichtlinien-der-sedo-gmbh/`). That page currently lists `dataprotection@sedo.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.