### PR TITLE
Update Shapr3D Zrt.: email address changed

### DIFF
--- a/companies/shapr3d.json
+++ b/companies/shapr3d.json
@@ -8,7 +8,7 @@
         "Shapr3D"
     ],
     "address": "H-1051 Budapest\nBajcsy-Zsilinszky út 12.\nHungary",
-    "email": "userdata@shapr3d.com",
+    "email": "privacy@shapr3d.com",
     "web": "https://www.shapr3d.com/",
     "sources": [
         "https://www.shapr3d.com/privacy-policy",


### PR DESCRIPTION
The registered address `userdata@shapr3d.com` no longer appears on the source page (`https://www.shapr3d.com/privacy-policy`). That page currently lists `privacy@shapr3d.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.