### PR TITLE
Update BOP LLC: email address changed

### DIFF
--- a/companies/shopbop.json
+++ b/companies/shopbop.json
@@ -13,7 +13,7 @@
     ],
     "address": "1245 E Washington Ave\nSuite 300\nMadison\nWI 53703\nUnited States of America",
     "phone": "+1 608 270 3930",
-    "email": "service@shopbop.com",
+    "email": "privacy@shopbop.com",
     "web": "https://www.shopbop.com/",
     "sources": [
         "https://www.shopbop.com/ci/aboutShopBop/privacypolicy.html",


### PR DESCRIPTION
The registered address `service@shopbop.com` no longer appears on the source page (`https://www.shopbop.com/ci/aboutShopBop/privacypolicy.html`). That page currently lists `privacy@shopbop.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.