### PR TITLE
Update dunnhumby Limited: email address changed

### DIFF
--- a/companies/sociomantic.json
+++ b/companies/sociomantic.json
@@ -9,7 +9,7 @@
     "name": "dunnhumby Limited",
     "address": "Gresham House\nMarine Road\nDun Laoghaire Co\nDublin\nIreland",
     "phone": "+44 20 3986 5499",
-    "email": "individualrights@dunnhumby.com",
+    "email": "dataprotection@dunnhumby.com",
     "web": "https://www.dunnhumby.com",
     "sources": [
         "https://www.dunnhumby.com/privacy-notice/",


### PR DESCRIPTION
The registered address `individualrights@dunnhumby.com` no longer appears on the source page (`https://www.dunnhumby.com/privacy-notice/`). That page currently lists `dataprotection@dunnhumby.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.