### PR TITLE
Update SV SparkassenVersicherung: email address changed

### DIFF
--- a/companies/sparkassenversicherung.json
+++ b/companies/sparkassenversicherung.json
@@ -15,7 +15,7 @@
     "address": "Löwentorstraße 65\n70376 Stuttgart\nDeutschland",
     "phone": "+49 711 898100",
     "fax": "+49 711 898109",
-    "email": "service@sv.de",
+    "email": "datenschutz@sv.de",
     "web": "https://www.sparkassenversicherung.de",
     "sources": [
         "https://www.sparkassenversicherung.de/datenschutz.html"


### PR DESCRIPTION
The registered address `service@sv.de` no longer appears on the source page (`https://www.sparkassenversicherung.de/datenschutz.html`). That page currently lists `datenschutz@sv.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.