### PR TITLE
Update Ströer SE & Co. KGaA: email address changed

### DIFF
--- a/companies/stroeer.json
+++ b/companies/stroeer.json
@@ -9,7 +9,7 @@
         "Herzrasen Fußball Live Ticker"
     ],
     "address": "Ströer Allee 1\n50999 Köln\nDeutschland",
-    "email": "datenschutzbeauftragter@stroeer.de",
+    "email": "datenschutz@stroeer.de",
     "web": "https://www.stroeer.de",
     "sources": [
         "https://www.stroeer.de/service/datenschutz.html"


### PR DESCRIPTION
The registered address `datenschutzbeauftragter@stroeer.de` no longer appears on the source page (`https://www.stroeer.de/service/datenschutz.html`). That page currently lists `datenschutz@stroeer.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.