### PR TITLE
Update SVIT Schweiz: email address changed

### DIFF
--- a/companies/svit.json
+++ b/companies/svit.json
@@ -7,7 +7,7 @@
     "address": "Giessereistrasse 18\n8005 Zürich\nSchweiz",
     "phone": "+41 44 434 78 88",
     "fax": "+41 44 434 78 99",
-    "email": "info@svit.ch",
+    "email": "dataprotection@svit.ch",
     "web": "https://www.svit.ch",
     "sources": [
         "https://www.svit.ch/de/datenschutz",


### PR DESCRIPTION
The registered address `info@svit.ch` no longer appears on the source page (`https://www.svit.ch/de/datenschutz`). That page currently lists `dataprotection@svit.ch` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.