### PR TITLE
Update Thomann GmbH: email address changed

### DIFF
--- a/companies/thomann-musikhaus.json
+++ b/companies/thomann-musikhaus.json
@@ -7,7 +7,7 @@
     "address": "Hans-Thomann-Straße 1\n96138 Burgebrach\nDeutschland",
     "phone": "+49 9546 922366",
     "fax": "+49 9546 922324",
-    "email": "info@thomann.de",
+    "email": "privacy@thomann.de",
     "web": "https://www.thomann.de",
     "sources": [
         "https://www.thomann.de/de/compinfo_privacy.html",


### PR DESCRIPTION
The registered address `info@thomann.de` no longer appears on the source page (`https://www.thomann.de/de/compinfo_privacy.html`). That page currently lists `privacy@thomann.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.