### PR TITLE
Update Tide Platform Ltd: email address changed

### DIFF
--- a/companies/tide-co.json
+++ b/companies/tide-co.json
@@ -8,7 +8,7 @@
     ],
     "name": "Tide Platform Ltd",
     "address": "5th Floor\n1 Appold Street\nLondon\nEC2A 2UT\nUnited Kingdom",
-    "email": "hello@tide.co",
+    "email": "dpo@tide.co",
     "web": "https://www.tide.co/",
     "sources": [
         "https://www.tide.co/privacy/"


### PR DESCRIPTION
The registered address `hello@tide.co` no longer appears on the source page (`https://www.tide.co/privacy/`). That page currently lists `dpo@tide.co` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.