### PR TITLE
Update Torquato AG: email address changed

### DIFF
--- a/companies/torquato.json
+++ b/companies/torquato.json
@@ -12,7 +12,7 @@
     "address": "c/o DS EXTERN GmbH\nFrapanweg 22\n22589 Hamburg\nDeutschland",
     "phone": "+49 4152 801400",
     "fax": "+49 4152 801555",
-    "email": "info@torquato.de",
+    "email": "datenschutz@torquato.de",
     "webform": "https://www.dsextern.de/anfragen",
     "web": "https://www.torquato.de",
     "sources": [


### PR DESCRIPTION
The registered address `info@torquato.de` no longer appears on the source page (`https://www.torquato.de/datenschutz/`). That page currently lists `datenschutz@torquato.de` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #57.