### PR TITLE
Update Tractebel Engineering S.A.: email address changed

### DIFF
--- a/companies/tractebel-be.json
+++ b/companies/tractebel-be.json
@@ -8,7 +8,7 @@
     ],
     "name": "Tractebel Engineering S.A.",
     "address": "Boulevard Simon Bolivar 34-36\n1000 Brussels\nBelgium",
-    "email": "privacy@tractebel.engie.com",
+    "email": "de@tractebel.engie.com",
     "web": "https://tractebel-engie.com",
     "sources": [
         "https://tractebel-engie.com/files/attachments/.6121/TRACTEBEL_PRIVACY_STATEMENT_EN_2023.pdf",


### PR DESCRIPTION
The registered address `privacy@tractebel.engie.com` no longer appears on the source page (`https://assets.tractebel-engie.com/uploads/2025/11/Datenschutzinformation-fur-Kunden-und-Partner.pdf`). That page currently lists `de@tractebel.engie.com` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #75.