### PR TITLE
Update Travix Nederland B.V.: email address changed

### DIFF
--- a/companies/travix.json
+++ b/companies/travix.json
@@ -15,7 +15,7 @@
         "Vayama"
     ],
     "address": "Hoekenrode 3\n1102 BR Amsterdam\nThe Netherlands",
-    "email": "privacy@travix.com",
+    "email": "dpo@travix.com",
     "web": "https://www.travix.com/",
     "sources": [
         "https://s1.travix.com/cheaptickets/DE/assets/pdf/ctde-privacy-de-updated-2024.pdf",


### PR DESCRIPTION
The registered address `privacy@travix.com` no longer appears on the source page (`https://s1.travix.com/cheaptickets/DE/assets/pdf/ctde-privacy-de-updated-2024.pdf`). That page currently lists `dpo@travix.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.