### PR TITLE
Update TYPEFORM, S.L.: email address changed

### DIFF
--- a/companies/typeform.json
+++ b/companies/typeform.json
@@ -5,7 +5,7 @@
     ],
     "name": "TYPEFORM, S.L.",
     "address": "C/Bac de Roda, 163\n08018 Barcelona\nSpain",
-    "email": "dpo@typeform.com",
+    "email": "gdpr@typeform.com",
     "web": "https://www.typeform.com/",
     "sources": [
         "https://admin.typeform.com/to/dwk6gt",


### PR DESCRIPTION
The registered address `dpo@typeform.com` no longer appears on the source page (`https://admin.typeform.com/to/dwk6gt`). That page currently lists `gdpr@typeform.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.