### PR TITLE
Update Umweltbundesamt: email address changed

### DIFF
--- a/companies/umweltbundesamt.json
+++ b/companies/umweltbundesamt.json
@@ -10,7 +10,7 @@
     "address": "Wörlitzer Platz 1\n06844 Dessau-Roßlau\nDeutschland",
     "phone": "+49 30 89035141",
     "fax": "+49 340 21032285",
-    "email": "buergerservice@uba.de",
+    "email": "datenschutzbeauftragter@uba.de",
     "web": "https://www.umweltbundesamt.de",
     "sources": [
         "https://www.umweltbundesamt.de/datenschutz-haftung",


### PR DESCRIPTION
The registered address `buergerservice@uba.de` no longer appears on the source page (`https://www.umweltbundesamt.de/datenschutz-haftung`). That page currently lists `datenschutzbeauftragter@uba.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.