### PR TITLE
Update Unfallkasse Brandenburg: email address changed

### DIFF
--- a/companies/unfallkasse-brandenburg.json
+++ b/companies/unfallkasse-brandenburg.json
@@ -10,7 +10,7 @@
     "address": "Müllroser Chaussee 75\n15236 Frankfurt (Oder)\nDeutschland",
     "phone": "+49 335 52160",
     "fax": "+49 335 5216222",
-    "email": "info@ukbb.de",
+    "email": "datenschutz@ukbb.de",
     "web": "https://www.ukbb.de/",
     "sources": [
         "https://www.ukbb.de/ueber-uns/datenschutz-und-informationspflichten",


### PR DESCRIPTION
The registered address `info@ukbb.de` no longer appears on the source page (`https://www.ukbb.de/ueber-uns/datenschutz-und-informationspflichten`). That page currently lists `datenschutz@ukbb.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.