### PR TITLE
Update Universität Augsburg: email address changed

### DIFF
--- a/companies/uni-augsburg.json
+++ b/companies/uni-augsburg.json
@@ -11,7 +11,7 @@
     "address": "Universitätsstr. 24\n86159 Augsburg\nDeutschland",
     "phone": "+49 821 5984600",
     "fax": "+49 821 5984591",
-    "email": "datenschutzbeauftragter@uni-augsburg.de",
+    "email": "datenschutz@uni-augsburg.de",
     "web": "https://www.uni-augsburg.de/",
     "sources": [
         "https://www.uni-augsburg.de/de/impressum/datenschutz/",


### PR DESCRIPTION
The registered address `datenschutzbeauftragter@uni-augsburg.de` no longer appears on the source page (`https://www.uni-augsburg.de/de/impressum/datenschutz/`). That page currently lists `datenschutz@uni-augsburg.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.