### PR TITLE
Update Universität Heidelberg: email address changed

### DIFF
--- a/companies/uni-heidelberg.json
+++ b/companies/uni-heidelberg.json
@@ -11,7 +11,7 @@
     "address": "Seminarstr. 2\n69117 Heidelberg\nDeutschland",
     "phone": "+49 6221 5419012",
     "fax": "+49 6221 5419020",
-    "email": "datenschutz@uni-heidelberg.de",
+    "email": "datenschutzbeauftragter@uni-heidelberg.de",
     "web": "https://www.uni-heidelberg.de",
     "sources": [
         "https://www.uni-heidelberg.de/de/datenschutzerklaerung",


### PR DESCRIPTION
The registered address `datenschutz@uni-heidelberg.de` no longer appears on the source page (`https://www.uni-heidelberg.de/de/datenschutzerklaerung`). That page currently lists `datenschutzbeauftragter@uni-heidelberg.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.