### PR TITLE
Update Unterstützungskasse der Volksfürsorge/Advocard e.V.: email address changed

### DIFF
--- a/companies/unterstuetzungskasse-der-volksfuersorge-advocard.json
+++ b/companies/unterstuetzungskasse-der-volksfuersorge-advocard.json
@@ -8,7 +8,7 @@
     ],
     "name": "Unterstützungskasse der Volksfürsorge/Advocard e.V.",
     "address": "Besenbinderhof 43\n20097 Hamburg\nDeutschland",
-    "email": "datenschutzbeauftragter.de@generali.com",
+    "email": "konzerndatenschutz.de@generali.com",
     "sources": [
         "https://www.generali.de/resource/blob/48976/93ab2257649b1088e3013ce34b74c4f6/03_Datenschutzhinweise_VAUK_.pdf"
     ],


### PR DESCRIPTION
The registered address `datenschutzbeauftragter.de@generali.com` no longer appears on the source page (`https://generali.de/datenschutz`). That page currently lists `konzerndatenschutz.de@generali.com` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #57.