### PR TITLE
Update VECTOR Technische Unternehmensberatung (TUB) GmbH: email address changed

### DIFF
--- a/companies/vector-tub.json
+++ b/companies/vector-tub.json
@@ -6,7 +6,7 @@
     "name": "VECTOR Technische Unternehmensberatung (TUB) GmbH",
     "address": "Ruhrhang 3\n45525 Hattingen\nDeutschland",
     "phone": "+49 2324 9197100",
-    "email": "info@vector-tub.com",
+    "email": "datenschutz@vector-tub.com",
     "web": "https://www.vector-ndt-training.com",
     "sources": [
         "https://www.vector-ndt-training.com/de/privacy"


### PR DESCRIPTION
The registered address `info@vector-tub.com` no longer appears on the source page (`https://www.vector-ndt-training.com/de/privacy`). That page currently lists `datenschutz@vector-tub.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.