### PR TITLE
Update VENTE-PRIVEE.COM: email address changed

### DIFF
--- a/companies/vente-privee.json
+++ b/companies/vente-privee.json
@@ -6,7 +6,7 @@
     "name": "VENTE-PRIVEE.COM",
     "address": "249, avenue du Président Wilson\n93210 La Plaine Saint Denis\nFrance",
     "phone": "+49 800 6270154",
-    "email": "aenderungen@vente-privee.com",
+    "email": "privacy@vente-privee.com",
     "web": "https://secure.de.vente-privee.com/authentication/Portal/DE",
     "sources": [
         "https://secure.de.vente-privee.com/Privacy%20policy/de-DE/Politique_de_confidentialite.pdf",


### PR DESCRIPTION
The registered address `aenderungen@vente-privee.com` no longer appears on the source page (`https://www.vente-privee.com/privacy-policy`). That page currently lists `privacy@vente-privee.com` as the privacy contact (render scan).

Found and verified by the Privacy Engine optimizer, run #75.