### PR TITLE
Update Niedersächsisches Ministerium für Inneres und Sport – Abteilung Verfassungsschutz: email address changed

### DIFF
--- a/companies/verfassungsschutz-nds.json
+++ b/companies/verfassungsschutz-nds.json
@@ -10,7 +10,7 @@
     "address": "Büttnerstraße 28\n30165 Hannover\nDeutschland",
     "phone": "+49 511 6709217",
     "fax": "+49 511 6709388",
-    "email": "datenschutz@verfassungsschutz.niedersachsen.de",
+    "email": "datenschutz.abt5@verfassungsschutz.niedersachsen.de",
     "web": "https://www.verfassungsschutz.niedersachsen.de",
     "sources": [
         "https://www.verfassungsschutz.niedersachsen.de/aktuelles_service/impressum/datenschutzerklaerung-nach-dsgvo-171680.html",


### PR DESCRIPTION
The registered address `datenschutz@verfassungsschutz.niedersachsen.de` no longer appears on the source page (`https://www.verfassungsschutz.niedersachsen.de/aktuelles_service/impressum/datenschutzerklaerung-nach-dsgvo-171680.html`). That page currently lists `datenschutz.abt5@verfassungsschutz.niedersachsen.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.