### PR TITLE
Update Karlheinz Jung GmbH: email address changed

### DIFF
--- a/companies/versandhaus-jung.json
+++ b/companies/versandhaus-jung.json
@@ -13,7 +13,7 @@
     "address": "Remchinger Straße 1\n75196 Remchingen\nDeutschland",
     "phone": "+49 7232 36540",
     "fax": "+49 7232 365444",
-    "email": "an@versandhaus-jung.de",
+    "email": "datenschutz@versandhaus-jung.de",
     "web": "https://www.versandhaus-jung.de",
     "sources": [
         "https://www.versandhaus-jung.de/Datenschutz",


### PR DESCRIPTION
The registered address `an@versandhaus-jung.de` no longer appears on the source page (`https://www.versandhaus-jung.de/Datenschutz`). That page currently lists `datenschutz@versandhaus-jung.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.