### PR TITLE
Update VIVALU GmbH: email address changed

### DIFF
--- a/companies/vivalu.json
+++ b/companies/vivalu.json
@@ -10,7 +10,7 @@
     "address": "Kaistr. 4\n40221 Düsseldorf\nDeutschland",
     "phone": "+49 211 7817520",
     "fax": "+49 211 78175299",
-    "email": "datenschutz@vivalu.com",
+    "email": "kzo@vivalu.com",
     "web": "https://www.vivalu.com/",
     "sources": [
         "https://www.vivalu.com/datenschutz/",


### PR DESCRIPTION
The registered address `datenschutz@vivalu.com` no longer appears on the source page (`https://www.vivalu.com/privacy-policy/`). That page currently lists `kzo@vivalu.com` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #75.