### PR TITLE
Update Bundesverband der Deutschen Volksbanken und Raiffeisenbanken e.V. (BVR): email address changed

### DIFF
--- a/companies/vr-bank.json
+++ b/companies/vr-bank.json
@@ -7,7 +7,7 @@
     "address": "Schellingstraße 4\n10785 Berlin\nDeutschland",
     "phone": "+49 30 20210",
     "fax": "+49 30 20211900",
-    "email": "info@bvr.de",
+    "email": "datenschutz@bvr.de",
     "web": "https://www.vr.de/privatkunden.html",
     "sources": [
         "https://www.vr.de/privatkunden/service/datenschutz.html",


### PR DESCRIPTION
The registered address `info@bvr.de` no longer appears on the source page (`https://vr.de/datenschutz.html`). That page currently lists `datenschutz@bvr.de` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #75.