### PR TITLE
Update Vungle Limited: email address changed

### DIFF
--- a/companies/vungle.json
+++ b/companies/vungle.json
@@ -11,7 +11,7 @@
         "Vungle, Inc."
     ],
     "address": "4th Floor\nFarringdon Point\n33 Farringdon Road\nLondon\nEC1M 3JF\nUnited Kingdom",
-    "email": "privacy@vungle.com",
+    "email": "gdpr@vungle.com",
     "web": "https://vungle.com/",
     "sources": [
         "https://vungle.com/privacy/"


### PR DESCRIPTION
The registered address `privacy@vungle.com` no longer appears on the source page (`https://vungle.com/blog/part-3-getting-ready-for-gdpr-practical-considerations/`). That page currently lists `gdpr@vungle.com` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #75.