### PR TITLE
Update Wallwisher, Inc.: email address changed

### DIFF
--- a/companies/wallwisher-inc.json
+++ b/companies/wallwisher-inc.json
@@ -8,7 +8,7 @@
         "padlet.com"
     ],
     "address": "981 Mission St\nSan Francisco, CA 94103\nUnited States of America",
-    "email": "hello@padlet.com",
+    "email": "privacy@padlet.com",
     "sources": [
         "https://padlet.com/about/privacy",
         "https://github.com/datenanfragen/data/pull/1030"


### PR DESCRIPTION
The registered address `hello@padlet.com` no longer appears on the source page (`https://padlet.com/about/privacy`). That page currently lists `privacy@padlet.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.