### PR TITLE
Update WattFox GmbH: email address changed

### DIFF
--- a/companies/wattfox-gmbh.json
+++ b/companies/wattfox-gmbh.json
@@ -9,7 +9,7 @@
     ],
     "address": "c/o dacuro GmbH\nOtto-Hahn-Straße 3\n69190 Walldorf\nDeutschland",
     "phone": "+49 6227 7893930",
-    "email": "DSB@wattfox.de",
+    "email": "datenschutz@wattfox.de",
     "web": "https://www.wattfox.de/",
     "sources": [
         "https://www.wattfox.de/datenschutz",


### PR DESCRIPTION
The registered address `DSB@wattfox.de` no longer appears on the source page (`https://www.wattfox.de/datenschutz`). That page currently lists `datenschutz@wattfox.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.