### PR TITLE
Update Josef WITT GmbH: email address changed

### DIFF
--- a/companies/witt-weiden.json
+++ b/companies/witt-weiden.json
@@ -13,7 +13,7 @@
     "address": "Schillerstraße 4 – 12\n92637 Weiden\nDeutschland",
     "phone": "+49 961 4009595",
     "fax": "+49 180 5 212101",
-    "email": "kundenservice@witt-weiden.de",
+    "email": "datenschutz@witt-weiden.de",
     "web": "https://www.witt-weiden.de/",
     "sources": [
         "https://www.witt-weiden.de/content/datenschutzhinweise",


### PR DESCRIPTION
The registered address `kundenservice@witt-weiden.de` no longer appears on the source page (`https://www.witt-weiden.de/content/datenschutzhinweise`). That page currently lists `datenschutz@witt-weiden.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.