### PR TITLE
Update NEW WORK SE: email address changed

### DIFF
--- a/companies/xing.json
+++ b/companies/xing.json
@@ -15,7 +15,7 @@
     "address": "Am Strandkai 1\n20457 Hamburg\nGermany",
     "phone": "+49 40 4191310",
     "fax": "+49 40 41913111",
-    "email": "info@xing.com",
+    "email": "gdpr_xts@xing.com",
     "webform": "https://www.xing.com/support/contact/security/data_protection",
     "web": "https://www.xing.com/",
     "sources": [


### PR DESCRIPTION
The registered address `info@xing.com` no longer appears on the source page (`https://privacy.xing.com/en/privacy-policy/printable-version`). That page currently lists `gdpr_xts@xing.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.