### PR TITLE
Update Y Combinator Management, LLC: email address changed

### DIFF
--- a/companies/ycombinator-com.json
+++ b/companies/ycombinator-com.json
@@ -11,7 +11,7 @@
         "Hacker News (news.ycombinator.com)"
     ],
     "address": "335 Pioneer Way\nMountain View\nCA 94041\nUnited States of America",
-    "email": "hn@ycombinator.com",
+    "email": "privacy@ycombinator.com",
     "web": "https://ycombinator.com/",
     "sources": [
         "https://www.ycombinator.com/legal/#privacy",


### PR DESCRIPTION
The registered address `hn@ycombinator.com` no longer appears on the source page (`https://www.ycombinator.com/legal/#privacy`). That page currently lists `privacy@ycombinator.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.