### PR TITLE
Update ZEIT Online GmbH: email address changed

### DIFF
--- a/companies/zeit-de.json
+++ b/companies/zeit-de.json
@@ -27,7 +27,7 @@
     "address": "Buceriusstraße\nEingang Speersort 1\n20095 Hamburg\nDeutschland",
     "phone": "+49 40 32800",
     "fax": "+49 40 327111",
-    "email": "dsb@zeit.de",
+    "email": "datenschutz@zeit.de",
     "web": "https://www.zeit.de",
     "sources": [
         "https://www.zeit.de/hilfe/datenschutz"


### PR DESCRIPTION
The registered address `dsb@zeit.de` no longer appears on the source page (`https://www.zeit.de/hilfe/datenschutz`). That page currently lists `datenschutz@zeit.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.