### PR TITLE
Update Zendesk International Ltd.: email address changed

### DIFF
--- a/companies/zendesk-international-ltd.json
+++ b/companies/zendesk-international-ltd.json
@@ -8,7 +8,7 @@
     ],
     "name": "Zendesk International Ltd.",
     "address": "55 Charlemont Place\nSaint Kevin’s\nDublin\nD02 F985\nIreland",
-    "email": "euprivacy@zendesk.com",
+    "email": "privacy@zendesk.com",
     "sources": [
         "https://www.zendesk.de/company/customers-partners/privacy-policy/",
         "https://github.com/datenanfragen/data/pull/951",


### PR DESCRIPTION
The registered address `euprivacy@zendesk.com` no longer appears on the source page (`https://www.zendesk.de/company/customers-partners/privacy-policy/`). That page currently lists `privacy@zendesk.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.