### PR TITLE
Update AO Deutschland Limited: email address changed

### DIFF
--- a/companies/ao-shop.json
+++ b/companies/ao-shop.json
@@ -6,7 +6,7 @@
     "name": "AO Deutschland Limited",
     "address": "Ben-Cammmarata-Straße 2\n50126 Bergheim\nDeutschland",
     "phone": "+49 2271 9063000",
-    "email": "hallo@ao.de",
+    "email": "dataprotection@ao.com",
     "web": "https://www.ao.de/",
     "sources": [
         "https://www.ao.de/hilfe-service/rechtliches/datenschutzerkl%C3%A4rung",


### PR DESCRIPTION
The registered address `hallo@ao.de` no longer appears on the source page (`https://www.ao.de/hilfe-service/rechtliches/datenschutzerkl%C3%A4rung`). That page currently lists `dataprotection@ao.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #61.