### PR TITLE
Update Axel Springer Mediahouse Berlin GmbH: email address changed

### DIFF
--- a/companies/axel-springer-mediahouse.json
+++ b/companies/axel-springer-mediahouse.json
@@ -14,7 +14,7 @@
     ],
     "address": "Mehringdamm 33\n10961 Berlin\nDeutschland",
     "phone": "+49 30 58585379",
-    "email": "datenschutz@rollingstone.de",
+    "email": "datenschutz@mediahouse-berlin.de",
     "web": "https://www.rollingstone.de/",
     "webform": "https://www.rollingstone.de/formular-auskunftsersuchen-und-loeschersuchen/",
     "sources": [


### PR DESCRIPTION
The registered address `datenschutz@rollingstone.de` no longer appears on the source page (`https://www.rollingstone.de/datenschutz/`). That page currently lists `datenschutz@mediahouse-berlin.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #61.