### PR TITLE
Update AZ Direct Österreich GmbH: email address changed

### DIFF
--- a/companies/az-direct-at.json
+++ b/companies/az-direct-at.json
@@ -10,7 +10,7 @@
     "address": "Donau-City-Straße 6\nAndromeda Tower\n1220 Wien\nÖsterreich",
     "phone": "+43 1 25965050",
     "fax": "+43 1 2591885",
-    "email": "office@bertelsmann.at",
+    "email": "datenschutz@az-direct.com",
     "sources": [
         "https://www.az-direct.com/site/unternehmen/standorte/",
         "https://github.com/datenanfragen/data/issues/203"


### PR DESCRIPTION
The registered address `office@bertelsmann.at` no longer appears on the source page (`https://www.az-direct.com/site/unternehmen/standorte/`). That page currently lists `datenschutz@az-direct.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #61.