### PR TITLE
Update Babista: email address changed

### DIFF
--- a/companies/babista.json
+++ b/companies/babista.json
@@ -8,7 +8,7 @@
     ],
     "name": "Babista",
     "address": "c/o Vanderstorm Ventures GmbH & Co. KG\nPostfach 110207\n10832 Berlin\nDeutschland",
-    "email": "service@babista.de",
+    "email": "datenschutz@payolution.com",
     "web": "https://www.babista.de",
     "sources": [
         "https://www.babista.de/datenschutz/",


### PR DESCRIPTION
The registered address `service@babista.de` no longer appears on the source page (`https://www.babista.de/datenschutz/`). That page currently lists `datenschutz@payolution.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #61.