### PR TITLE
Update Barclays Bank Ireland PLC Hamburg Branch: email address changed

### DIFF
--- a/companies/barclaycard.json
+++ b/companies/barclaycard.json
@@ -11,7 +11,7 @@
     "address": "Gasstraße 4c\n22761 Hamburg\nDeutschland",
     "phone": "+49 40 89099866",
     "fax": "+49 40 896470",
-    "email": "datenschutz@barclays.de",
+    "email": "datenschutz@barclaycard.de",
     "web": "https://www.barclays.de/",
     "sources": [
         "https://github.com/datenanfragen/data/issues/20",


### PR DESCRIPTION
The registered address `datenschutz@barclays.de` no longer appears on the source page (`https://github.com/datenanfragen/data/issues/20`). That page currently lists `datenschutz@barclaycard.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #61.