### PR TITLE
Update Base Plus SAS: email address changed

### DIFF
--- a/companies/base-plus.json
+++ b/companies/base-plus.json
@@ -11,7 +11,7 @@
         "Europrogrès SAS"
     ],
     "address": "13 Rue Jacobi Netter\n67200 Strasbourg\nFrance",
-    "email": "dpo@base-plus.fr",
+    "email": "dpo@idaia.group",
     "web": "https://www.base-plus.fr",
     "sources": [
         "https://www.base-plus.fr/politique-de-donnees-personnelles.html",


### PR DESCRIPTION
The registered address `dpo@base-plus.fr` no longer appears on the source page (`https://www.base-plus.fr/politique-de-donnees-personnelles.html`). That page currently lists `dpo@idaia.group` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #61.