### PR TITLE
Update Basecamp LLC: email address changed

### DIFF
--- a/companies/basecamp.json
+++ b/companies/basecamp.json
@@ -17,7 +17,7 @@
         "Writeboard"
     ],
     "address": "2045 W Grand Ave Ste B\nPMB 53289\nChicago IL 60612\nUnited States of America",
-    "email": "privacy@basecamp.com",
+    "email": "privacy@37signals.com",
     "web": "https://basecamp.com",
     "sources": [
         "https://basecamp.com/about/policies/privacy",


### PR DESCRIPTION
The registered address `privacy@basecamp.com` no longer appears on the source page (`https://basecamp.com/about/policies/privacy`). That page currently lists `privacy@37signals.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #61.