### PR TITLE
Update billigweg.de: email address changed

### DIFF
--- a/companies/billigweg-de.json
+++ b/companies/billigweg-de.json
@@ -9,7 +9,7 @@
     "name": "billigweg.de",
     "address": "Triplemind GmbH\nBerliner Straße 2\n63065 Offenbach am Main\nDeutschland",
     "phone": "+49 800 1004276",
-    "email": "datenschutz@triplemind.com",
+    "email": "datenschutz@billigweg.de",
     "web": "https://www.billigweg.de/",
     "sources": [
         "https://www.billigweg.de/datenschutz/"


### PR DESCRIPTION
The registered address `datenschutz@triplemind.com` no longer appears on the source page (`https://www.billigweg.de/datenschutz/`). That page currently lists `datenschutz@billigweg.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.