### PR TITLE
Update Heinr. Böker Baumwerk GmbH Solingen: email address changed

### DIFF
--- a/companies/boker-de.json
+++ b/companies/boker-de.json
@@ -9,7 +9,7 @@
     "name": "Heinr. Böker Baumwerk GmbH Solingen",
     "address": "Schützenstr. 30\n42659 Solingen\nDeutschland",
     "phone": "+49 212 40120",
-    "email": "info@boker.de",
+    "email": "datenschutz@boniversum.de",
     "web": "https://www.boker.de",
     "sources": [
         "https://www.boker.de/datenschutz",


### PR DESCRIPTION
The registered address `info@boker.de` no longer appears on the source page (`https://www.boker.de/datenschutz`). That page currently lists `datenschutz@boniversum.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.