### PR TITLE
Update Bold Company B.V: email address changed

### DIFF
--- a/companies/bold-company.json
+++ b/companies/bold-company.json
@@ -9,7 +9,7 @@
     ],
     "address": "Beursplein 37\n3011AA Rotterdam\nThe Netherlands",
     "phone": "+31 88 018 4700",
-    "email": "info@boldcompany.nl",
+    "email": "privacy@starapple.nl",
     "web": "https://www.boldcompany.nl/",
     "sources": [
         "https://www.boldcompany.nl/privacy-statement",


### PR DESCRIPTION
The registered address `info@boldcompany.nl` no longer appears on the source page (`https://www.boldcompany.nl/privacy-statement`). That page currently lists `privacy@starapple.nl` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.