### PR TITLE
Update BuzzFeed, Inc.: email address changed

### DIFF
--- a/companies/buzzfeed.json
+++ b/companies/buzzfeed.json
@@ -26,7 +26,7 @@
         "BFMP Video, Inc. (formerly)"
     ],
     "address": "111 E. 18th Street\n13th Floor\nNew York\nNY 10003\nUnited States of America",
-    "email": "data-privacy@buzzfeed.com",
+    "email": "dpo@independent.co.uk",
     "web": "https://www.buzzfeed.com",
     "sources": [
         "https://www.buzzfeed.com/about/privacy",


### PR DESCRIPTION
The registered address `data-privacy@buzzfeed.com` no longer appears on the source page (`https://www.buzzfeed.com/about/privacy`). That page currently lists `dpo@independent.co.uk` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.