### PR TITLE
Update Bundeszentrale für gesundheitliche Aufklärung (BZgA): email address changed

### DIFF
--- a/companies/bzga-bund.json
+++ b/companies/bzga-bund.json
@@ -10,7 +10,7 @@
     "address": "Maarweg 149 – 161\n50825 Köln\nDeutschland",
     "phone": "+49 221 89920",
     "fax": "+49 221 8992300",
-    "email": "datenschutzbeauftragter@bzga.de",
+    "email": "datenschutzbeauftragter@bioeg.de",
     "web": "https://www.bzga.de/",
     "sources": [
         "https://www.bzga.de/datenschutz/",


### PR DESCRIPTION
The registered address `datenschutzbeauftragter@bzga.de` no longer appears on the source page (`https://www.bzga.de/datenschutz/`). That page currently lists `datenschutzbeauftragter@bioeg.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.