### PR TITLE
Update CAPERA Immobilien Service GmbH: email address changed

### DIFF
--- a/companies/capera-immobilien.json
+++ b/companies/capera-immobilien.json
@@ -7,7 +7,7 @@
     "address": "Schülerstraße 40\n07545 Gera\nDeutschland",
     "phone": "+49 365 55214344",
     "fax": "+49 6102 8154419101",
-    "email": "datenschutz@capera-immoblien.de",
+    "email": "datenschutz@capera-immobilien.de",
     "web": "https://www.capera-immobilien.de",
     "sources": [
         "https://capera-immobilien.de/datenschutz/",


### PR DESCRIPTION
The registered address `datenschutz@capera-immoblien.de` no longer appears on the source page (`https://capera-immobilien.de/datenschutz/`). That page currently lists `datenschutz@capera-immobilien.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.