### PR TITLE
Update CCP hf.: email address changed

### DIFF
--- a/companies/ccpgames.json
+++ b/companies/ccpgames.json
@@ -14,7 +14,7 @@
         "Sparc"
     ],
     "address": "Grandagardur 8\n101 Reykjavik\nIceland",
-    "email": "request@privacy.ccpgames.com",
+    "email": "dpo@fenris.com",
     "web": "https://www.ccpgames.com/",
     "sources": [
         "https://www.ccpgames.com/privacy-policy",


### PR DESCRIPTION
The registered address `request@privacy.ccpgames.com` no longer appears on the source page (`https://www.ccpgames.com/privacy-policy`). That page currently lists `dpo@fenris.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.