### PR TITLE
Update CDU-Landesverband Baden-Württemberg: email address changed

### DIFF
--- a/companies/cdu-bw.json
+++ b/companies/cdu-bw.json
@@ -10,7 +10,7 @@
     "address": "Heilbronner Straße 43\n70191 Stuttgart\nDeutschland",
     "phone": "+49 711 669040",
     "fax": "+49 711 6690415",
-    "email": "datenschutz@ubgnet.de",
+    "email": "datenschutz@cdu.de",
     "web": "https://www.cdu-bw.de",
     "sources": [
         "https://www.cdu-bw.de/impressum/",


### PR DESCRIPTION
The registered address `datenschutz@ubgnet.de` no longer appears on the source page (`https://www.cdu-bw.de/impressum/`). That page currently lists `datenschutz@cdu.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.