### PR TITLE
Update Chartboost, Inc.: email address changed

### DIFF
--- a/companies/chartboost.json
+++ b/companies/chartboost.json
@@ -8,7 +8,7 @@
     ],
     "name": "Chartboost, Inc.",
     "address": "185 Clara Street\nRoom 101B\nSan Francisco CA 94107\nUnited States of America",
-    "email": "privacy@chartboost.com",
+    "email": "privacy@loopme.com",
     "web": "https://www.chartboost.com/",
     "sources": [
         "https://answers.chartboost.com/en-us/articles/200780269",


### PR DESCRIPTION
The registered address `privacy@chartboost.com` no longer appears on the source page (`https://legal.loopme.com/privacy-center`). That page currently lists `privacy@loopme.com` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #73.