### PR TITLE
Update CINECITTA' Multiplexkino GmbH & Co. KG: email address changed

### DIFF
--- a/companies/cinecitta.json
+++ b/companies/cinecitta.json
@@ -10,7 +10,7 @@
     "address": "c/o Rechtsanwaltskanzlei Costard\nLina-Ammon-Straße 9\n90471 Nürnberg\nDeutschland",
     "phone": "+49 911 7903034",
     "fax": "+49 911 7903035",
-    "email": "info@it-rechtsberater.de",
+    "email": "datenschutz@sofort.com",
     "web": "https://www.cinecitta.de",
     "sources": [
         "https://www.cinecitta.de/de/Datenschutzerklaerung-4889,560649.html",


### PR DESCRIPTION
The registered address `info@it-rechtsberater.de` no longer appears on the source page (`https://cinecitta.de/datenschutz/`). That page currently lists `datenschutz@sofort.com` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #73.