### PR TITLE
Update compass private pflegeberatung GmbH: email address changed

### DIFF
--- a/companies/compass-pflegeberatung.json
+++ b/companies/compass-pflegeberatung.json
@@ -9,7 +9,7 @@
     "name": "compass private pflegeberatung GmbH",
     "address": "c/o KINAST Rechtsanwaltsgesellschaft mbH\nHohenzollernring 54\n50672 Köln\nDeutschland",
     "phone": "+49 221 2221830",
-    "email": "mail@kinast.eu",
+    "email": "datenschutz@compass-pflegeberatung.de",
     "web": "https://www.compass-pflegeberatung.de/",
     "sources": [
         "https://www.compass-pflegeberatung.de/datenschutz",


### PR DESCRIPTION
The registered address `mail@kinast.eu` no longer appears on the source page (`https://www.compass-pflegeberatung.de/datenschutz`). That page currently lists `datenschutz@compass-pflegeberatung.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.