### PR TITLE
Update Connatix Holdings Inc.: email address changed

### DIFF
--- a/companies/connatix.json
+++ b/companies/connatix.json
@@ -8,7 +8,7 @@
     ],
     "name": "Connatix Holdings Inc.",
     "address": "666 Broadway\n10th Floor\nNew York\nNY 10012\nUnited States of America",
-    "email": "privacy@connatix.com",
+    "email": "privacy@jwpconnatix.com",
     "web": "https://www.connatix.com/",
     "sources": [
         "https://www.connatix.com/privacy-policy",


### PR DESCRIPTION
The registered address `privacy@connatix.com` no longer appears on the source page (`https://www.connatix.com/privacy-policy`). That page currently lists `privacy@jwpconnatix.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.