### PR TITLE
Update CoviMedical GmbH: email address changed

### DIFF
--- a/companies/covimedical.json
+++ b/companies/covimedical.json
@@ -13,7 +13,7 @@
     ],
     "address": "Steinwiese 18\n35685 Dillenburg\nDeutschland",
     "phone": "+49 2771 4278962",
-    "email": "email@covimedical.de",
+    "email": "datenschutz@ckmgroup.de",
     "web": "https://covimedical.de",
     "sources": [
         "https://15minutentest.de/de/de/datenschutz",


### PR DESCRIPTION
The registered address `email@covimedical.de` no longer appears on the source page (`https://15minutentest.de/de/de/datenschutz`). That page currently lists `datenschutz@ckmgroup.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.