### PR TITLE
Update Degussa Sonne/Mond Goldhandel GmbH: email address changed

### DIFF
--- a/companies/degussa-goldhandel.json
+++ b/companies/degussa-goldhandel.json
@@ -10,7 +10,7 @@
     "address": "c/o @-yet GmbH\nSchloss Eicherhof\n42799 Leichlingen\nDeutschland",
     "phone": "+49 2175 16550",
     "fax": "+49 69 860068222",
-    "email": "datenschutz@degussa-goldhandel.de",
+    "email": "datenschutz@degussa.com",
     "web": "https://shop.degussa-goldhandel.de/",
     "sources": [
         "https://www.degussa-goldhandel.de/infos/datenschutz/",


### PR DESCRIPTION
The registered address `datenschutz@degussa-goldhandel.de` no longer appears on the source page (`https://www.degussa-goldhandel.de/infos/datenschutz/`). That page currently lists `datenschutz@degussa.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.