### PR TITLE
Update Delta Projects AB: email address changed

### DIFF
--- a/companies/deltaprojects.json
+++ b/companies/deltaprojects.json
@@ -9,7 +9,7 @@
     "name": "Delta Projects AB",
     "address": "Linnégatan 89E\n115 23 Stockholm\nSweden",
     "phone": "+46 8 667 76 92",
-    "email": "privacy@deltaprojects.com",
+    "email": "dpo@azerion.com",
     "web": "https://www.deltaprojects.com/",
     "sources": [
         "https://www.deltaprojects.com/privacy-policy/",


### PR DESCRIPTION
The registered address `privacy@deltaprojects.com` no longer appears on the source page (`https://www.deltaprojects.com/privacy-policy/`). That page currently lists `dpo@azerion.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.