### PR TITLE
Update denn's Biomarkt GmbH: email address changed

### DIFF
--- a/companies/denns-biomarkt.json
+++ b/companies/denns-biomarkt.json
@@ -9,7 +9,7 @@
     "name": "denn's Biomarkt GmbH",
     "address": "Hofer Str. 11\n95183 Töpen\nDeutschland",
     "phone": "+49 9295 180",
-    "email": "datenschutz@denns.de",
+    "email": "datenschutz@dennree.de",
     "web": "https://www.denns-biomarkt.de",
     "sources": [
         "https://www.denns-biomarkt.de/ueber-uns/impressum/",


### PR DESCRIPTION
The registered address `datenschutz@denns.de` no longer appears on the source page (`https://www.denns-biomarkt.de/ueber-uns/impressum/`). That page currently lists `datenschutz@dennree.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.