### PR TITLE
Update Deutsche Post AG: email address changed

### DIFF
--- a/companies/deutsche-post.json
+++ b/companies/deutsche-post.json
@@ -13,7 +13,7 @@
     ],
     "address": "Charles-de-Gaulle-Straße 20\n53113 Bonn\nDeutschland",
     "phone": "+49 228 1820",
-    "email": "datenschutz@dpdhl.com",
+    "email": "datenschutz@dhl.com",
     "webform": "https://www.deutschepost.de/de/hilfe-kundenservice/formulare/datenschutz.html",
     "web": "https://www.deutschepost.de",
     "sources": [


### PR DESCRIPTION
The registered address `datenschutz@dpdhl.com` no longer appears on the source page (`https://www.deutschepost.de/de/f/footer/datenschutz.html`). That page currently lists `datenschutz@dhl.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.