### PR TITLE
Update DHL 2-Mann-Handling GmbH: email address changed

### DIFF
--- a/companies/dhl-2-mann-handling-gmbh.json
+++ b/companies/dhl-2-mann-handling-gmbh.json
@@ -5,7 +5,7 @@
     ],
     "name": "DHL 2-Mann-Handling GmbH",
     "address": "Charles-de-Gaulle-Straße 20\n53113 Bonn\nDeutschland",
-    "email": "DHL-2MH-datenschutz@dhl.com",
+    "email": "datenschutz@dpdhl.com",
     "web": "https://www.dhl.de/de/geschaeftskunden/paket/leistungen-und-services/2-mann-handling.html",
     "sources": [
         "https://www.dhl.de/de/toolbar/footer/datenschutz.html"


### PR DESCRIPTION
The registered address `DHL-2MH-datenschutz@dhl.com` no longer appears on the source page (`https://www.dhl.de/de/toolbar/footer/datenschutz.html`). That page currently lists `datenschutz@dpdhl.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.