### PR TITLE
Update Partei der Humanisten: email address changed

### DIFF
--- a/companies/diehumanisten.json
+++ b/companies/diehumanisten.json
@@ -9,7 +9,7 @@
     "name": "Partei der Humanisten",
     "address": "Bänschstraße 52\n10247 Berlin\nDeutschland",
     "phone": "+49 30 85762470",
-    "email": "dsb@diehumanisten.de",
+    "email": "datenschutzbeauftragter@datenschutzexperte.de",
     "web": "https://diehumanisten.de/",
     "sources": [
         "https://diehumanisten.de/datenschutzerklaerung/"


### PR DESCRIPTION
The registered address `dsb@diehumanisten.de` no longer appears on the source page (`https://diehumanisten.de/datenschutzerklaerung/`). That page currently lists `datenschutzbeauftragter@datenschutzexperte.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.