### PR TITLE
Update Cabot Credit Management Group Ltd.: email address changed

### DIFF
--- a/companies/dlc-gb.json
+++ b/companies/dlc-gb.json
@@ -12,7 +12,7 @@
     ],
     "address": "1 Kings Hill Avenue\nKings Hill\nKent\nME19 4UA\nUnited Kingdom",
     "phone": "+44 344 556 0242",
-    "email": "dataprotection@cabotcm.com",
+    "email": "dataprotection@cabotfinancial.com",
     "web": "https://www.cabotcreditmanagement.com/",
     "sources": [
         "https://www.cabotcreditmanagement.com/privacy-and-cookie-policy/",


### PR DESCRIPTION
The registered address `dataprotection@cabotcm.com` no longer appears on the source page (`https://www.cabotcreditmanagement.com/privacy-and-cookie-policy/`). That page currently lists `dataprotection@cabotfinancial.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.