### PR TITLE
Update Dr. Ansay Ltd.: email address changed

### DIFF
--- a/companies/dransay-com.json
+++ b/companies/dransay-com.json
@@ -8,7 +8,7 @@
     ],
     "name": "Dr. Ansay Ltd.",
     "address": "Merchants Street 5\n1171 Valletta\nMalta",
-    "email": "support@dransay.com",
+    "email": "datenschutz@heydata.eu",
     "web": "https://dransay.com",
     "sources": [
         "https://dransay.com/datenschutz"


### PR DESCRIPTION
The registered address `support@dransay.com` no longer appears on the source page (`https://dransay.com/datenschutz`). That page currently lists `datenschutz@heydata.eu` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.