### PR TITLE
Update Internetmarketing Bielefeld GmbH: email address changed

### DIFF
--- a/companies/druckerzubehoer-de.json
+++ b/companies/druckerzubehoer-de.json
@@ -13,7 +13,7 @@
     "address": "Am Lenkwerk 3\n33609 Bielefeld\nDeutschland",
     "phone": "+49 521 16395974",
     "fax": "+49 521 3046863",
-    "email": "datenschutzbeauftragter@druckerzubehoer.de",
+    "email": "email@iitr.de",
     "web": "https://www.druckerzubehoer.de/",
     "sources": [
         "https://www.druckerzubehoer.de/rechtliches/datenschutzerklaerung/",


### PR DESCRIPTION
The registered address `datenschutzbeauftragter@druckerzubehoer.de` no longer appears on the source page (`https://druckerzubehoer.de/datenschutz`). That page currently lists `email@iitr.de` as the privacy contact (render scan).

Found and verified by the Privacy Engine optimizer, run #73.