### PR TITLE
Update Edelmetall-Service GmbH & Co. KG.: email address changed

### DIFF
--- a/companies/edelmetall-handel-de.json
+++ b/companies/edelmetall-handel-de.json
@@ -10,7 +10,7 @@
     "address": "Gewerbering 29b\n76287 Rheinstetten\nDeutschland",
     "phone": "+49 7242 9535111",
     "fax": "+49 7242 9535129",
-    "email": "shop@edelmetall-handel.de",
+    "email": "datenschutz@scheideanstalt.de",
     "web": "http://www.edelmetall-handel.de/",
     "sources": [
         "http://www.edelmetall-handel.de/datenschutz/",


### PR DESCRIPTION
The registered address `shop@edelmetall-handel.de` no longer appears on the source page (`http://www.edelmetall-handel.de/datenschutz/`). That page currently lists `datenschutz@scheideanstalt.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.