### PR TITLE
Update BILD hilft e.V. „Ein Herz für Kinder“: email address changed

### DIFF
--- a/companies/ein-herz-fuer-kinder.json
+++ b/companies/ein-herz-fuer-kinder.json
@@ -9,7 +9,7 @@
     "name": "BILD hilft e.V. „Ein Herz für Kinder“",
     "address": "Axel-Springer-Platz 1\n20350 Hamburg\nDeutschland",
     "phone": "+49 30 58585379",
-    "email": "datenschutz.kundenservice@axelspringer.de",
+    "email": "datenschutz@ehfk.de",
     "web": "https://www.ein-herz-fuer-kinder.de",
     "sources": [
         "https://www.ein-herz-fuer-kinder.de/datenschutz"


### PR DESCRIPTION
The registered address `datenschutz.kundenservice@axelspringer.de` no longer appears on the source page (`https://www.ein-herz-fuer-kinder.de/datenschutz`). That page currently lists `datenschutz@ehfk.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.