### PR TITLE
Update COKIDOO STUDIOS S.L.U.: email address changed

### DIFF
--- a/companies/erasmusu.json
+++ b/companies/erasmusu.json
@@ -12,7 +12,7 @@
     ],
     "address": "Calle Fernando Alonso Navarro 12, 1º\n30009 Murcia\nSpain",
     "phone": "+34 694 47 24 62",
-    "email": "legal@erasmusu.com",
+    "email": "privacy@spotahome.com",
     "web": "https://erasmusu.com",
     "sources": [
         "https://erasmusu.com/en/legal#section-13",


### PR DESCRIPTION
The registered address `legal@erasmusu.com` no longer appears on the source page (`https://erasmusu.com/en/legal#section-13`). That page currently lists `privacy@spotahome.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.