### PR TITLE
Update Exponential Interactive, Inc.: email address changed

### DIFF
--- a/companies/exponential-com.json
+++ b/companies/exponential-com.json
@@ -10,7 +10,7 @@
     "address": "30 Stamford Street\nLondon\nSE19LQ\nUnited Kingdom",
     "phone": "+1 510 250 5500",
     "fax": "+1 510 250 5700",
-    "email": "privacy@exponential.com",
+    "email": "privacy@vdx.tv",
     "web": "http://exponential.com/",
     "sources": [
         "http://exponential.com/privacy/"


### PR DESCRIPTION
The registered address `privacy@exponential.com` no longer appears on the source page (`http://exponential.com/privacy/`). That page currently lists `privacy@vdx.tv` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.