### PR TITLE
Update FIT PLUS Fitness Center GmbH: email address changed

### DIFF
--- a/companies/fit-plus.json
+++ b/companies/fit-plus.json
@@ -9,7 +9,7 @@
     "name": "FIT PLUS Fitness Center GmbH",
     "address": "Altdorfer Straße 38\n84030 Landshut\nDeutschland",
     "phone": "+49 8781 7489869",
-    "email": "datenschutz@fit-plus.info",
+    "email": "datenschutz@fit-plus.de",
     "web": "https://fit-plus.info/",
     "sources": [
         "https://fit-plus.info/datenschutz",


### PR DESCRIPTION
The registered address `datenschutz@fit-plus.info` no longer appears on the source page (`https://fit-plus.info/datenschutz`). That page currently lists `datenschutz@fit-plus.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.