### PR TITLE
Update Fox News Network, LLC: email address changed

### DIFF
--- a/companies/foxnews.json
+++ b/companies/foxnews.json
@@ -8,7 +8,7 @@
     ],
     "name": "Fox News Network, LLC",
     "address": "1211 Avenue of the Americas\n15th Floor\nNew York\nNY 10036\nUnited States of America",
-    "email": "ldepartment@foxnews.com",
+    "email": "privacy@fox.com",
     "web": "https://www.foxnews.com/",
     "sources": [
         "https://www.foxnews.com/privacy-policy"


### PR DESCRIPTION
The registered address `ldepartment@foxnews.com` no longer appears on the source page (`https://www.foxnews.com/privacy-policy`). That page currently lists `privacy@fox.com` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #55.