### PR TITLE
Update WOGE Saar, Wohnungsgesellschaft Saarland mbH: email address changed

### DIFF
--- a/companies/freundlich-wohnen.json
+++ b/companies/freundlich-wohnen.json
@@ -9,7 +9,7 @@
     "name": "WOGE Saar, Wohnungsgesellschaft Saarland mbH",
     "address": "c/o LEG Service GmbH\nBalthasar-Goldstein-Straße 31\n66131 Saarbrücken\nDeutschland",
     "phone": "+49 681 9899600",
-    "email": "datenschutz@woge-saar.de",
+    "email": "datenschutz@strukturholding.de",
     "web": "https://www.freundlich-wohnen.de",
     "sources": [
         "https://www.freundlich-wohnen.de/datenschutz/",


### PR DESCRIPTION
The registered address `datenschutz@woge-saar.de` no longer appears on the source page (`https://www.freundlich-wohnen.de/datenschutz/`). That page currently lists `datenschutz@strukturholding.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.