### PR TITLE
Update FTM Freizeit- und Trendmarketing GmbH & Co. KG: email address changed

### DIFF
--- a/companies/ftm-freizeit-und-trendmarketing-gmbh-co-kg.json
+++ b/companies/ftm-freizeit-und-trendmarketing-gmbh-co-kg.json
@@ -13,7 +13,7 @@
     "address": "Postfach 1223\n77602 Offenburg\nDeutschland",
     "phone": "+49 781 6396100",
     "fax": "+49 781 6396101",
-    "email": "ftm@datenschutzanfrage.de",
+    "email": "datenschutz@daydreams.de",
     "web": "https://www.daydreams.de/datenschutzanfrage-formular",
     "sources": [
         "https://www.daydreams.de/datenschutz",


### PR DESCRIPTION
The registered address `ftm@datenschutzanfrage.de` no longer appears on the source page (`https://www.daydreams.de/datenschutz`). That page currently lists `datenschutz@daydreams.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.