### PR TITLE
Update Chief Constable Greater Manchester Police: email address changed

### DIFF
--- a/companies/gmp-police.json
+++ b/companies/gmp-police.json
@@ -12,7 +12,7 @@
     ],
     "address": "Openshaw Complex\nLawton Street\nManchester\nM11 2NS\nUnited Kingdom",
     "phone": "+44 161 856 2529",
-    "email": "subjectaccess@gmp.police.uk",
+    "email": "dataprotection@gmp.pnn.police.uk",
     "webform": "https://www.gmp.police.uk/rqo/request/ri/request-information/ir/ask-for-delete-change-information/",
     "web": "https://www.gmp.police.uk/",
     "sources": [


### PR DESCRIPTION
The registered address `subjectaccess@gmp.police.uk` no longer appears on the source page (`https://github.com/datenanfragen/data/issues/215`). That page currently lists `dataprotection@gmp.pnn.police.uk` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.