### PR TITLE
Update Go-Ahead Verkehrsgesellschaft Deutschland GmbH: email address changed

### DIFF
--- a/companies/go-ahead-bahn.json
+++ b/companies/go-ahead-bahn.json
@@ -9,7 +9,7 @@
     "name": "Go-Ahead Verkehrsgesellschaft Deutschland GmbH",
     "address": "Rothebühlplatz 21-25\n70178 Stuttgart\nDeutschland",
     "phone": "+49 821 89982544",
-    "email": "datenschutz@goahead-de.com",
+    "email": "datenschutz@arverio.de",
     "web": "https://www.go-ahead-bahn.de",
     "sources": [
         "https://www.go-ahead-bahn.de/datenschutz",


### PR DESCRIPTION
The registered address `datenschutz@goahead-de.com` no longer appears on the source page (`https://www.go-ahead-bahn.de/datenschutz`). That page currently lists `datenschutz@arverio.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.