### PR TITLE
Update Geschäfts- und Koordinierungsstelle GovData: email address changed

### DIFF
--- a/companies/govdata.json
+++ b/companies/govdata.json
@@ -9,7 +9,7 @@
     "name": "Geschäfts- und Koordinierungsstelle GovData",
     "address": "Senatskanzlei\nRathausmarkt 1\n20095 Hamburg\nDeutschland",
     "phone": "+49 40 428312500",
-    "email": "behoerdlicherdatenschutz@sk.hamburg.de",
+    "email": "datenschutz@fitko.de",
     "web": "https://www.govdata.de/",
     "sources": [
         "https://www.govdata.de/web/guest/datenschutz"


### PR DESCRIPTION
The registered address `behoerdlicherdatenschutz@sk.hamburg.de` no longer appears on the source page (`https://www.govdata.de/web/guest/datenschutz`). That page currently lists `datenschutz@fitko.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.