### PR TITLE
Update Grammarly Inc.: email address changed

### DIFF
--- a/companies/grammarly.json
+++ b/companies/grammarly.json
@@ -6,7 +6,7 @@
     "name": "Grammarly Inc.",
     "address": "c/o VeraSafe Ireland Ltd\nUnit 3D North Point House\nNorth Point Business Park\nNew Mallow Road\nCork T23AT2P\nIreland",
     "phone": "+380 68 207 6118",
-    "email": "privacy@grammarly.com",
+    "email": "privacy@superhuman.com",
     "web": "https://www.grammarly.com/",
     "sources": [
         "https://www.grammarly.com/privacy-policy",


### PR DESCRIPTION
The registered address `privacy@grammarly.com` no longer appears on the source page (`https://www.grammarly.com/privacy-policy`). That page currently lists `privacy@superhuman.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.