### PR TITLE
Update Grover Group GmbH: email address changed

### DIFF
--- a/companies/grovercom.json
+++ b/companies/grovercom.json
@@ -12,7 +12,7 @@
         "Grover Finance II GmbH"
     ],
     "address": "c/o data protection nord GmbH\nKurfürstendamm 212\n10719 Berlin\nGermany",
-    "email": "office@datenschutz-nord.de",
+    "email": "datenschutz@grover.de",
     "web": "https://www.grover.com",
     "sources": [
         "https://www.grover.com/de-de/g-about/datenschutzerklaerung",


### PR DESCRIPTION
The registered address `office@datenschutz-nord.de` no longer appears on the source page (`https://www.grover.com/de-de/g-about/datenschutzerklaerung`). That page currently lists `datenschutz@grover.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.