### PR TITLE
Update Offene Ganztagsgrundschule Heinrichstraße Braunschweig: email address changed

### DIFF
--- a/companies/grundschule-heinrichstrasse-bs.json
+++ b/companies/grundschule-heinrichstrasse-bs.json
@@ -11,7 +11,7 @@
     "address": "Heinrichstraße 30\n38106 Braunschweig\nDeutschland",
     "phone": "+49 531 330564",
     "fax": "+49 531 2338739",
-    "email": "GS.Heinrichstrasse@braunschweig.de",
+    "email": "silke.laenger@gs-heinrich.de",
     "web": "http://www.grundschule-heinrichstrasse.de",
     "sources": [
         "http://www.grundschule-heinrichstrasse.de/index.php?id=70"


### PR DESCRIPTION
The registered address `GS.Heinrichstrasse@braunschweig.de` no longer appears on the source page (`https://grundschule-heinrichstrasse.de/datenschutzerklaerung/`). That page currently lists `silke.laenger@gs-heinrich.de` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #55.