### PR TITLE
Update Grundschule Waggum Braunschweig: email address changed

### DIFF
--- a/companies/grundschule-waggum-bs.json
+++ b/companies/grundschule-waggum-bs.json
@@ -11,7 +11,7 @@
     "address": "Claudiusstraße 1\n38110 Braunschweig\nDeutschland",
     "phone": "+49 5307 6544",
     "fax": "+49 5307 980280",
-    "email": "gs.waggum@braunschweig.de",
+    "email": "datenschutz@nlq.nibis.de",
     "web": "https://wordpress.nibis.de/gswaggum/",
     "sources": [
         "https://wordpress.nibis.de/gswaggum/kontakt/"


### PR DESCRIPTION
The registered address `gs.waggum@braunschweig.de` no longer appears on the source page (`https://wordpress.nibis.de/datenschutzerklaerung`). That page currently lists `datenschutz@nlq.nibis.de` as the privacy contact (render scan).

Found and verified by the Privacy Engine optimizer, run #55.