### PR TITLE
Update Grundschule Volkmarode Braunschweig: email address changed

### DIFF
--- a/companies/gs-volkmarode-bs.json
+++ b/companies/gs-volkmarode-bs.json
@@ -11,7 +11,7 @@
     "address": "Unterdorf 24\n38104 Braunschweig\nDeutschland",
     "phone": "+49 531 3104660",
     "fax": "+49 531 31046619",
-    "email": "gs.volkmarode@braunschweig.de",
+    "email": "datenschutz@nlq.nibis.de",
     "web": "https://wordpress.nibis.de/gsvolkmarode/",
     "sources": [
         "https://wordpress.nibis.de/gsvolkmarode/impressum/"


### PR DESCRIPTION
The registered address `gs.volkmarode@braunschweig.de` no longer appears on the source page (`https://wordpress.nibis.de/datenschutzerklaerung`). That page currently lists `datenschutz@nlq.nibis.de` as the privacy contact (render scan).

Found and verified by the Privacy Engine optimizer, run #73.