### PR TITLE
Update GYMLIB SAS: email address changed

### DIFF
--- a/companies/gymlib-sas.json
+++ b/companies/gymlib-sas.json
@@ -5,7 +5,7 @@
     ],
     "name": "GYMLIB SAS",
     "address": "156 rue de la Roquette\n75011 Paris\nFrance",
-    "email": "legal@gymlib.com",
+    "email": "dpo@egym-wellpass.com",
     "web": "https://gymlib.com",
     "sources": [
         "https://legals.gymlib.com/tos",


### PR DESCRIPTION
The registered address `legal@gymlib.com` no longer appears on the source page (`https://fr.egym-wellpass.com/fr-fr/confidentialite-wellpass`). That page currently lists `dpo@egym-wellpass.com` as the privacy contact (render scan).

Found and verified by the Privacy Engine optimizer, run #73.