### PR TITLE
Update Hagen Grote GmbH: email address changed

### DIFF
--- a/companies/hagengrote.json
+++ b/companies/hagengrote.json
@@ -10,7 +10,7 @@
     "address": "c/o ZB Datenschutz und -sicherheit GmbH & Co. KG\nHansestraße A1/79\n51149 Köln\nDeutschland",
     "phone": "+49 2203 8984444",
     "fax": "+49 2151 6070999",
-    "email": "dsb.hagengrote@zb-datenschutz.com",
+    "email": "datenschutz@hagengrote.de",
     "web": "https://www.hagengrote.de",
     "sources": [
         "https://www.hagengrote.de/datenschutz",


### PR DESCRIPTION
The registered address `dsb.hagengrote@zb-datenschutz.com` no longer appears on the source page (`https://www.hagengrote.de/datenschutz`). That page currently lists `datenschutz@hagengrote.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.