### PR TITLE
Update Hans Würtz Schule Braunschweig: email address changed

### DIFF
--- a/companies/hans-wuertz-schule-bs.json
+++ b/companies/hans-wuertz-schule-bs.json
@@ -11,7 +11,7 @@
     "address": "Kruppstraße 24 a\n38126 Braunschweig\nDeutschland",
     "phone": "+49 531 680370",
     "fax": "+49 531 6803719",
-    "email": "hans-wuertz-schule@braunschweig.de",
+    "email": "datenschutz@hws-bs1.de",
     "web": "https://www.hans-wuertz-schule.com/",
     "sources": [
         "https://www.hans-wuertz-schule.com/about/"


### PR DESCRIPTION
The registered address `hans-wuertz-schule@braunschweig.de` no longer appears on the source page (`https://www.hans-wuertz-schule.com/about/`). That page currently lists `datenschutz@hws-bs1.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.