### PR TITLE
Update Intuition Machines, Inc.: email address changed

### DIFF
--- a/companies/hcaptcha.json
+++ b/companies/hcaptcha.json
@@ -11,7 +11,7 @@
         "hCaptcha"
     ],
     "address": "350 Alabama St\nSan Francisco, CA 94110\nUnited States of America",
-    "email": "support@hcaptcha.com",
+    "email": "privacy@imachines.com",
     "web": "https://www.hcaptcha.com",
     "sources": [
         "https://www.hcaptcha.com/privacy",


### PR DESCRIPTION
The registered address `support@hcaptcha.com` no longer appears on the source page (`https://www.hcaptcha.com/privacy`). That page currently lists `privacy@imachines.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.