### PR TITLE
Update Helvetia Schweizerische Versicherungsgesellschaft AG: email address changed

### DIFF
--- a/companies/helvetia-de.json
+++ b/companies/helvetia-de.json
@@ -10,7 +10,7 @@
     "address": "Berliner Str. 56-58\n60311 Frankfurt\nDeutschland",
     "phone": "+49 69 13320",
     "fax": "+49 69 1332474",
-    "email": "datenschutz@helvetia.de",
+    "email": "datenschutz@baloise.de",
     "web": "https://www.helvetia.com/",
     "sources": [
         "https://www.helvetia.com/de/web/de/ueber-uns/service/datenschutz.html",


### PR DESCRIPTION
The registered address `datenschutz@helvetia.de` no longer appears on the source page (`https://www.helvetia.com/de/web/de/ueber-uns/service/datenschutz.html`). That page currently lists `datenschutz@baloise.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.