### PR TITLE
Update Hermes Germany GmbH: email address changed

### DIFF
--- a/companies/hermes.json
+++ b/companies/hermes.json
@@ -10,7 +10,7 @@
     "address": "Essener Straße 89\n22419 Hamburg\nDeutschland",
     "phone": "+49 40 537550",
     "fax": "+49 40 53754870",
-    "email": "datenschutz@hermesworld.com",
+    "email": "datenschutz@myhermes.de",
     "web": "https://www.myhermes.de/",
     "sources": [
         "https://www.myhermes.de/datenschutz/",


### PR DESCRIPTION
The registered address `datenschutz@hermesworld.com` no longer appears on the source page (`https://www.myhermes.de/datenschutz/`). That page currently lists `datenschutz@myhermes.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.