### PR TITLE
Update hhp GmbH: email address changed

### DIFF
--- a/companies/hhp-de.json
+++ b/companies/hhp-de.json
@@ -6,7 +6,7 @@
     "name": "hhp GmbH",
     "address": "Sophienstraße 15 – 17\n76133 Karlsruhe\nDeutschland",
     "fax": "+49 721 1614399",
-    "email": "info@hhp.de",
+    "email": "datenschutz@zalando.de",
     "web": "https://www.hhp.de",
     "sources": [
         "https://www.hhp.de/unternehmen-hhp/datenschutzbestimmungen",


### PR DESCRIPTION
The registered address `info@hhp.de` no longer appears on the source page (`https://www.hhp.de/unternehmen-hhp/datenschutzbestimmungen`). That page currently lists `datenschutz@zalando.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.