### PR TITLE
Update Hirscher Datentechnik GmbH: email address changed

### DIFF
--- a/companies/hirscher-de.json
+++ b/companies/hirscher-de.json
@@ -6,7 +6,7 @@
     "name": "Hirscher Datentechnik GmbH",
     "address": "Wöhrder Hauptstraße 31\n90489 Nürnberg\nDeutschland",
     "phone": "+49 911 588660",
-    "email": "datenschutz@hirscher.de",
+    "email": "datenschutz@anwaelte-gkr.de",
     "web": "https://www.hirscher.de",
     "sources": [
         "https://www.hirscher.de/datenschutzerklaerung/"


### PR DESCRIPTION
The registered address `datenschutz@hirscher.de` no longer appears on the source page (`https://hirscher.de/datenschutz`). That page currently lists `datenschutz@anwaelte-gkr.de` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #73.