### PR TITLE
Update Handelskammer Hamburg: email address changed

### DIFF
--- a/companies/hk24.json
+++ b/companies/hk24.json
@@ -11,7 +11,7 @@
     "address": "Adolphsplatz 1\n20457 Hamburg\nDeutschland",
     "phone": "+49 40 36138138",
     "fax": "+49 40 36138401",
-    "email": "datenschutz@hk24.de",
+    "email": "datenschutz@handelskammer-hamburg.de",
     "web": "https://hk24.de",
     "sources": [
         "https://www.hk24.de/ueber-uns/impressum-nutzungsbedingungen-agbs/impressum-1140706",


### PR DESCRIPTION
The registered address `datenschutz@hk24.de` no longer appears on the source page (`https://www.hk24.de/ueber-uns/impressum-nutzungsbedingungen-agbs/impressum-1140706`). That page currently lists `datenschutz@handelskammer-hamburg.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.