### PR TITLE
Update Home Shopping Europe GmbH: email address changed

### DIFF
--- a/companies/hse24.json
+++ b/companies/hse24.json
@@ -7,7 +7,7 @@
     "address": "Münchener Straße 101 h\n85737 Ismaning\nDeutschland",
     "phone": "+49 800 2788888",
     "fax": "+49 180 1 87359999",
-    "email": "datenschutz@hse24.de",
+    "email": "datenschutz@hse.de",
     "web": "https://www.hse24.de/",
     "sources": [
         "https://www.hse24.de/service/datenschutz.html",


### PR DESCRIPTION
The registered address `datenschutz@hse24.de` no longer appears on the source page (`https://hse24.de/dpl/c/service/datenschutz`). That page currently lists `datenschutz@hse.de` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #73.