### PR TITLE
Update IDAIA: email address changed

### DIFF
--- a/companies/idaia-group.json
+++ b/companies/idaia-group.json
@@ -11,7 +11,7 @@
         "Cartégie"
     ],
     "address": "3 Rue Christian Franceries\nParc Chavailles 2\n33520 Bruges\nBelgium",
-    "email": "dpo@cartegie.com",
+    "email": "dpo@idaia.group",
     "web": "https://www.idaia.group/",
     "sources": [
         "https://www.idaia.group/fr/donnees-personnelles",


### PR DESCRIPTION
The registered address `dpo@cartegie.com` no longer appears on the source page (`https://www.idaia.group/fr/donnees-personnelles`). That page currently lists `dpo@idaia.group` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.