### PR TITLE
Update Ikano Bank AB - Suomen sivuliike: email address changed

### DIFF
--- a/companies/ikano-bank-fi.json
+++ b/companies/ikano-bank-fi.json
@@ -9,7 +9,7 @@
     "name": "Ikano Bank AB - Suomen sivuliike",
     "address": "PL 85\n02601 Espoo\nFinland",
     "phone": "+358 10 7735718",
-    "email": "tietosuoja@ikano.fi",
+    "email": "dpo@ikano.se",
     "web": "https://ikanobank.fi/",
     "sources": [
         "https://ikanobank.fi/tietoameistä/tietosuoja",


### PR DESCRIPTION
The registered address `tietosuoja@ikano.fi` no longer appears on the source page (`https://ikanobank.fi/tietoameistä/tietosuoja`). That page currently lists `dpo@ikano.se` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.