### PR TITLE
Update Ikano Bank AB - Oddział w Polsce: email address changed

### DIFF
--- a/companies/ikano-bank-pl.json
+++ b/companies/ikano-bank-pl.json
@@ -9,7 +9,7 @@
     "name": "Ikano Bank AB - Oddział w Polsce",
     "address": "ul. Postępu 14\n02-676 Warsaw\nPoland",
     "phone": "+48 22 431 56 00",
-    "email": "iod@ikano.pl",
+    "email": "dpo@ikano.se",
     "web": "https://ikanobank.pl",
     "sources": [
         "https://ikanobank.pl/nota-prawna",


### PR DESCRIPTION
The registered address `iod@ikano.pl` no longer appears on the source page (`https://ikanobank.pl/nota-prawna`). That page currently lists `dpo@ikano.se` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.