### PR TITLE
Update IKEA Deutschland GmbH & Co. KG: email address changed

### DIFF
--- a/companies/ikea.json
+++ b/companies/ikea.json
@@ -9,7 +9,7 @@
     "name": "IKEA Deutschland GmbH & Co. KG",
     "address": "Am Wandersmann 2 – 4\n65719 Hofheim-Wallau\nDeutschland",
     "phone": "+49 6192 9399999",
-    "email": "dsb@ikea.com",
+    "email": "privacy@taskrabbit.com",
     "web": "https://www.ikea.com/de/de/",
     "sources": [
         "https://www.ikea.com/de/de/customer-service/privacy-policy/",


### PR DESCRIPTION
The registered address `dsb@ikea.com` no longer appears on the source page (`https://www.ikea.com/de/de/customer-service/privacy-policy/`). That page currently lists `privacy@taskrabbit.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.