### PR TITLE
Update Index Exchange, Inc.: email address changed

### DIFF
--- a/companies/indexexchange.json
+++ b/companies/indexexchange.json
@@ -8,7 +8,7 @@
     ],
     "name": "Index Exchange, Inc.",
     "address": "c/o Legal Army, S.L.\nB88103700\nMaría de Molina, 60 4th\n28006 Madrid\nSpain",
-    "email": "gdpr@legalarmy.net",
+    "email": "privacy@indexexchange.com",
     "web": "https://www.indexexchange.com/",
     "sources": [
         "https://www.indexexchange.com/privacy/"


### PR DESCRIPTION
The registered address `gdpr@legalarmy.net` no longer appears on the source page (`https://www.indexexchange.com/privacy/`). That page currently lists `privacy@indexexchange.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.