### PR TITLE
Update infas quo GmbH: email address changed

### DIFF
--- a/companies/infas-quo.json
+++ b/companies/infas-quo.json
@@ -12,7 +12,7 @@
     ],
     "address": "Prinzregentenufer 3\n90489 Nürnberg\nDeutschland",
     "phone": "+49 911 5805610",
-    "email": "datenschutz@infas-quo.de",
+    "email": "privacy@osmfoundation.org",
     "web": "https://infas-quo.de",
     "sources": [
         "https://infas-quo.de/datenschutz/",


### PR DESCRIPTION
The registered address `datenschutz@infas-quo.de` no longer appears on the source page (`https://wiki.osmfoundation.org/wiki/Privacy_Policy`). That page currently lists `privacy@osmfoundation.org` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #73.