### PR TITLE
Update Mantle Germany GmbH: email address changed

### DIFF
--- a/companies/infratest-dimap.json
+++ b/companies/infratest-dimap.json
@@ -9,7 +9,7 @@
     ],
     "address": "Landsberger Str. 284\n80687 München\nDeutschland",
     "phone": "+49 800 0001468",
-    "email": "datenschutz.kantarpublic@kantar.com",
+    "email": "datenschutz@dimap.de",
     "web": "https://www.infratest-dimap.de",
     "sources": [
         "https://www.infratest-dimap.de/kontakt/datenschutz/",


### PR DESCRIPTION
The registered address `datenschutz.kantarpublic@kantar.com` no longer appears on the source page (`https://www.infratest-dimap.de/kontakt/datenschutz/`). That page currently lists `datenschutz@dimap.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.