### PR TITLE
Update Kaufland Česká republika v.o.s.: email address changed

### DIFF
--- a/companies/kaufland-cz.json
+++ b/companies/kaufland-cz.json
@@ -9,7 +9,7 @@
     "name": "Kaufland Česká republika v.o.s.",
     "address": "Bělohorská 2428/203\n169 00 Praha 6\nCzech Republic",
     "phone": "+420 800 165 894",
-    "email": "oou@kaufland.cz",
+    "email": "gdpr@kaufland-online.cz",
     "web": "https://www.kaufland.cz",
     "sources": [
         "https://prodejny.kaufland.cz/ochrana-osobnich-udaju.html"


### PR DESCRIPTION
The registered address `oou@kaufland.cz` no longer appears on the source page (`https://prodejny.kaufland.cz/ochrana-osobnich-udaju.html`). That page currently lists `gdpr@kaufland-online.cz` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.