### PR TITLE
Update Kommunale Wohnungsgesellschaft mbH Erfurt: email address changed

### DIFF
--- a/companies/kommunale-wohnungsgesellschaft-erfurt.json
+++ b/companies/kommunale-wohnungsgesellschaft-erfurt.json
@@ -6,7 +6,7 @@
     "name": "Kommunale Wohnungsgesellschaft mbH Erfurt",
     "address": "Juri-Gagarin-Ring 148\n99084 Erfurt\nDeutschland",
     "phone": "+49 361 30283028",
-    "email": "zuhause@kowo.de",
+    "email": "datenschutz@domusconsult.de",
     "sources": [
         "https://kowo.de/datenschutz",
         "https://github.com/datenanfragen/data/pull/2777"


### PR DESCRIPTION
The registered address `zuhause@kowo.de` no longer appears on the source page (`https://kowo.de/datenschutzerklaerung/`). That page currently lists `datenschutz@domusconsult.de` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #75.