### PR TITLE
Update KOMPASS-Karten GmbH: email address changed

### DIFF
--- a/companies/kompass-karten.json
+++ b/companies/kompass-karten.json
@@ -11,7 +11,7 @@
     "address": "Karl-Kapfererstraße 5\n6020 Innsbruck\nÖsterreich",
     "phone": "+43 512 2655610",
     "fax": "+43 512 2655618",
-    "email": "datenschutz@kompass.at",
+    "email": "datenschutz@kompass-fb.com",
     "web": "https://www.kompass.de",
     "sources": [
         "https://www.kompass.de/service/datenschutz/",


### PR DESCRIPTION
The registered address `datenschutz@kompass.at` no longer appears on the source page (`https://www.kompass.de/service/datenschutz/`). That page currently lists `datenschutz@kompass-fb.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.