### PR TITLE
Update limango GmbH: email address changed

### DIFF
--- a/companies/limango.json
+++ b/companies/limango.json
@@ -7,7 +7,7 @@
     "address": "Georg-Muche-Straße 1\n80807 München\nDeutschland",
     "phone": "+49 800 5499800",
     "fax": "+49 89 248851259",
-    "email": "support@limango.de",
+    "email": "datenschutz@limango.com",
     "web": "https://www.limango.de/",
     "sources": [
         "https://www.limango.de/datenschutz",


### PR DESCRIPTION
The registered address `support@limango.de` no longer appears on the source page (`https://www.limango.de/datenschutz`). That page currently lists `datenschutz@limango.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.