### PR TITLE
Update Ludwig-Maximilians-Universität München: email address changed

### DIFF
--- a/companies/ludwig-maximilians-universitaet-muenchen.json
+++ b/companies/ludwig-maximilians-universitaet-muenchen.json
@@ -11,7 +11,7 @@
     "address": "Geschwister-Scholl-Platz 1\n80539 München\nDeutschland",
     "phone": "+49 89 21802414",
     "fax": "+49 89 21802322",
-    "email": "poststelle@verwaltung.uni-muenchen.de",
+    "email": "datenschutz@med.uni-muenchen.de",
     "webform": "https://www.lmu.de/de/footer/datenschutz/kontakt-zum-behoerdlichen-datenschutzbeauftragten.html",
     "web": "https://www.lmu.de/",
     "sources": [


### PR DESCRIPTION
The registered address `poststelle@verwaltung.uni-muenchen.de` no longer appears on the source page (`https://www.lmu.de/de/die-lmu/struktur/organisation/vertretungen-beauftragte-und-ansprechpersonen/datenschutzbeauftragte.html`). That page currently lists `datenschutz@med.uni-muenchen.de` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #75.