### PR TITLE
Update The Rocket Science Group LLC: email address changed

### DIFF
--- a/companies/mailchimp.json
+++ b/companies/mailchimp.json
@@ -12,7 +12,7 @@
         "MailChimp (mailchimp.com)"
     ],
     "address": "675 Ponce de Leon Ave NE\nSuite 5000\nAtlanta\nGA 30308\nUnited States of America",
-    "email": "personaldatarequests@mailchimp.com",
+    "email": "dpo@creditkarma.com",
     "webform": "https://mailchimp.com/privacy-rights/",
     "web": "https://mailchimp.com",
     "sources": [


### PR DESCRIPTION
The registered address `personaldatarequests@mailchimp.com` no longer appears on the source page (`https://mailchimp.com/legal/privacy/`). That page currently lists `dpo@creditkarma.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.