### PR TITLE
Update Mailgun Technologies, Inc.: email address changed

### DIFF
--- a/companies/mailgun.json
+++ b/companies/mailgun.json
@@ -8,7 +8,7 @@
     ],
     "name": "Mailgun Technologies, Inc.",
     "address": "112 E Pecan St #1135\nSan Antonio\nTX 78205\nUnited States of America",
-    "email": "privacy@mailgun.com",
+    "email": "dpo@sinch.com",
     "web": "https://www.mailgun.com",
     "sources": [
         "https://www.mailgun.com/privacy-policy/"


### PR DESCRIPTION
The registered address `privacy@mailgun.com` no longer appears on the source page (`https://www.mailgun.com/privacy-policy/`). That page currently lists `dpo@sinch.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.