### PR TITLE
Update Mailjet SAS: email address changed

### DIFF
--- a/companies/mailjet.json
+++ b/companies/mailjet.json
@@ -8,7 +8,7 @@
     ],
     "name": "Mailjet SAS",
     "address": "13-13 bis rue de l’Aubrac\n75012 Paris\nFrance",
-    "email": "privacy@mailgun.com",
+    "email": "dpo@sinch.com",
     "web": "https://www.mailjet.com/",
     "sources": [
         "https://www.mailjet.com/privacy-policy/"


### PR DESCRIPTION
The registered address `privacy@mailgun.com` no longer appears on the source page (`https://www.mailjet.com/privacy-policy/`). That page currently lists `dpo@sinch.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.