### PR TITLE
Update Marks and Spencer plc: email address changed

### DIFF
--- a/companies/marksandspencer.json
+++ b/companies/marksandspencer.json
@@ -20,7 +20,7 @@
     "name": "Marks and Spencer plc",
     "address": "Chester Business Park\nWrexham Road\nChester\nCH4 9GA\nUnited Kingdom",
     "phone": "+44 333 014 8555",
-    "email": "customer.dpo@customersupport.marksandspencer.com",
+    "email": "generaldataprotectionrequests@customer-support.marksandspencer.com",
     "web": "https://www.marksandspencer.com/",
     "sources": [
         "https://www.marksandspencer.com/c/faqs/legal-and-ethical-policies/what-is-our-privacy-policy"


### PR DESCRIPTION
The registered address `customer.dpo@customersupport.marksandspencer.com` no longer appears on the source page (`https://marksandspencer.com/content/data-protection-policy`). That page currently lists `generaldataprotectionrequests@customer-support.marksandspencer.com` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #75.