### PR TITLE
Update MatchAffinity.ie: email address changed

### DIFF
--- a/companies/matchaffinity-ie.json
+++ b/companies/matchaffinity-ie.json
@@ -8,7 +8,7 @@
     ],
     "name": "MatchAffinity.ie",
     "address": "MIL\nc/o Skadden\n40 Bank Street\nCanary Wharf\nLondon\nE14 5DS\nUnited Kingdom",
-    "email": "privacy@matchaffinity.com",
+    "email": "privacy@matchaffinity.ie",
     "web": "https://www.matchaffinity.ie",
     "sources": [
         "https://www.matchaffinity.ie/pages/misc/privacy"


### PR DESCRIPTION
The registered address `privacy@matchaffinity.com` no longer appears on the source page (`https://matchaffinity.ie/pages/misc/privacy.html?styled=1`). That page currently lists `privacy@matchaffinity.ie` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #75.