### PR TITLE
Update METRO Markets GmbH: email address changed

### DIFF
--- a/companies/metro-markets.json
+++ b/companies/metro-markets.json
@@ -5,7 +5,7 @@
     ],
     "name": "METRO Markets GmbH",
     "address": "Ria-Thiele-Str. 2a\n40549 Düsseldorf\nDeutschland",
-    "email": "datenschutz@metro-markets.de",
+    "email": "datenschutzbeauftragter@metro.de",
     "web": "https://www.metro.de/marktplatz/",
     "sources": [
         "https://www.metro.de/unternehmen/datenschutzhinweise/marktplatz",


### PR DESCRIPTION
The registered address `datenschutz@metro-markets.de` no longer appears on the source page (`https://www.metro.de/unternehmen/datenschutzhinweise/marktplatz`). That page currently lists `datenschutzbeauftragter@metro.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.