### PR TITLE
Update Light In The Box Ltd.: email address changed

### DIFF
--- a/companies/miniinthebox.json
+++ b/companies/miniinthebox.json
@@ -11,7 +11,7 @@
         "MiniInTheBox.com (www.miniinthebox.com)"
     ],
     "address": "131 – 151 Great Titchfield Street\nGreater London\nLondon\nW1W 5BB\nUnited Kingdom",
-    "email": "dataprotectionofficer@lightinthebox.com",
+    "email": "dataprotectionofficer@miniinthebox.com",
     "web": "https://www.miniinthebox.com/",
     "sources": [
         "https://www.miniinthebox.com/r/privacy.html",


### PR DESCRIPTION
The registered address `dataprotectionofficer@lightinthebox.com` no longer appears on the source page (`https://www.miniinthebox.com/r/privacy.html`). That page currently lists `dataprotectionofficer@miniinthebox.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.