### PR TITLE
Update Myunidays Limited: email address changed

### DIFF
--- a/companies/myunidays.json
+++ b/companies/myunidays.json
@@ -10,7 +10,7 @@
     ],
     "address": "c/o PLANIT//LEGAL\nJungfernstieg 1\n20095 Hamburg\nDeutschland",
     "phone": "+44 115 985 3070",
-    "email": "unidays_eu_representative@planit.legal",
+    "email": "dpo@myunidays.com",
     "web": "https://www.myunidays.com",
     "sources": [
         "https://www.myunidays.com/DE/de-DE/privacy-policy",


### PR DESCRIPTION
The registered address `unidays_eu_representative@planit.legal` no longer appears on the source page (`https://www.myunidays.com/DE/de-DE/privacy-policy`). That page currently lists `dpo@myunidays.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.