### PR TITLE
Update Nano Interactive GmbH: email address changed

### DIFF
--- a/companies/nanointeractive.json
+++ b/companies/nanointeractive.json
@@ -8,7 +8,7 @@
     ],
     "name": "Nano Interactive GmbH",
     "address": "Lindwurmstr. 27\n80337 München\nGermany",
-    "email": "privacy@nanointeractive.com",
+    "email": "dpo@sopro.io",
     "web": "https://www.nanointeractive.com/",
     "sources": [
         "https://www.nanointeractive.com/privacy-statement/"


### PR DESCRIPTION
The registered address `privacy@nanointeractive.com` no longer appears on the source page (`https://www.nanointeractive.com/privacy-statement/`). That page currently lists `dpo@sopro.io` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.