### PR TITLE
Update Nanu-Nana Internetshop GmbH & Co. KG: email address changed

### DIFF
--- a/companies/nanu-nana.json
+++ b/companies/nanu-nana.json
@@ -9,7 +9,7 @@
     "name": "Nanu-Nana Internetshop GmbH & Co. KG",
     "address": "Lange Straße 48\n26122 Oldenburg\nDeutschland",
     "phone": "+49 441 9224270",
-    "email": "datenschutz@nanu-nana.de",
+    "email": "datenschutz@gfp24.de",
     "web": "https://www.nanu-nana.de/",
     "sources": [
         "https://www.nanu-nana.de/datenschutz/"


### PR DESCRIPTION
The registered address `datenschutz@nanu-nana.de` no longer appears on the source page (`https://www.nanu-nana.de/datenschutz/`). That page currently lists `datenschutz@gfp24.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.