### PR TITLE
Update Nativo, Inc.: email address changed

### DIFF
--- a/companies/nativo.json
+++ b/companies/nativo.json
@@ -8,7 +8,7 @@
     ],
     "name": "Nativo, Inc.",
     "address": "222 Pacific Coast Highway\n10th Floor\nEl Segundo, CA 90245\nUnited States of America",
-    "email": "privacy@nativo.com",
+    "email": "privacy-nativo@life360.com",
     "webform": "https://submit-irm.trustarc.com/services/validation/e1b081d3-40df-4137-add0-7e34cf4d13b2",
     "web": "https://www.nativo.com/",
     "sources": [


### PR DESCRIPTION
The registered address `privacy@nativo.com` no longer appears on the source page (`https://www.nativo.com/legal/privacy-policy`). That page currently lists `privacy-nativo@life360.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.