### PR TITLE
Update NetCologne Gesellschaft für Telekommunikation mbH: email address changed

### DIFF
--- a/companies/netcologne.json
+++ b/companies/netcologne.json
@@ -10,7 +10,7 @@
     "address": "Am Coloneum 9\n50829 Köln\nDeutschland",
     "phone": "+49 221 2222313",
     "fax": "+49 221 22225255",
-    "email": "Datenschutz@netcologne.de",
+    "email": "datenschutz@netcologne.com",
     "web": "https://www.netcologne.de/",
     "sources": [
         "https://www.netcologne.de/datenschutz",


### PR DESCRIPTION
The registered address `Datenschutz@netcologne.de` no longer appears on the source page (`https://www.netcologne.de/datenschutz`). That page currently lists `datenschutz@netcologne.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.