### PR TITLE
Update nic.at GmbH: email address changed

### DIFF
--- a/companies/nic-at-gmbh.json
+++ b/companies/nic-at-gmbh.json
@@ -8,7 +8,7 @@
     ],
     "name": "nic.at GmbH",
     "address": "Jakob-Haringer-Straße 8/V\n5020 Salzburg\nÖsterreich",
-    "email": "service@nic.at",
+    "email": "privacy@matomo.org",
     "web": "https://www.nic.at",
     "sources": [
         "https://www.nic.at/de/wissenswertes/rechtliche-hintergruende/datenschutzerklaerung",


### PR DESCRIPTION
The registered address `service@nic.at` no longer appears on the source page (`https://www.nic.at/de/wissenswertes/rechtliche-hintergruende/datenschutzerklaerung`). That page currently lists `privacy@matomo.org` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.