### PR TITLE
Update Open Bank S.A.: email address changed

### DIFF
--- a/companies/openbank.json
+++ b/companies/openbank.json
@@ -10,7 +10,7 @@
     "name": "Open Bank S.A.",
     "address": "Plaza de Santa Bárbara 2\n28004 Madrid\nSpain",
     "phone": "+49 69 945189175",
-    "email": "datenschutz@openbank.com",
+    "email": "datenschutz@openbank.de",
     "web": "https://www.openbank.de/",
     "sources": [
         "https://www.openbank.de/datenschutzpolitik"


### PR DESCRIPTION
The registered address `datenschutz@openbank.com` no longer appears on the source page (`https://www.openbank.de/datenschutzpolitik`). That page currently lists `datenschutz@openbank.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.