### PR TITLE
Update openPetition gGmbH: email address changed

### DIFF
--- a/companies/openpetition-de.json
+++ b/companies/openpetition-de.json
@@ -8,7 +8,7 @@
     ],
     "name": "openPetition gGmbH",
     "address": "Greifswalder Str. 4\n10405 Berlin\nDeutschland",
-    "email": "datenschutz@openpetition.de",
+    "email": "datenschutz@openpetition.net",
     "web": "https://www.openpetition.de",
     "sources": [
         "https://www.openpetition.de/content/data_privacy"


### PR DESCRIPTION
The registered address `datenschutz@openpetition.de` no longer appears on the source page (`https://www.openpetition.de/content/data_privacy`). That page currently lists `datenschutz@openpetition.net` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.