### PR TITLE
Update Oskar.de GmbH: email address changed

### DIFF
--- a/companies/oskar-de.json
+++ b/companies/oskar-de.json
@@ -8,7 +8,7 @@
     ],
     "name": "Oskar.de GmbH",
     "address": "Greschbachstraße 6a\n76229 Karlsruhe\nDeutschland",
-    "email": "datenschutzanfragen@xdsb.de",
+    "email": "datenschutzbeauftragter@oskar.de",
     "web": "https://www.oskar.de/",
     "sources": [
         "https://www.oskar.de/datenschutz/",


### PR DESCRIPTION
The registered address `datenschutzanfragen@xdsb.de` no longer appears on the source page (`https://www.oskar.de/datenschutz/`). That page currently lists `datenschutzbeauftragter@oskar.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.