### PR TITLE
Update Otto GmbH & Co. KGaA: email address changed

### DIFF
--- a/companies/otto-handel.json
+++ b/companies/otto-handel.json
@@ -9,7 +9,7 @@
     "name": "Otto GmbH & Co. KGaA",
     "address": "20088 Hamburg\nDeutschland",
     "phone": "+49 40 36033603",
-    "email": "datenschutzauskunft@info.otto.de",
+    "email": "datenschutzbeauftragter@ottogroup.com",
     "web": "https://www.otto.de/",
     "sources": [
         "https://www.otto.de/service/datenschutz/",


### PR DESCRIPTION
The registered address `datenschutzauskunft@info.otto.de` no longer appears on the source page (`https://www.otto.de/service/datenschutz/`). That page currently lists `datenschutzbeauftragter@ottogroup.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.