### PR TITLE
Update Panasonic Marketing Europe GmbH: email address changed

### DIFF
--- a/companies/panasonic.json
+++ b/companies/panasonic.json
@@ -8,7 +8,7 @@
         "Panasonic Deutschland"
     ],
     "address": "Hagenauer Straße 43\n65203 Wiesbaden\nDeutschland",
-    "email": "data_protection@eu.panasonic.com",
+    "email": "dataprotection@domesticandgeneral.com",
     "web": "https://www.panasonic.com/de",
     "sources": [
         "https://www.panasonic.com/de/datenschutz.html",


### PR DESCRIPTION
The registered address `data_protection@eu.panasonic.com` no longer appears on the source page (`https://www.panasonic.com/de/datenschutz.html`). That page currently lists `dataprotection@domesticandgeneral.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.