### PR TITLE
Update PERX TECHNOLOGIES PTE LTD: email address changed

### DIFF
--- a/companies/perxtech.json
+++ b/companies/perxtech.json
@@ -9,7 +9,7 @@
     "name": "PERX TECHNOLOGIES PTE LTD",
     "address": "The Riverwalk\n20 Upper Circular Road\n#02-21B\nSingapore 058416\nSingapore",
     "phone": "+65 6816 2711",
-    "email": "dpo@getperx.com",
+    "email": "dpo@perxtech.com",
     "web": "https://www.perxtech.com",
     "sources": [
         "https://www.perxtech.com/privacy/#privacy",


### PR DESCRIPTION
The registered address `dpo@getperx.com` no longer appears on the source page (`https://www.perxtech.com/privacy/#privacy`). That page currently lists `dpo@perxtech.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.