### PR TITLE
Update Picnic Technologies B.V.: email address changed

### DIFF
--- a/companies/picnic-app-fr.json
+++ b/companies/picnic-app-fr.json
@@ -8,7 +8,7 @@
     ],
     "name": "Picnic Technologies B.V.",
     "address": "Van Marwijk Kooystraat 15\n1114 AG Amsterdam\nThe Netherlands",
-    "email": "service@picnic-app.fr",
+    "email": "dpo@picnic.nl",
     "web": "https://picnic.app/fr/",
     "sources": [
         "https://picnic.app/fr/politique-de-confidentialite/"


### PR DESCRIPTION
The registered address `service@picnic-app.fr` no longer appears on the source page (`https://picnic.app/fr/politique-de-confidentialite/`). That page currently lists `dpo@picnic.nl` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.