### PR TITLE
Update Polizei Berlin: email address changed

### DIFF
--- a/companies/polizei-berlin.json
+++ b/companies/polizei-berlin.json
@@ -9,7 +9,7 @@
     "name": "Polizei Berlin",
     "address": "Keibelstr. 36\n10178 Berlin\nDeutschland",
     "phone": "+49 30 46640",
-    "email": "justiziariat@polizei.berlin.de",
+    "email": "datenschutz@statistik-bbb.de",
     "web": "https://www.berlin.de/polizei/",
     "sources": [
         "https://www.berlin.de/polizei/datenschutzerklaerung.700498.php",


### PR DESCRIPTION
The registered address `justiziariat@polizei.berlin.de` no longer appears on the source page (`https://www.berlin.de/polizei/datenschutzerklaerung.700498.php`). That page currently lists `datenschutz@statistik-bbb.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.