### PR TITLE
Update posterXXL GmbH: email address changed

### DIFF
--- a/companies/posterxxl.json
+++ b/companies/posterxxl.json
@@ -7,7 +7,7 @@
     "address": "Infanteriestraße 11a\n80797 München\nDeutschland",
     "phone": "+49 89 36035915",
     "fax": "+49 180 6 806809",
-    "email": "service@posterxxl.de",
+    "email": "dpo@storiogroup.com",
     "web": "https://www.posterxxl.de/",
     "sources": [
         "https://www.posterxxl.de/datenschutzerklaerung",


### PR DESCRIPTION
The registered address `service@posterxxl.de` no longer appears on the source page (`https://www.posterxxl.de/datenschutzerklaerung`). That page currently lists `dpo@storiogroup.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.