### PR TITLE
Update comparado GmbH: email address changed

### DIFF
--- a/companies/preis-de.json
+++ b/companies/preis-de.json
@@ -10,7 +10,7 @@
     "address": "Auf der Hude 87\n21339 Lüneburg\nDeutschland",
     "phone": "+49 4131 9993280",
     "fax": "+49 4131 9993281",
-    "email": "datenschutz@comparado.de",
+    "email": "privacy@idealo.de",
     "web": "https://www.preis.de",
     "sources": [
         "https://www.preis.de/impressum/#datenschutz"


### PR DESCRIPTION
The registered address `datenschutz@comparado.de` no longer appears on the source page (`https://www.preis.de/impressum/#datenschutz`). That page currently lists `privacy@idealo.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.