### PR TITLE
Update PSD Bank Berlin-Brandenburg eG: email address changed

### DIFF
--- a/companies/psd-bb.json
+++ b/companies/psd-bb.json
@@ -10,7 +10,7 @@
     "address": "Handjerystr. 34–36\n12159 Berlin\nDeutschland",
     "phone": "+49 30 850820",
     "fax": "+49 30 85082239",
-    "email": "datenschutz@psd-bb.de",
+    "email": "datenschutz@bbbank.de",
     "web": "https://www.psd-berlin-brandenburg.de/",
     "sources": [
         "https://www.psd-berlin-brandenburg.de/service/rechtliche-hinweise/datenschutzhinweis-zur-website.html"


### PR DESCRIPTION
The registered address `datenschutz@psd-bb.de` no longer appears on the source page (`https://www.bbbank.de/datenschutzhinweis.html`). That page currently lists `datenschutz@bbbank.de` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #75.