### PR TITLE
Update Reise.de: email address changed

### DIFF
--- a/companies/reise-de.json
+++ b/companies/reise-de.json
@@ -9,7 +9,7 @@
     "name": "Reise.de",
     "address": "c/o Triplemind GmbH\nBerliner Straße 2\n63065 Offenbach am Main\nDeutschland",
     "phone": "+49 991 296767865",
-    "email": "datenschutz@triplemind.com",
+    "email": "datenschutz@reise.de",
     "web": "https://www.reise.de",
     "sources": [
         "https://www.reise.de/datenschutz/"


### PR DESCRIPTION
The registered address `datenschutz@triplemind.com` no longer appears on the source page (`https://www.reise.de/datenschutz/`). That page currently lists `datenschutz@reise.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.