### PR TITLE
Update Rocket.Chat Technologies Corp.: email address changed

### DIFF
--- a/companies/rocketchat.json
+++ b/companies/rocketchat.json
@@ -9,7 +9,7 @@
     ],
     "name": "Rocket.Chat Technologies Corp.",
     "address": "2711 Centerville Road\nSuite 400 Wilmington\nDE 19808\nUnited States of America",
-    "email": "privacy@rocket.chat",
+    "email": "privacy@rocket.chat.please",
     "web": "https://rocket.chat",
     "sources": [
         "https://rocket.chat/terms",


### PR DESCRIPTION
The registered address `privacy@rocket.chat` no longer appears on the source page (`https://rocket.chat/terms`). That page currently lists `privacy@rocket.chat.please` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.