### PR TITLE
Update RocketReach: email address changed

### DIFF
--- a/companies/rocketreach.json
+++ b/companies/rocketreach.json
@@ -10,7 +10,7 @@
     "name": "RocketReach",
     "address": "144 N 7th St\nPO #421\nBrooklyn, NY 11211\nUnited States of America",
     "phone": "+1 833 212 3828",
-    "email": "article27@verasafe.com",
+    "email": "privacy@rocketreach.co",
     "web": "https://rocketreach.co",
     "sources": [
         "https://rocketreach.co/privacy",


### PR DESCRIPTION
The registered address `article27@verasafe.com` no longer appears on the source page (`https://rocketreach.co/privacy`). That page currently lists `privacy@rocketreach.co` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.