### PR TITLE
Update Realschule Sidonienstraße Braunschweig: email address changed

### DIFF
--- a/companies/rs-sidonien-bs.json
+++ b/companies/rs-sidonien-bs.json
@@ -11,7 +11,7 @@
     "address": "Sidonienstraße 3\n38118 Braunschweig\nDeutschland",
     "phone": "+49 531 281242",
     "fax": "+49 531 2812426",
-    "email": "schulleitung.sidonien@rs-sidonien.de",
+    "email": "datenschutz@realschule-sidonienstrasse.de",
     "web": "http://www.rs-sidonien.de/",
     "sources": [
         "http://www.rs-sidonien.de/datenschutz/index.php",


### PR DESCRIPTION
The registered address `schulleitung.sidonien@rs-sidonien.de` no longer appears on the source page (`https://www.rs-sidonien.de/datenschutzerklaerung-teil-2/`). That page currently lists `datenschutz@realschule-sidonienstrasse.de` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #75.