### PR TITLE
Update Schober Information Group Deutschland GmbH: email address changed

### DIFF
--- a/companies/schober.json
+++ b/companies/schober.json
@@ -10,7 +10,7 @@
     "address": "Meisenweg 37\n70771 Leinfelden-Echterdingen\nDeutschland",
     "phone": "+49 7156 3040",
     "fax": "+49 7156 304369",
-    "email": "datenschutz@schober.de",
+    "email": "datenschutz@capaneo.de",
     "web": "https://schober.de",
     "sources": [
         "https://schober.de/datenschutz/",


### PR DESCRIPTION
The registered address `datenschutz@schober.de` no longer appears on the source page (`https://schober.de/datenschutz/`). That page currently lists `datenschutz@capaneo.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.