### PR TITLE
Update sheego: email address changed

### DIFF
--- a/companies/schwab-versand.json
+++ b/companies/schwab-versand.json
@@ -12,7 +12,7 @@
     ],
     "address": "c/o Josef Witt GmbH\nSchillerstraße 4 – 12\n92637 Weiden i.d.Opf.\nDeutschland",
     "phone": "+49 69 75005688",
-    "email": "service@sheego.de",
+    "email": "datenschutz@witt-weiden.de",
     "web": "https://www.sheego.de",
     "sources": [
         "https://www.sheego.de/content/datenschutzhinweise",


### PR DESCRIPTION
The registered address `service@sheego.de` no longer appears on the source page (`https://www.sheego.de/content/datenschutzhinweise`). That page currently lists `datenschutz@witt-weiden.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.