### PR TITLE
Update Seamless.AI: email address changed

### DIFF
--- a/companies/seamless.json
+++ b/companies/seamless.json
@@ -5,7 +5,7 @@
     ],
     "name": "Seamless.AI",
     "address": "c/o IT Governance Europe\nThe Mill Enterprise Hub\nSagreenan\nDrogheda\nCo. Louth\nA92 CD3D\nIreland",
-    "email": "eurep@itgovernance.eu",
+    "email": "privacy@seamlessleads.com",
     "webform": "https://login.seamless.ai/personalDataRequest",
     "web": "https://seamless.ai",
     "sources": [


### PR DESCRIPTION
The registered address `eurep@itgovernance.eu` no longer appears on the source page (`https://seamless.ai/policies/privacy-policy`). That page currently lists `privacy@seamlessleads.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.