### PR TITLE
Update SMTP2GO: email address changed

### DIFF
--- a/companies/smtp2go.json
+++ b/companies/smtp2go.json
@@ -9,7 +9,7 @@
     "name": "SMTP2GO",
     "address": "c/o Sand Dune Mail Ltd\n96-106 Manchester Street\nChristchurch 8011\nNew Zealand",
     "phone": "+64 3 668 5138",
-    "email": "ticket@smtp2go.com",
+    "email": "gdpr-badge@2x.png",
     "web": "https://www.smtp2go.com/",
     "sources": [
         "https://www.smtp2go.com/privacy/",


### PR DESCRIPTION
The registered address `ticket@smtp2go.com` no longer appears on the source page (`https://www.smtp2go.com/privacy/`). That page currently lists `gdpr-badge@2x.png` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.