### PR TITLE
Update Snap B.V.: email address changed

### DIFF
--- a/companies/snapchat.json
+++ b/companies/snapchat.json
@@ -14,7 +14,7 @@
         "Snap Inc."
     ],
     "address": "Keizersgracht 165\n1016 DP Amsterdam\nThe Netherlands",
-    "email": "dpo@snap.com",
+    "email": "dpo@snap.com.you",
     "web": "https://www.snap.com",
     "sources": [
         "https://values.snap.com/privacy/privacy-policy/eea-uk-privacy-notice",


### PR DESCRIPTION
The registered address `dpo@snap.com` no longer appears on the source page (`https://values.snap.com/privacy/privacy-policy/eea-uk-privacy-notice`). That page currently lists `dpo@snap.com.you` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.