### PR TITLE
Update Verband der Sparda-Banken e.V.: email address changed

### DIFF
--- a/companies/sparda-bank.json
+++ b/companies/sparda-bank.json
@@ -10,7 +10,7 @@
     "address": "Friedrich-Ebert-Anlage 35 – 37\n60327 Frankfurt am Main\nDeutschland",
     "phone": "+49 69 7920940",
     "fax": "+49 69 792094290",
-    "email": "datenschutz@sparda-verband.de",
+    "email": "datenschutz@atruvia.de",
     "web": "http://www.sparda.de/",
     "sources": [
         "http://www.sparda.de/datenschutz.php",


### PR DESCRIPTION
The registered address `datenschutz@sparda-verband.de` no longer appears on the source page (`https://sparda.de/apps-datenschutz/`). That page currently lists `datenschutz@atruvia.de` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #75.