### PR TITLE
Update Spezialitäten-Haus G. Schulteis GmbH: email address changed

### DIFF
--- a/companies/spezi-haus-de.json
+++ b/companies/spezi-haus-de.json
@@ -9,7 +9,7 @@
     ],
     "name": "Spezialitäten-Haus G. Schulteis GmbH",
     "address": "Bachstraße 22\n52066 Aachen\nDeutschland",
-    "email": "info@spezi-haus.de",
+    "email": "datenschutz@boniversum.de",
     "web": "https://www.spezi-haus.de",
     "sources": [
         "https://www.spezi-haus.de/datenschutzerklaerung",


### PR DESCRIPTION
The registered address `info@spezi-haus.de` no longer appears on the source page (`https://www.spezi-haus.de/datenschutzerklaerung`). That page currently lists `datenschutz@boniversum.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.