### PR TITLE
Update Verfasste Studierendenschaft der Johannes Gutenberg-Universität Mainz K.d.ö.R.: email address changed

### DIFF
--- a/companies/studierendenschaft-uni-mainz.json
+++ b/companies/studierendenschaft-uni-mainz.json
@@ -13,7 +13,7 @@
     ],
     "address": "Staudingerweg 21\n55128 Mainz\nDeutschland",
     "phone": "+49 6131 3924801",
-    "email": "datenschutz@asta.uni-mainz.de",
+    "email": "datenschutz@uni-mainz.de",
     "sources": [
         "https://asta.uni-mainz.de/2020/03/15/datenschutzerklaerung-hochschulgesetz/",
         "https://asta.uni-mainz.de/impressum/",


### PR DESCRIPTION
The registered address `datenschutz@asta.uni-mainz.de` no longer appears on the source page (`https://550jahre.uni-mainz.de/datenschutz/`). That page currently lists `datenschutz@uni-mainz.de` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #75.