### PR TITLE
Update Stuzubi GmbH: email address changed

### DIFF
--- a/companies/stuzubi.json
+++ b/companies/stuzubi.json
@@ -9,7 +9,7 @@
     "name": "Stuzubi GmbH",
     "address": "c/o blueDatex Health GmbH\nKantstr. 30\n10623 Berlin\nDeutschland",
     "phone": "+49 30 88712453",
-    "email": "kontakt@bluedatex.de",
+    "email": "datenschutzbeauftragter@datenschutzexperte.de",
     "web": "https://stuzubi.de",
     "sources": [
         "https://stuzubi.de/datenschutz/",


### PR DESCRIPTION
The registered address `kontakt@bluedatex.de` no longer appears on the source page (`https://stuzubi.de/datenschutz/`). That page currently lists `datenschutzbeauftragter@datenschutzexperte.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.