### PR TITLE
Update Süddeutsche Zeitung GmbH: email address changed

### DIFF
--- a/companies/sueddeutsche.json
+++ b/companies/sueddeutsche.json
@@ -14,7 +14,7 @@
     "address": "atarax Unternehmensgruppe\nLuitpold-Maier-Str. 7\n91074 Herzogenaurach\nDeutschland",
     "phone": "+49 9132 79800",
     "fax": "+49 89 21839777",
-    "email": "swmh-datenschutz@atarax.de",
+    "email": "datenschutz@sz.de",
     "web": "https://www.sueddeutsche.de",
     "sources": [
         "https://www.swmh-datenschutz.de/sz",


### PR DESCRIPTION
The registered address `swmh-datenschutz@atarax.de` no longer appears on the source page (`https://www.swmh-datenschutz.de/sz`). That page currently lists `datenschutz@sz.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.