### PR TITLE
Update SUPERSONIC STUDIOS Ltd.: email address changed

### DIFF
--- a/companies/supersonic-com.json
+++ b/companies/supersonic-com.json
@@ -9,7 +9,7 @@
     "name": "SUPERSONIC STUDIOS Ltd.",
     "address": "121 Menachem Begin Rd.\nTel Aviv\nIsrael",
     "phone": "+1 888 835 5392",
-    "email": "dpo@ironsrc.com",
+    "email": "dpo@unity3d.com",
     "web": "https://supersonic.com/",
     "sources": [
         "https://supersonic.com/privacy-policy/",


### PR DESCRIPTION
The registered address `dpo@ironsrc.com` no longer appears on the source page (`https://supersonic.com/privacy-policy/`). That page currently lists `dpo@unity3d.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.