### PR TITLE
Update Swapfiets Spain S.l.: email address changed

### DIFF
--- a/companies/swapfiets-es.json
+++ b/companies/swapfiets-es.json
@@ -6,7 +6,7 @@
     "name": "Swapfiets Spain S.l.",
     "address": "Carrer De Marià Cubí 7\n08006 Barcelona\nSpain",
     "phone": "+34 932 20 23 71",
-    "email": "privacy@swapfiets.com",
+    "email": "privacy@pon.com",
     "web": "https://swapfiets.es/",
     "sources": [
         "https://swapfiets.es/en-ES/privacy",


### PR DESCRIPTION
The registered address `privacy@swapfiets.com` no longer appears on the source page (`https://swapfiets.es/en-ES/privacy`). That page currently lists `privacy@pon.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.