### PR TITLE
Update Swapfiets B.V.: email address changed

### DIFF
--- a/companies/swapfiets-nl.json
+++ b/companies/swapfiets-nl.json
@@ -6,7 +6,7 @@
     "name": "Swapfiets B.V.",
     "address": "Amsteldijk 216\n1079 LK Amsterdam\nThe Netherlands",
     "phone": "+31 88 991 1600",
-    "email": "privacy@swapfiets.nl",
+    "email": "privacy@pon.com",
     "web": "https://swapfiets.nl/",
     "sources": [
         "https://swapfiets.nl/en-NL/privacy",


### PR DESCRIPTION
The registered address `privacy@swapfiets.nl` no longer appears on the source page (`https://swapfiets.nl/en-NL/privacy`). That page currently lists `privacy@pon.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.