### PR TITLE
Update Communication Services Tele2 GmbH: email address changed

### DIFF
--- a/companies/tele2.json
+++ b/companies/tele2.json
@@ -7,7 +7,7 @@
     "address": "In der Steele 39\n40599 Düsseldorf\nDeutschland",
     "phone": "+49 211 40824082",
     "fax": "+49 211 40824093",
-    "email": "datenschutz@tele2.com",
+    "email": "datenschutz@amiva.de",
     "web": "https://www.tele2.de/",
     "sources": [
         "https://www.tele2.de/Unternehmen/Datenschutz",


### PR DESCRIPTION
The registered address `datenschutz@tele2.com` no longer appears on the source page (`https://www.tele2.de/Unternehmen/Datenschutz`). That page currently lists `datenschutz@amiva.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.