### PR TITLE
Update Thomson Reuters (Professional) UK Ltd.: email address changed

### DIFF
--- a/companies/thomsonreuters.json
+++ b/companies/thomsonreuters.json
@@ -30,7 +30,7 @@
     ],
     "address": "30 South Colonnade-Canary Wharf\nLondon\nE14 5EP\nUnited Kingdom",
     "phone": "+44 20 7250 1122",
-    "email": "privacy.enquiries@tr.com",
+    "email": "privacy.issues@thomsonreuters.com",
     "webform": "https://privacyportal-cdn.onetrust.com/dsarwebform/dbf5ae8a-0a6a-4f4b-b527-7f94d0de6bbc/5dc91c0f-f1b7-4b6e-9d42-76043adaf72d.html",
     "web": "https://reuters.com",
     "sources": [


### PR DESCRIPTION
The registered address `privacy.enquiries@tr.com` no longer appears on the source page (`https://www.thomsonreuters.com/en/privacy-statement.html`). That page currently lists `privacy.issues@thomsonreuters.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.