### PR TITLE
Update Tibber Deutschland GmbH: email address changed

### DIFF
--- a/companies/tibber-de.json
+++ b/companies/tibber-de.json
@@ -8,7 +8,7 @@
     ],
     "name": "Tibber Deutschland GmbH",
     "address": "Strelitzer Str. 60\n10115 Berlin\nDeutschland",
-    "email": "hello@tibber.com",
+    "email": "datenschutzbeauftragter@datenschutzexperte.de",
     "sources": [
         "https://tibber.com/de/datenschutzerklarung/tibber-deutschland",
         "https://tibber.com/de/datenschutzerklarung/ihre-rechte",


### PR DESCRIPTION
The registered address `hello@tibber.com` no longer appears on the source page (`https://tibber.com/de/datenschutzerklarung/tibber-deutschland`). That page currently lists `datenschutzbeauftragter@datenschutzexperte.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.