### PR TITLE
Update Ticketcounter BV: email address changed

### DIFF
--- a/companies/ticketcounter-nl.json
+++ b/companies/ticketcounter-nl.json
@@ -9,7 +9,7 @@
     "name": "Ticketcounter BV",
     "address": "Van Nelleweg 1404\n3044 BC Rotterdam\nThe Netherlands",
     "phone": "+31 10 751 6400",
-    "email": "info@ticketcounter.nl",
+    "email": "fg@ticketcounter.eu",
     "web": "https://ticketcounter.nl/",
     "sources": [
         "https://ticketcounter.nl/privacy/",


### PR DESCRIPTION
The registered address `info@ticketcounter.nl` no longer appears on the source page (`https://ticketcounter.nl/privacy-verklaring/`). That page currently lists `fg@ticketcounter.eu` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #75.