### PR TITLE
Update Treatwell DACH GmbH: email address changed

### DIFF
--- a/companies/treatwell-dach.json
+++ b/companies/treatwell-dach.json
@@ -10,7 +10,7 @@
     ],
     "name": "Treatwell DACH GmbH",
     "address": "Greifswalder Str. 212\n10405 Berlin\nDeutschland",
-    "email": "koenigkunde@treatwell.de",
+    "email": "dpo@treatwell.com",
     "web": "https://www.treatwell.de",
     "sources": [
         "https://www.treatwell.de/info/datenschutz/",


### PR DESCRIPTION
The registered address `koenigkunde@treatwell.de` no longer appears on the source page (`https://www.treatwell.de/info/datenschutz/`). That page currently lists `dpo@treatwell.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.