### PR TITLE
Update trend.test Gesellschaft für telefonische Datenerhebung mbH: email address changed

### DIFF
--- a/companies/trendtest.json
+++ b/companies/trendtest.json
@@ -6,7 +6,7 @@
     "name": "trend.test Gesellschaft für telefonische Datenerhebung mbH",
     "address": "Kolonnenstr. 26\n10829 Berlin\nDeutschland",
     "phone": "+49 89 996001850",
-    "email": "datenschutz@ipsos.de",
+    "email": "dpo.germany@ipsos.com",
     "web": "https://www.trendtest.de",
     "sources": [
         "https://www.trendtest.de/datenschutzerklaerung/",


### PR DESCRIPTION
The registered address `datenschutz@ipsos.de` no longer appears on the source page (`https://www.trendtest.de/datenschutzerklaerung/`). That page currently lists `dpo.germany@ipsos.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.