### PR TITLE
Update TravelScout24.de: email address changed

### DIFF
--- a/companies/triplemind.json
+++ b/companies/triplemind.json
@@ -9,7 +9,7 @@
     "name": "TravelScout24.de",
     "address": "c/o Triplemind GmbH\nBerliner Strasse 2\n63065 Offenbach am Main\nDeutschland",
     "phone": "+49 991 296767867",
-    "email": "datenschutz@triplemind.com",
+    "email": "datenschutz@travelscout24.de",
     "web": "https://www.travelscout24.de",
     "sources": [
         "https://www.travelscout24.de/datenschutz/"


### PR DESCRIPTION
The registered address `datenschutz@triplemind.com` no longer appears on the source page (`https://www.travelscout24.de/datenschutz/`). That page currently lists `datenschutz@travelscout24.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.