### PR TITLE
Update Umzugsauktion GmbH & Co. KG: email address changed

### DIFF
--- a/companies/umzugsauktion-de.json
+++ b/companies/umzugsauktion-de.json
@@ -10,7 +10,7 @@
     "address": "Frohmattenstraße 2b\n79268 Bötzingen\nDeutschland",
     "phone": "+49 7663 91430",
     "fax": "+49 7663 9143166",
-    "email": "datenschutzbeauftragter@umzugauktion.de",
+    "email": "datenschutzbeauftragter@umzugspreisvergleich.de",
     "web": "https://www.umzugsauktion.de/",
     "sources": [
         "https://www.umzugsauktion.de/datenschutz/"


### PR DESCRIPTION
The registered address `datenschutzbeauftragter@umzugauktion.de` no longer appears on the source page (`https://www.umzugsauktion.de/datenschutz/`). That page currently lists `datenschutzbeauftragter@umzugspreisvergleich.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.