### PR TITLE
Update UNIVERSUM Business GmbH: email address changed

### DIFF
--- a/companies/universum-business.json
+++ b/companies/universum-business.json
@@ -10,7 +10,7 @@
     "address": "Hanauer Landstraße 164\n60314 Frankfurt am Main\nDeutschland",
     "phone": "+49 69 42091325",
     "fax": "+49 69 42091353",
-    "email": "datenschutz@universum-group.de",
+    "email": "datenschutz@universum-inkasso.de",
     "webform": "https://www.universum-group.de/datenschutz/selbstauskunft/",
     "web": "https://www.universum-group.de",
     "sources": [


### PR DESCRIPTION
The registered address `datenschutz@universum-group.de` no longer appears on the source page (`https://www.universum-group.de/datenschutz/`). That page currently lists `datenschutz@universum-inkasso.de` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.