### PR TITLE
Update Viessmann Climate Solutions SE: email address changed

### DIFF
--- a/companies/viessmann.json
+++ b/companies/viessmann.json
@@ -11,7 +11,7 @@
     "address": "Viessmannstraße 1\n35108 Allendorf (Eder)\nGermany",
     "phone": "+49 6452 700",
     "fax": "+49 6452 702780",
-    "email": "datenschutz@viessmann.com",
+    "email": "datenschutz@viessmann-climatesolutions.com",
     "web": "https://www.viessmann.de/",
     "sources": [
         "https://www.viessmann.de/de/datenschutzerklaerung.html",


### PR DESCRIPTION
The registered address `datenschutz@viessmann.com` no longer appears on the source page (`https://www.viessmann.de/de/datenschutzerklaerung.html`). That page currently lists `datenschutz@viessmann-climatesolutions.com` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.