### PR TITLE
Update Vonmählen GmbH: email address changed

### DIFF
--- a/companies/vonmaehlen.json
+++ b/companies/vonmaehlen.json
@@ -9,7 +9,7 @@
     "name": "Vonmählen GmbH",
     "address": "Vor dem Bardowicker Tore 49\n21339 Lüneburg\nDeutschland",
     "phone": "+49 4131 2209577",
-    "email": "datenschutz@vonmaehlen.com",
+    "email": "thomas.sessner@d-iso.com",
     "web": "https://www.vonmaehlen.com",
     "sources": [
         "https://www.vonmaehlen.com/custom/index/sCustom/107",


### PR DESCRIPTION
The registered address `datenschutz@vonmaehlen.com` no longer appears on the source page (`https://vonmaehlen.com/policies/privacy-policy`). That page currently lists `thomas.sessner@d-iso.com` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #75.