### PR TITLE
Update Wallis Online Ltd.: email address changed

### DIFF
--- a/companies/wallis.json
+++ b/companies/wallis.json
@@ -8,7 +8,7 @@
     ],
     "name": "Wallis Online Ltd.",
     "address": "49-51 Dale Street\nManchester\nM1 2HF\nUnited Kingdom",
-    "email": "DPO@wallis.com",
+    "email": "dpo@debenhams.co.uk",
     "web": "http://www.wallis.co.uk",
     "sources": [
         "https://www.wallis.co.uk/page/cs-privacy-policy.html"


### PR DESCRIPTION
The registered address `DPO@wallis.com` no longer appears on the source page (`https://www.wallis.co.uk/page/cs-privacy-policy.html`). That page currently lists `dpo@debenhams.co.uk` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.