### PR TITLE
Update WINDATEN: email address changed

### DIFF
--- a/companies/windaten.json
+++ b/companies/windaten.json
@@ -9,7 +9,7 @@
     "name": "WINDATEN",
     "address": "Nelkenstraße 2\n71723 Großbottwar\nDeutschland",
     "phone": "+49 7148 1637171",
-    "email": "info@win-daten.de",
+    "email": "dpo@wordpress.org",
     "web": "https://win-daten.de/",
     "sources": [
         "https://win-daten.de/datenschutz",


### PR DESCRIPTION
The registered address `info@win-daten.de` no longer appears on the source page (`https://win-daten.de/datenschutz`). That page currently lists `dpo@wordpress.org` as the privacy contact (fast scan).

Found and verified by the Privacy Engine optimizer, run #68.