### PR TITLE
Update „Alternative für Deutschland“ Mecklenburg-Vorpommern: email address changed

### DIFF
--- a/companies/afd-mv.json
+++ b/companies/afd-mv.json
@@ -10,7 +10,7 @@
     "address": "Woldegker Straße 27\n17033 Neubrandenburg\nDeutschland",
     "phone": "+49 395 36967312",
     "fax": "+49 395 36967313",
-    "email": "datenschutz@afd-mv.de",
+    "email": "datenschutzbeauftragter@afd-mv.de",
     "web": "https://afd-mv.de",
     "sources": [
         "https://afd-mv.de/partei/geschaeftsstelle/",


### PR DESCRIPTION
The registered address `datenschutz@afd-mv.de` no longer appears on the source page (`None`). That page currently lists `datenschutzbeauftragter@afd-mv.de` as the privacy contact (claude scan).

Found and verified by the Privacy Engine optimizer, run #70.