### PR TITLE
Update Jimdo GmbH: email address changed

### DIFF
--- a/companies/jimdo.json
+++ b/companies/jimdo.json
@@ -10,7 +10,7 @@
     "address": "Stresemannstraße 375\n22761 Hamburg\nDeutschland",
     "phone": "+49 40 82244997",
     "fax": "+49 40 82244998",
-    "email": "datenschutz@jimdo.com",
+    "email": "privacy@jimdo.com",
     "web": "https://jimdo.com/",
     "sources": [
         "https://de.jimdo.com/info/datenschutzerklaerung/",


### PR DESCRIPTION
The registered address `datenschutz@jimdo.com` no longer appears on the source page (`None`). That page currently lists `privacy@jimdo.com` as the privacy contact (claude scan).

Found and verified by the Privacy Engine optimizer, run #76.