### PR TITLE
Update Jumio Corporation: email address changed

### DIFF
--- a/companies/jumio.json
+++ b/companies/jumio.json
@@ -8,7 +8,7 @@
         "Netverify"
     ],
     "address": "395 Page Mill Road, Suite 150\nPalo Alto, CA 94306\nUnited States of America",
-    "email": "privacy@jumio.com",
+    "email": "dpo@jumio.com",
     "web": "https://www.jumio.com",
     "sources": [
         "https://www.jumio.com/legal-information/privacy-policy/jumio-corp-privacy-policy-for-online-services/",


### PR DESCRIPTION
The registered address `privacy@jumio.com` no longer appears on the source page (`None`). That page currently lists `dpo@jumio.com` as the privacy contact (claude scan).

Found and verified by the Privacy Engine optimizer, run #76.