### PR TITLE
Update Deutsche Lufthansa AG: email address changed

### DIFF
--- a/companies/lufthansa.json
+++ b/companies/lufthansa.json
@@ -11,7 +11,7 @@
     ],
     "address": "FRA CJ/D\n60546 Frankfurt\nDeutschland",
     "phone": "+49 69 86799799",
-    "email": "datenauskunft@dlh.de",
+    "email": "datenschutz@dlh.de",
     "web": "https://www.lufthansa.com",
     "sources": [
         "https://www.lufthansa.com/de/de/Informationen-zum-Datenschutz",


### PR DESCRIPTION
The registered address `datenauskunft@dlh.de` no longer appears on the source page (`None`). That page currently lists `datenschutz@dlh.de` as the privacy contact (claude scan).

Found and verified by the Privacy Engine optimizer, run #76.