### PR TITLE
Update Marriott International, Inc.: email address changed

### DIFF
--- a/companies/marriott.json
+++ b/companies/marriott.json
@@ -8,7 +8,7 @@
     ],
     "name": "Marriott International, Inc.",
     "address": "c/o Luxury Reservations Limited\n10 Earlsfort Terrace\nDublin D02 T380\nIreland",
-    "email": "privacy@marriott.com",
+    "email": "marriottdpo@marriott.com",
     "webform": "https://privacyportal-cdn.onetrust.com/dsarwebform/0894cd2c-85ba-4d0b-8ec1-e18f3735e0e0/e4eef8ab-3071-4679-a374-5847fbe290de.html",
     "web": "https://www.marriott.com/",
     "sources": [


### PR DESCRIPTION
The registered address `privacy@marriott.com` no longer appears on the source page (`None`). That page currently lists `marriottdpo@marriott.com` as the privacy contact (claude scan).

Found and verified by the Privacy Engine optimizer, run #76.