### PR TITLE
Update Namecheap Inc.: email address changed

### DIFF
--- a/companies/namecheap.json
+++ b/companies/namecheap.json
@@ -8,7 +8,7 @@
     ],
     "name": "Namecheap Inc.",
     "address": "4600 East Washington Street\nSuite 305\nPhoenix\nAZ 85034\nUnited States of America",
-    "email": "legal@namecheap.com",
+    "email": "dpo@namecheap.com",
     "web": "https://www.namecheap.com/",
     "sources": [
         "https://www.namecheap.com/legal/general/privacy-policy.aspx",


### PR DESCRIPTION
The registered address `legal@namecheap.com` no longer appears on the source page (`None`). That page currently lists `dpo@namecheap.com` as the privacy contact (claude scan).

Found and verified by the Privacy Engine optimizer, run #76.