### PR TITLE
Update nepatec GmbH: email address changed

### DIFF
--- a/companies/nepatec.json
+++ b/companies/nepatec.json
@@ -11,7 +11,7 @@
     "address": "Seelhorststraße 44\n30175 Hannover\nDeutschland",
     "phone": "+49 511 93594651",
     "fax": "+49 511 93594657",
-    "email": "datenschutz@nepatec.de",
+    "email": "info@nepatec.de",
     "web": "https://www.nepatec.de",
     "sources": [
         "https://www.nepatec.de/j/privacy",


### PR DESCRIPTION
The registered address `datenschutz@nepatec.de` no longer appears on the source page (`None`). That page currently lists `info@nepatec.de` as the privacy contact (claude scan).

Found and verified by the Privacy Engine optimizer, run #76.