### PR TITLE
Update Personio GmbH: email address changed

### DIFF
--- a/companies/personio-gmbh.json
+++ b/companies/personio-gmbh.json
@@ -8,7 +8,7 @@
     ],
     "name": "Personio GmbH",
     "address": "Rundfunkplatz 4\n80335 München\nDeutschland",
-    "email": "datenschutz@personio.de",
+    "email": "privacy@personio.com",
     "sources": [
         "https://www.personio.de/datenschutzerklaerung/",
         "https://github.com/datenanfragen/data/pull/1147"


### PR DESCRIPTION
The registered address `datenschutz@personio.de` no longer appears on the source page (`None`). That page currently lists `privacy@personio.com` as the privacy contact (claude scan).

Found and verified by the Privacy Engine optimizer, run #76.