### PR TITLE
Update Read It Later, Inc.: email address changed

### DIFF
--- a/companies/pocket.json
+++ b/companies/pocket.json
@@ -11,7 +11,7 @@
         "Pocket (getpocket.com)"
     ],
     "address": "233 Sansome\nSuite 1200\nSan Francisco\nCA 94104\nUnited States of America",
-    "email": "privacy@getpocket.com",
+    "email": "legal@getpocket.com",
     "web": "https://getpocket.com/",
     "sources": [
         "https://getpocket.com/privacy"


### PR DESCRIPTION
The registered address `privacy@getpocket.com` no longer appears on the source page (`None`). That page currently lists `legal@getpocket.com` as the privacy contact (claude scan).

Found and verified by the Privacy Engine optimizer, run #76.