### PR TITLE
Update The Rubicon Project Ltd.: email address changed

### DIFF
--- a/companies/rubiconproject.json
+++ b/companies/rubiconproject.json
@@ -12,7 +12,7 @@
     ],
     "address": "Walmar House\n5th Floor\n296 Regent St.\nLondon\nW1B 3HR\nUnited Kingdom",
     "phone": "+44 20 3206 2400",
-    "email": "privacy@rubiconproject.com",
+    "email": "dpo@rubiconproject.com",
     "web": "https://rubiconproject.com/",
     "sources": [
         "https://rubiconproject.com/privacy/",


### PR DESCRIPTION
The registered address `privacy@rubiconproject.com` no longer appears on the source page (`None`). That page currently lists `dpo@rubiconproject.com` as the privacy contact (claude scan).

Found and verified by the Privacy Engine optimizer, run #76.