### PR TITLE
Update Sirius Inkasso GmbH: email address changed

### DIFF
--- a/companies/sirius-inkasso.json
+++ b/companies/sirius-inkasso.json
@@ -7,7 +7,7 @@
     "address": "Werdener Straße 4\n40227 Düsseldorf\nDeutschland",
     "phone": "+49 221 882910",
     "fax": "+49 221 882911333",
-    "email": "siriusinfo@gfkl.com",
+    "email": "datenschutz.sirius@lowellgroup.de",
     "web": "http://www.sirius-inkasso.de/",
     "sources": [
         "http://www.sirius-inkasso.de/impressum/"


### PR DESCRIPTION
The registered address `siriusinfo@gfkl.com` no longer appears on the source page (`None`). That page currently lists `datenschutz.sirius@lowellgroup.de` as the privacy contact (claude scan).

Found and verified by the Privacy Engine optimizer, run #76.