### PR TITLE
Update Aspiro AB: email address changed

### DIFF
--- a/companies/tidal.json
+++ b/companies/tidal.json
@@ -11,7 +11,7 @@
         "TIDAL"
     ],
     "address": "540 W 26th Street, 8th Floor\nNew York, NY 10001\nUnited States of America",
-    "email": "support@tidal.com",
+    "email": "dataprotectionofficer@tidal.com",
     "web": "https://tidal.com/",
     "sources": [
         "https://tidal.com/privacy",


### PR DESCRIPTION
The registered address `support@tidal.com` no longer appears on the source page (`None`). That page currently lists `dataprotectionofficer@tidal.com` as the privacy contact (claude scan).

Found and verified by the Privacy Engine optimizer, run #76.