### PR TITLE
Update Trading 212 Ltd: email address changed

### DIFF
--- a/companies/trading212.json
+++ b/companies/trading212.json
@@ -14,7 +14,7 @@
     ],
     "address": "3 Lachezar Stanchev Str.\nLitex Tower, floor 10\nSofia 1797\nBulgaria",
     "phone": "+359 800 46 049",
-    "email": "dpo@trading212.com",
+    "email": "dpo.uk@trading212.com",
     "web": "https://trading212.com",
     "sources": [
         "https://www.trading212.com/legal-documentation/privacy-policy-cy",


### PR DESCRIPTION
The registered address `dpo@trading212.com` no longer appears on the source page (`None`). That page currently lists `dpo.uk@trading212.com` as the privacy contact (claude scan).

Found and verified by the Privacy Engine optimizer, run #76.