### PR TITLE
Update ZOXS GmbH: email address changed

### DIFF
--- a/companies/zoxs.json
+++ b/companies/zoxs.json
@@ -10,7 +10,7 @@
     "address": "Am Schornacker 51\n46485 Wesel\nDeutschland",
     "phone": "+49 281 16397999",
     "fax": "+49 281 16397997",
-    "email": "verkaufen@zoxs.de",
+    "email": "info@n-inf.de",
     "web": "https://www.zoxs.de",
     "sources": [
         "https://www.zoxs.de/datenschutz.html",


### PR DESCRIPTION
The registered address `verkaufen@zoxs.de` no longer appears on the source page (`None`). That page currently lists `info@n-inf.de` as the privacy contact (claude scan).

Found and verified by the Privacy Engine optimizer, run #76.