### PR TITLE
Update Gameforge AG: email address changed

### DIFF
--- a/companies/gameforge.json
+++ b/companies/gameforge.json
@@ -15,7 +15,7 @@
     "address": "Albert-Nestler-Straße 8\n76131 Karlsruhe\nGermany",
     "phone": "+49 721 3548080",
     "fax": "+49 721 354808159",
-    "email": "datenschutz@gameforge.com",
+    "email": "info@gameforge.com",
     "web": "https://corporate.gameforge.com",
     "sources": [
         "https://agbserver.gameforge.com/enGB-Privacy-Gameforge-AG.html",


### PR DESCRIPTION
The registered address `datenschutz@gameforge.com` no longer appears on the source page (`https://corporate.gameforge.com/privacy-policy`). That page currently lists `info@gameforge.com` as the privacy contact (screenshot scan).

Found and verified by the Privacy Engine optimizer, run #78.