### PR TITLE
Update Grundschule Lamme Braunschweig: email address changed

### DIFF
--- a/companies/gs-lamme-bs.json
+++ b/companies/gs-lamme-bs.json
@@ -11,7 +11,7 @@
     "address": "Lammer Heide 9\n38116 Braunschweig\nDeutschland",
     "phone": "+49 531 5160759",
     "fax": "+49 531 5168665",
-    "email": "gs.lamme@braunschweig.de",
+    "email": "datenschutz@braunschweig.de",
     "web": "https://www.gs-lamme.de/",
     "sources": [
         "https://www.braunschweig.de/leben/schule_bildung/schulportal/schulen/schulen/gs-lamme.html"


### PR DESCRIPTION
The registered address `gs.lamme@braunschweig.de` no longer appears on the source page (`https://wordpress.nibis.de/gslamme/files/2024/10/Datenschutzblatt-Annahme-und-Vermittlung-von-Zuwendungen-1.pdf`). That page currently lists `datenschutz@braunschweig.de` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #78.