### PR TITLE
Update Kirchengemeinde Büddenstedt: email address changed

### DIFF
--- a/companies/kirchengemeinde-bueddenstedt.json
+++ b/companies/kirchengemeinde-bueddenstedt.json
@@ -10,7 +10,7 @@
     "address": "Niedernstraße 47\n38364 Schöningen\nDeutschland",
     "phone": "+49 5352 4764",
     "fax": "+49 5352 4745",
-    "email": "helmstedt-sued.pfa@lk-bs.de",
+    "email": "datenschutz@lk-bs.de",
     "web": "http://www.kirchengemeinde-bueddenstedt.de/",
     "sources": [
         "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=815"


### PR DESCRIPTION
The registered address `helmstedt-sued.pfa@lk-bs.de` no longer appears on the source page (`https://kirchengemeinde-bueddenstedt.de/service/datenschutz`). That page currently lists `datenschutz@lk-bs.de` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #78.