### PR TITLE
Update Kirchengemeinde St. Antonius Hasselfelde: email address changed

### DIFF
--- a/companies/kirchengemeinde-st-antonius-hasselfelde.json
+++ b/companies/kirchengemeinde-st-antonius-hasselfelde.json
@@ -10,7 +10,7 @@
     "address": "Blumenaustraße 7\n38899 Oberharz am Brocken\nDeutschland",
     "phone": "+49 39459 71371",
     "fax": "+49 39459 18845",
-    "email": "hasselfelde.buero@lk-bs.de",
+    "email": "datenschutz@lk-bs.de",
     "web": "http://www.hasselfelde-evangelisch.de/",
     "sources": [
         "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=722"


### PR DESCRIPTION
The registered address `hasselfelde.buero@lk-bs.de` no longer appears on the source page (`https://hasselfelde-evangelisch.de/service/datenschutz`). That page currently lists `datenschutz@lk-bs.de` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #78.