### PR TITLE
Update Kirchengemeinde St. Georg Calvörde: email address changed

### DIFF
--- a/companies/kirchengemeinde-st-georg-calvoerde.json
+++ b/companies/kirchengemeinde-st-georg-calvoerde.json
@@ -10,7 +10,7 @@
     "address": "An der Kirche 1\n39359 Calvörde\nDeutschland",
     "phone": "+49 39051 259",
     "fax": "+49 39051 98225",
-    "email": "calvoerde.pfa@lk-bs.de",
+    "email": "datenschutz@lk-bs.de",
     "web": "https://www.pfarrverband-calvoerde-uthmoeden.de/",
     "sources": [
         "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1023"


### PR DESCRIPTION
The registered address `calvoerde.pfa@lk-bs.de` no longer appears on the source page (`https://pfarrverband-calvoerde-uthmoeden.de/service/datenschutz`). That page currently lists `datenschutz@lk-bs.de` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #78.