### PR TITLE
Update Kirchengemeinde St. Markus Reislingen-Neuhaus in Wolfsburg: email address changed

### DIFF
--- a/companies/kirchengemeinde-st-markus-reislingen-neuhaus-in-wolfsburg.json
+++ b/companies/kirchengemeinde-st-markus-reislingen-neuhaus-in-wolfsburg.json
@@ -10,7 +10,7 @@
     "address": "Kantor-Wurm-Straße 1\n38446 Wolfsburg\nDeutschland",
     "phone": "+49 5363 4134",
     "fax": "+49 5363 1887",
-    "email": "markus-reislingen.buero@lk-bs.de",
+    "email": "datenschutz@lk-bs.de",
     "web": "http://www.kirche-reislingen-neuhaus.de/",
     "sources": [
         "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=1044"


### PR DESCRIPTION
The registered address `markus-reislingen.buero@lk-bs.de` no longer appears on the source page (`https://kirche-reislingen-neuhaus.de/service/datenschutz`). That page currently lists `datenschutz@lk-bs.de` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #78.