### PR TITLE
Update Piraeus Bank S.A.: email address changed

### DIFF
--- a/companies/piraeusbank.json
+++ b/companies/piraeusbank.json
@@ -9,7 +9,7 @@
     "name": "Piraeus Bank S.A.",
     "address": "4 Ameriki Street\n10564 Athens\nGreece",
     "phone": "+30 21 0328 8000",
-    "email": "DPOOffice@piraeusbank.gr",
+    "email": "PiraeusbankDPOOffice@piraeusbank.gr",
     "web": "https://www.piraeusbank.gr/",
     "sources": [
         "https://www.piraeusbank.gr/-/jssmedia/Project/Piraeus/PiraeusBank/shared/Files/PiraeusBank/support/gdpr/DPO-en.pdf",


### PR DESCRIPTION
The registered address `DPOOffice@piraeusbank.gr` no longer appears on the source page (`https://www.piraeusbank.gr/el/support/gdpr`). That page currently lists `PiraeusbankDPOOffice@piraeusbank.gr` as the privacy contact (screenshot scan).

Found and verified by the Privacy Engine optimizer, run #78.