### PR TITLE
Update Propstei Wolfenbüttel: email address changed

### DIFF
--- a/companies/propstei-wolfenbuettel.json
+++ b/companies/propstei-wolfenbuettel.json
@@ -10,7 +10,7 @@
     "address": "Neuer Weg 90\n38302 Wolfenbüttel\nDeutschland",
     "phone": "+49 5331 972830",
     "fax": "+49 5331 972838",
-    "email": "wolfenbuettel.pr@lk-bs.de",
+    "email": "datenschutz@lk-bs.de",
     "web": "http://www.propstei-wf.de/",
     "sources": [
         "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/wolfenbuettel.html"


### PR DESCRIPTION
The registered address `wolfenbuettel.pr@lk-bs.de` no longer appears on the source page (`https://propstei-wf.de/service/datenschutz`). That page currently lists `datenschutz@lk-bs.de` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #78.