### PR TITLE
Update Renault Deutschland AG: email address changed

### DIFF
--- a/companies/renault-de.json
+++ b/companies/renault-de.json
@@ -10,7 +10,7 @@
     "address": "Renault Nissan Straße 6 - 10\n50321 Brühl\nDeutschland",
     "phone": "+49 2232 730",
     "fax": "+49 2232 739226",
-    "email": "datenschutzbeauftragter.deutschland@renault.de",
+    "email": "datenschutz.deutschland@renault.de",
     "web": "https://www.renault.de",
     "quality": "verified",
     "sources": [


### PR DESCRIPTION
The registered address `datenschutzbeauftragter.deutschland@renault.de` no longer appears on the source page (`https://www.renault.de/datenschutz.html`). That page currently lists `datenschutz.deutschland@renault.de` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #78.