### PR TITLE
Update FAX.de GmbH & Co.KG: email address changed

### DIFF
--- a/companies/fax.json
+++ b/companies/fax.json
@@ -13,7 +13,7 @@
     ],
     "address": "c/o ZiDa-Datenschutz GmbH\nWaldhofer Str. 102\n69123 Heidelberg\nDeutschland",
     "phone": "+49 621 30696731",
-    "email": "e.zimmermann@zida-datenschutz.de",
+    "email": "e.zimmermann@zida-gmbh.de",
     "web": "https://www.fax.de",
     "sources": [
         "https://www.fax.de/de/datenschutz.html",


### PR DESCRIPTION
The registered address `e.zimmermann@zida-datenschutz.de` no longer appears on the source page (`https://www.fax.de/de/datenschutz.html`). That page currently lists `e.zimmermann@zida-gmbh.de` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #78.