### PR TITLE
Update FIL Fondsbank GmbH: email address changed

### DIFF
--- a/companies/fidelity-de.json
+++ b/companies/fidelity-de.json
@@ -13,7 +13,7 @@
     "address": "Postfach 11 06 63\n60041 Frankfurt am Main\nDeutschland",
     "phone": "+49 6173 5091923",
     "fax": "+49 6173 5094199",
-    "email": "info@fidelity.de",
+    "email": "skuhn@pohlmann-company.com",
     "web": "https://www.fidelity.de",
     "sources": [
         "https://www.fidelity.de/datenschutzhinweise/",


### PR DESCRIPTION
The registered address `info@fidelity.de` no longer appears on the source page (`https://www.fidelity.de/datenschutzhinweise/`). That page currently lists `skuhn@pohlmann-company.com` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #78.