### PR TITLE
Update Grundschule Am Schwarzen Berge Braunschweig: email address changed

### DIFF
--- a/companies/gsasberg-bs.json
+++ b/companies/gsasberg-bs.json
@@ -11,7 +11,7 @@
     "address": "Am Schwarzen Berge 73\n38112 Braunschweig\nDeutschland",
     "phone": "+49 531 322130",
     "fax": "+49 531 2322721",
-    "email": "datenschutz@gs-asb.de",
+    "email": "datenschutz@nlq.nibis.de",
     "web": "https://wordpress.nibis.de/gsasberg/",
     "sources": [
         "https://wordpress.nibis.de/gsasberg/files/2018/11/GSASB_Info_DGSVO.pdf",


### PR DESCRIPTION
The registered address `datenschutz@gs-asb.de` no longer appears on the source page (`https://wordpress.nibis.de/datenschutzerklaerung`). That page currently lists `datenschutz@nlq.nibis.de` as the privacy contact (render scan).

Found and verified by the Privacy Engine optimizer, run #78.