### PR TITLE
Update Innovid, Inc.: email address changed

### DIFF
--- a/companies/innovid.json
+++ b/companies/innovid.json
@@ -13,7 +13,7 @@
         "Innovid AU PTY Ltd."
     ],
     "address": "30 Irving Place\n12th Floor\nNew York\nNY 10003\nUnited States of America",
-    "email": "privacy@innovid.com",
+    "email": "info@myedpo.com",
     "web": "https://www.innovid.com/",
     "sources": [
         "https://www.innovid.com/privacy-policy/"


### PR DESCRIPTION
The registered address `privacy@innovid.com` no longer appears on the source page (`https://www.innovid.com/privacy-policy`). That page currently lists `info@myedpo.com` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #78.