### PR TITLE
Update Deutsches Jugendherbergswerk: email address changed

### DIFF
--- a/companies/jugendherbergede.json
+++ b/companies/jugendherbergede.json
@@ -7,7 +7,7 @@
     "address": "c/o Hauptverband für Jugendwandern und Jugendherbergen e.V.\nLeonardo-da-Vinci-Weg 1\n32760 Detmold\nDeutschland",
     "phone": "+49 5231 7401220",
     "fax": "+49 5231 7401225",
-    "email": "hauptverband@jugendherberge.de",
+    "email": "office@datenschutz-nord.de",
     "web": "https://www.jugendherberge.de",
     "sources": [
         "https://github.com/datenanfragen/data/issues/371",


### PR DESCRIPTION
The registered address `hauptverband@jugendherberge.de` no longer appears on the source page (`https://jugendherberge.de/datenschutz`). That page currently lists `office@datenschutz-nord.de` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #78.