### PR TITLE
Update PERM4 | Permanent Recruiting GmbH: email address changed

### DIFF
--- a/companies/perm4.json
+++ b/companies/perm4.json
@@ -10,7 +10,7 @@
     "address": "c/o activeMind AG\nKurfürstendamm 56\n10707 Berlin\nDeutschland",
     "phone": "+49 30 333063100",
     "fax": "+49 30 333063149",
-    "email": "datenschutz@perm4.com",
+    "email": "zlamal@iitr.de",
     "web": "https://www.perm4.com/",
     "sources": [
         "https://www.perm4.com/impressum/",


### PR DESCRIPTION
The registered address `datenschutz@perm4.com` no longer appears on the source page (`https://www.perm4.com/datenschutzinformation-fuer-mitarbeitende`). That page currently lists `zlamal@iitr.de` as the privacy contact (render scan).

Found and verified by the Privacy Engine optimizer, run #78.