### PR TITLE
Update QUADRESS GmbH: email address changed

### DIFF
--- a/companies/quadress.json
+++ b/companies/quadress.json
@@ -10,7 +10,7 @@
     "address": "Josef-Haumann-Str. 7a\n44866 Bochum\nDeutschland",
     "phone": "+49 2327 303825",
     "fax": "+49 2327 303820",
-    "email": "dsb.quadress@zb-datenschutz.de",
+    "email": "dsb.quadress@zb-datenschutz.com",
     "web": "http://www.quadress.de/",
     "sources": [
         "http://www.quadress.de/datenschutz",


### PR DESCRIPTION
The registered address `dsb.quadress@zb-datenschutz.de` no longer appears on the source page (`https://quadress.de/das-braucht-man-neues-quadress-kundentool-mit-datenschutz-beauskunftungen-via-blockchain/`). That page currently lists `dsb.quadress@zb-datenschutz.com` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #78.