### PR TITLE
Update Zemanta, Inc.: email address changed

### DIFF
--- a/companies/zemanta.json
+++ b/companies/zemanta.json
@@ -11,7 +11,7 @@
         "Outbrain DSP"
     ],
     "address": "111 West 19th Street\n3rd floor\nNew York\nNY 10011\nUnited States of America",
-    "email": "Privacy@outbrain.com",
+    "email": "ob-dpo@teads.com",
     "web": "http://www.zemanta.com/",
     "sources": [
         "https://www.outbrain.com/privacy/privacy-policy-outbrain-dsp/",


### PR DESCRIPTION
The registered address `Privacy@outbrain.com` no longer appears on the source page (`https://www.outbrain.com/privacy/privacy-policy-outbrain-dsp/`). That page currently lists `ob-dpo@teads.com` as the privacy contact (site scan).

Found and verified by the Privacy Engine optimizer, run #78.