### PR TITLE
Update AVM Computersysteme Vertriebs GmbH: email address changed

### DIFF
--- a/companies/avm.json
+++ b/companies/avm.json
@@ -19,7 +19,7 @@
     "address": "Alt-Moabit 95\n10559 Berlin\nGermany",
     "phone": "+49 30 399760",
     "fax": "+49 30 39976299",
-    "email": "datenschutz@avm.de",
+    "email": "datenschutz@fritz.com",
     "web": "https://avm.de",
     "sources": [
         "https://avm.de/datenschutz",


### PR DESCRIPTION
The registered address `datenschutz@avm.de` no longer appears on the source page (`None`). That page currently lists `datenschutz@fritz.com` as the privacy contact (claude scan).

Found and verified by the Privacy Engine optimizer, run #78.