### PR TITLE
Update Grundschule Rautheim Braunschweig: email address changed

### DIFF
--- a/companies/gs-rautheim.json
+++ b/companies/gs-rautheim.json
@@ -11,7 +11,7 @@
     "address": "Schulstraße 7\n38126 Braunschweig\nDeutschland",
     "phone": "+49 531 693091",
     "fax": "+49 531 2622788",
-    "email": "gs.rautheim@braunschweig.de",
+    "email": "datenschutz@braunschweig.de",
     "sources": [
         "https://www.braunschweig.de/leben/schule_bildung/schulportal/schulen/schulen/gs-rautheim.html"
     ],


### PR DESCRIPTION
The registered address `gs.rautheim@braunschweig.de` no longer appears on the source page (`None`). That page currently lists `datenschutz@braunschweig.de` as the privacy contact (claude scan).

Found and verified by the Privacy Engine optimizer, run #78.