### PR TITLE
Update Knorex: email address changed

### DIFF
--- a/companies/knorex.json
+++ b/companies/knorex.json
@@ -8,7 +8,7 @@
     ],
     "name": "Knorex",
     "address": "1159 Sonora Court\nSuite 122\nSunnyvale\nCA 94086\nUnited States of America",
-    "email": "privacy@knorex.com",
+    "email": "dpo@knorex.com",
     "web": "https://www.knorex.com/",
     "sources": [
         "https://www.knorex.com/privacy-policy-website"


### PR DESCRIPTION
The registered address `privacy@knorex.com` no longer appears on the source page (`None`). That page currently lists `dpo@knorex.com` as the privacy contact (claude scan).

Found and verified by the Privacy Engine optimizer, run #78.