### PR TITLE
Update LYNX B.V. Germany Branch: email address changed

### DIFF
--- a/companies/lynxbroker-de.json
+++ b/companies/lynxbroker-de.json
@@ -17,7 +17,7 @@
     "address": "Charlottenstraße 68\n10117 Berlin\nDeutschland",
     "phone": "+49 30 303286690",
     "fax": "+49 30 303286699",
-    "email": "datenschutz@lynxbroker.de",
+    "email": "dpo@lynxbroker.de",
     "web": "https://www.lynxbroker.de/",
     "sources": [
         "https://www.lynxbroker.de/info/datenschutz/",


### PR DESCRIPTION
The registered address `datenschutz@lynxbroker.de` no longer appears on the source page (`None`). That page currently lists `dpo@lynxbroker.de` as the privacy contact (claude scan).

Found and verified by the Privacy Engine optimizer, run #78.