### PR TITLE
Update Mango Technologies, Inc.: email address changed

### DIFF
--- a/companies/mango-technologies-inc.json
+++ b/companies/mango-technologies-inc.json
@@ -9,7 +9,7 @@
     ],
     "address": "350 10th Ave 5th Floor\nSan Diego, CA 92101\nUnited States of America",
     "phone": "+1 888 625 4258",
-    "email": "data@clickup.com",
+    "email": "support@clickup.com",
     "web": "https://clickup.com/",
     "sources": [
         "https://clickup.com/privacy",


### PR DESCRIPTION
The registered address `data@clickup.com` no longer appears on the source page (`None`). That page currently lists `support@clickup.com` as the privacy contact (claude scan).

Found and verified by the Privacy Engine optimizer, run #78.