### PR TITLE
Update NeS GmbH: email address changed

### DIFF
--- a/companies/nes-gmbh.json
+++ b/companies/nes-gmbh.json
@@ -13,7 +13,7 @@
     ],
     "address": "Wissollstraße 5-43\n45478 Mülheim an der Ruhr\nDeutschland",
     "phone": "+49 89 70066700",
-    "email": "datenschutz@netto-online.de",
+    "email": "datenschutzbeauftragter@netto-online.de",
     "web": "https://www.netto-online.de",
     "sources": [
         "https://www.netto-online.de/impressum",


### PR DESCRIPTION
The registered address `datenschutz@netto-online.de` no longer appears on the source page (`None`). That page currently lists `datenschutzbeauftragter@netto-online.de` as the privacy contact (claude scan).

Found and verified by the Privacy Engine optimizer, run #78.