### PR TITLE
Update Piranha Games Inc.: email address changed

### DIFF
--- a/companies/piranha-games.json
+++ b/companies/piranha-games.json
@@ -11,7 +11,7 @@
         "MechWarrior Online"
     ],
     "address": "2065 - 88 Pender St W\nVancouver, BC V6B 6N9\nCanada",
-    "email": "dpo@piranhagames.com",
+    "email": "privacy@piranhagames.com",
     "web": "https://piranhagames.com/",
     "sources": [
         "https://mwomercs.com/privacy",


### PR DESCRIPTION
The registered address `dpo@piranhagames.com` no longer appears on the source page (`None`). That page currently lists `privacy@piranhagames.com` as the privacy contact (claude scan).

Found and verified by the Privacy Engine optimizer, run #78.