### PR TITLE
Update Pluralsight, LLC: email address changed

### DIFF
--- a/companies/pluralsight.json
+++ b/companies/pluralsight.json
@@ -9,7 +9,7 @@
     "name": "Pluralsight, LLC",
     "address": "Southpoint, Herbert House\n11 Harmony Row\nDublin\nDO2 H270\nIreland",
     "phone": "+1 801 784 9007",
-    "email": "support@pluralsight.com",
+    "email": "privacy@pluralsight.com",
     "web": "https://www.pluralsight.com",
     "sources": [
         "https://www.pluralsight.com/privacy",


### PR DESCRIPTION
The registered address `support@pluralsight.com` no longer appears on the source page (`None`). That page currently lists `privacy@pluralsight.com` as the privacy contact (claude scan).

Found and verified by the Privacy Engine optimizer, run #78.