### PR TITLE
Update Kirchengemeinde Walkenried: email address changed

### DIFF
--- a/companies/kirchengemeinde-walkenried.json
+++ b/companies/kirchengemeinde-walkenried.json
@@ -10,7 +10,7 @@
     "address": "Pfarrplatz 6\n37445 Walkenried\nDeutschland",
     "phone": "+49 5525 800",
     "fax": "+49 5525 959645",
-    "email": "pfarrer(at)kirchengemeinde-walkenried.de",
+    "email": "pfarrer@kirchengemeinde-walkenried.de",
     "web": "http://www.kirchengemeinde-walkenried.de/",
     "sources": [
         "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=732"

--- a/companies/kirchengemeinde-walkenried.json
+++ b/companies/kirchengemeinde-walkenried.json
@@ -10,7 +10,7 @@
     "address": "Pfarrplatz 6\n37445 Walkenried\nDeutschland",
     "phone": "+49 5525 800",
     "fax": "+49 5525 959645",
-    "email": "kapellenfleck-harz.pfa@lk-bs.de",
+    "email": "pfarrer(at)kirchengemeinde-walkenried.de",
     "web": "http://www.kirchengemeinde-walkenried.de/",
     "sources": [
         "https://www.landeskirche-braunschweig.de/gemeinden/propsteien/einrichtungen.html?user_lkbsaddress_pi2%5Bid%5D=732"


### PR DESCRIPTION
The registered address `kapellenfleck-harz.pfa@lk-bs.de` no longer appears on the source page (`https://kirchengemeinde-walkenried.de/datenschutz`). That page currently lists `pfarrer(at)kirchengemeinde-walkenried.de` as the privacy contact (screenshot scan).

Found and verified by the Privacy Engine optimizer, run #78.