### PR TITLE
Add 'The Pokémon Company International, Inc.' (community contribution)

### DIFF
--- a/companies/pokemon.json
+++ b/companies/pokemon.json
@@ -1,0 +1,20 @@
+{
+    "slug": "pokemon",
+    "relevant-countries": [
+        "all"
+    ],
+    "categories": [
+        "entertainment"
+    ],
+    "name": "The Pokémon Company International, Inc.",
+    "address": "10770 NE 8th Street\nSuite 1500\nBellevue, WA 98004\nEstados Unidos",
+    "email": "privacyquestions@pokemon.com",
+    "webform": "https://support.pokemon.com/hc/es/requests/new?ticket_form_id=360000012406",
+    "web": "https://www.pokemon.com",
+    "sources": [
+        "https://www.pokemon.com/es/legal/aviso-de-privacidad",
+        "https://github.com/datenanfragen/data/pull/3846"
+    ],
+    "suggested-transport-medium": "webform",
+    "quality": "verified"
+}


### PR DESCRIPTION
This suggestion was submitted through the website.

**Edit in: [company JSON generator](https://company-json.datenanfragen.de/#!url=https%3A%2F%2Fraw.githubusercontent.com%2Fdatenanfragen-community-edits%2Fdata%2Fsuggest_pokemon_1787666506663%2Fcompanies%2Fpokemon.json), [data editor](https://data-editor.datenanfragen.de/#/review/3846)[^1]**

[^1]: Closed beta